### PR TITLE
Fix deploy namespace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       SERVICE_ACCOUNT_NAME: github-actions-deployer
       GKE_CLUSTER_NAME: eventflow-cluster
       GKE_ZONE: us-central1
-      GKE_NAMESPACE: acofitec
+      GKE_NAMESPACE: eventflow
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- use correct GKE namespace in deploy workflow

## Testing
- `mvn -B -f quarkus-app/pom.xml package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a5aa88738833382769a9319e32b2b