### PR TITLE
Fix redirect for protected page

### DIFF
--- a/quarkus-app/src/main/java/org/acme/login/PrivatePageResource.java
+++ b/quarkus-app/src/main/java/org/acme/login/PrivatePageResource.java
@@ -1,0 +1,30 @@
+package org.acme.login;
+
+import java.io.InputStream;
+import java.net.URI;
+
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/private.html")
+public class PrivatePageResource {
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public Response get(@CookieParam("user") String user) {
+        if (user == null || user.isEmpty()) {
+            return Response.seeOther(URI.create("/login.html")).build();
+        }
+        InputStream page = getClass().getClassLoader()
+                .getResourceAsStream("META-INF/resources/private.html");
+        if (page == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(page).build();
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle `/private.html` via new JAX-RS resource
- redirect unauthenticated users to `/login.html`

## Testing
- `mvn -o test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_687b8c926c108333b7e5ed7224baf1f5