### PR TITLE
Add Firebase OIDC login example

### DIFF
--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -77,3 +77,17 @@ native executable:
 After getting a cup of coffee, you'll be able to run this executable directly:
 
 > ./target/getting-started-1.0.0-SNAPSHOT-runner
+
+## Firebase Login Demo
+
+1. Configure your Firebase project values in `src/main/resources/application.properties` (`firebase.api-key`, `firebase.auth-domain`, `firebase.project-id`).
+2. Start the application in dev mode:
+
+```bash
+mvn quarkus:dev
+```
+
+3. Open [http://localhost:8080/login](http://localhost:8080/login) and authenticate with Google.
+4. After successful login the ID token is sent in the `Authorization` header to `/protected` and the backend validates it with Firebase using Quarkus OIDC.
+5. The protected page displays the authenticated user name.
+

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -37,6 +37,18 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-qute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -53,6 +53,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -37,7 +37,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
+            <artifactId>quarkus-rest-qute</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive-qute</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-qute</artifactId>
         </dependency>
         <dependency>

--- a/quarkus-app/src/main/java/org/acme/firebase/GreetingResource.java
+++ b/quarkus-app/src/main/java/org/acme/firebase/GreetingResource.java
@@ -1,0 +1,51 @@
+package org.acme.firebase;
+
+import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/")
+public class GreetingResource {
+
+    @Inject
+    Template login;
+
+    @Inject
+    Template protectedPage;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @ConfigProperty(name = "firebase.api-key")
+    String apiKey;
+
+    @ConfigProperty(name = "firebase.auth-domain")
+    String authDomain;
+
+    @ConfigProperty(name = "firebase.project-id")
+    String projectId;
+
+    @GET
+    @Path("login")
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance login() {
+        return login.data("apiKey", apiKey)
+                .data("authDomain", authDomain)
+                .data("projectId", projectId);
+    }
+
+    @GET
+    @Path("protected")
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance protectedPage() {
+        return protectedPage.data("name", identity.getPrincipal().getName());
+    }
+}

--- a/quarkus-app/src/main/java/org/acme/firebase/GreetingResource.java
+++ b/quarkus-app/src/main/java/org/acme/firebase/GreetingResource.java
@@ -18,6 +18,7 @@ public class GreetingResource {
     Template login;
 
     @Inject
+    @io.quarkus.qute.Location("protected")
     Template protectedPage;
 
     @Inject

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -1,3 +1,11 @@
-# Quarkus Configuration file
-# key = value
-quarkus.http.auth.session.encryption-key=01234567890123456789012345678912
+# Firebase configuration
+firebase.api-key=YOUR_API_KEY
+firebase.auth-domain=YOUR_PROJECT.firebaseapp.com
+firebase.project-id=YOUR_PROJECT_ID
+
+# OIDC configuration for Firebase
+quarkus.oidc.auth-server-url=https://securetoken.google.com/${firebase.project-id}
+quarkus.oidc.application-type=service
+quarkus.oidc.client-id=${firebase.project-id}
+quarkus.http.auth.permission.protected.paths=/protected
+quarkus.http.auth.permission.protected.policy=authenticated

--- a/quarkus-app/src/main/resources/templates/login.html
+++ b/quarkus-app/src/main/resources/templates/login.html
@@ -11,9 +11,9 @@
 <button id="loginBtn">Iniciar sesión</button>
 <script>
     const firebaseConfig = {
-        apiKey: "{{apiKey}}",
-        authDomain: "{{authDomain}}",
-        projectId: "{{projectId}}"
+        apiKey: "{apiKey}",
+        authDomain: "{authDomain}",
+        projectId: "{projectId}"
     };
     firebase.initializeApp(firebaseConfig);
     const provider = new firebase.auth.GoogleAuthProvider();

--- a/quarkus-app/src/main/resources/templates/login.html
+++ b/quarkus-app/src/main/resources/templates/login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+</head>
+<body>
+<h1>Login con Google</h1>
+<button id="loginBtn">Iniciar sesión</button>
+<script>
+    const firebaseConfig = {
+        apiKey: "{{apiKey}}",
+        authDomain: "{{authDomain}}",
+        projectId: "{{projectId}}"
+    };
+    firebase.initializeApp(firebaseConfig);
+    const provider = new firebase.auth.GoogleAuthProvider();
+    document.getElementById('loginBtn').addEventListener('click', async () => {
+        const result = await firebase.auth().signInWithPopup(provider);
+        const token = await result.user.getIdToken();
+        const res = await fetch('/protected', {
+            headers: { 'Authorization': 'Bearer ' + token }
+        });
+        document.open();
+        document.write(await res.text());
+        document.close();
+    });
+</script>
+</body>
+</html>

--- a/quarkus-app/src/main/resources/templates/protected.html
+++ b/quarkus-app/src/main/resources/templates/protected.html
@@ -5,7 +5,7 @@
     <title>Protegido</title>
 </head>
 <body>
-<h1>Bienvenido {{name}}</h1>
+<h1>Bienvenido {name}</h1>
 <p>Acceso concedido con Firebase.</p>
 </body>
 </html>

--- a/quarkus-app/src/main/resources/templates/protected.html
+++ b/quarkus-app/src/main/resources/templates/protected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Protegido</title>
+</head>
+<body>
+<h1>Bienvenido {{name}}</h1>
+<p>Acceso concedido con Firebase.</p>
+</body>
+</html>

--- a/quarkus-app/src/test/java/org/acme/firebase/FirebaseLoginTest.java
+++ b/quarkus-app/src/test/java/org/acme/firebase/FirebaseLoginTest.java
@@ -1,0 +1,39 @@
+package org.acme.firebase;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class FirebaseLoginTest {
+
+    @Test
+    public void loginPageLoads() {
+        given()
+            .when().get("/login")
+            .then()
+            .statusCode(200)
+            .body(containsString("Login con Google"));
+    }
+
+    @Test
+    public void protectedUnauthorized() {
+        given()
+            .when().get("/protected")
+            .then()
+            .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "alice")
+    public void protectedAuthorized() {
+        given()
+            .when().get("/protected")
+            .then()
+            .statusCode(200)
+            .body(containsString("alice"));
+    }
+}

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.oidc.tenant-enabled=false


### PR DESCRIPTION
## Summary
- integrate quarkus-qute, quarkus-oidc and quarkus-security
- configure application.properties for Firebase OIDC
- add GreetingResource showing login and protected page
- add Qute templates with Firebase web SDK
- document how to test in README
- add Quarkus tests for login page and protected endpoint

## Testing
- `mvn test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6876f78328f4833395ae3767873e3478