### PR TITLE
Fix workflow order for GKE deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,14 @@
 name: Deploy to GKE
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build Native"]
+    types:
+      - completed
 
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     container:
       image: google/cloud-sdk:latest

--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: eventflow
   annotations:
     kubernetes.io/ingress.class: gce
+    networking.gke.io/static-ip: "eventflow"
 spec:
   ingressClassName: gce
   rules:
-    - host: eventflow.example.com
+    - host: eventflow.opensourcesantiago.io
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Summary
- trigger GKE deploy workflow only after the build completes successfully
- configure ingress with static IP and custom host

## Testing
- `mvn -q -B package -f quarkus-app/pom.xml` *(failed: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a72a4d92083339ec3c96b0833d609