### PR TITLE
Fix workflow build context

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -26,11 +26,16 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build native binary
-        run: mvn clean package -Pnative -Dquarkus.native.container-build=true -f quarkus-app/pom.xml
+        working-directory: quarkus-app
+        run: mvn clean package -Pnative -Dquarkus.native.container-build=true
+
+      - name: Verify native binary exists
+        run: ls quarkus-app/target/*-runner
 
       - name: Build Docker image
+        working-directory: quarkus-app
         run: |
-          docker build -f quarkus-app/src/main/docker/Dockerfile.native -t quay.io/sergio_canales_e/eventflow:latest .
+          docker build -f src/main/docker/Dockerfile.native -t quay.io/sergio_canales_e/eventflow:latest .
 
       - name: Push Docker image
         env:


### PR DESCRIPTION
## Summary
- update `build-native.yml` to run Maven and Docker in `quarkus-app`
- ensure the native binary exists before docker build

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -f quarkus-app/pom.xml -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6877e530cf488333bb3ff93bfd4174bd