### PR TITLE
Add SSL configuration for GKE Ingress

### DIFF
--- a/deployment/ingress.yaml
+++ b/deployment/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: gce
     networking.gke.io/static-ip: "eventflow"
+    networking.gke.io/managed-certificates: eventflow-cert
 spec:
   ingressClassName: gce
   rules:

--- a/deployment/managed-cert.yaml
+++ b/deployment/managed-cert.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: eventflow-cert
+  namespace: eventflow
+spec:
+  domains:
+    - eventflow.opensourcesantiago.io


### PR DESCRIPTION
## Summary
- configure GKE Ingress to use a ManagedCertificate
- add `managed-cert.yaml` manifest with domain settings

## Testing
- `mvn -f quarkus-app/pom.xml -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a859edcf88333829af54203368f6b