### PR TITLE
Remove unnecessary curl install

### DIFF
--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -19,7 +19,6 @@
 ###
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /work/
-RUN microdnf install -y curl && microdnf clean all
 COPY target/*-runner /work/application
 RUN chmod 775 /work/application
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- drop microdnf curl installation from the native Dockerfile

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687a6ff76b0083339e8cfc027741d785