### PR TITLE
Configure OAuth secret with GitHub secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,12 +39,20 @@ jobs:
 
       - name: Update OAuth secret
         env:
-          OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
+          OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
+          OIDC_AUTH_URI: ${{ secrets.OIDC_AUTH_URI }}
+          OIDC_TOKEN_URI: ${{ secrets.OIDC_TOKEN_URI }}
+          OIDC_JWKS_URI: ${{ secrets.OIDC_JWKS_URI }}
+          OIDC_REDIRECT_URI: ${{ secrets.OIDC_REDIRECT_URI }}
         run: |
           kubectl -n "$GKE_NAMESPACE" create secret generic google-oauth \
-            --from-literal=client-id="$OAUTH_CLIENT_ID" \
-            --from-literal=client-secret="$OAUTH_CLIENT_SECRET" \
+            --from-literal=client-id="$OIDC_CLIENT_ID" \
+            --from-literal=client-secret="$OIDC_CLIENT_SECRET" \
+            --from-literal=auth-uri="$OIDC_AUTH_URI" \
+            --from-literal=token-uri="$OIDC_TOKEN_URI" \
+            --from-literal=jwks-uri="$OIDC_JWKS_URI" \
+            --from-literal=redirect-uri="$OIDC_REDIRECT_URI" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Apply Kubernetes manifests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Smart event management platform: spaces, activities, speakers, attendees, and personalized planning.
 
-This demo uses Google Sign-In (OAuth 2.0) through Quarkus OIDC. Provide your OAuth credentials via the `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` environment variables.
+This demo uses Google Sign-In (OAuth 2.0) through Quarkus OIDC. Provide your OAuth credentials via the following environment variables:
 
-To avoid the `invalid_client` error from Google, make sure the OAuth client is configured with the correct redirect URI. Quarkus expects `https://eventflow.opensourcesantiago.io/q/oidc/redirect` by default. Add this URI to your OAuth client settings and update the `google-oauth` secret or the environment variables with your actual client ID and secret.
+```
+OIDC_CLIENT_ID
+OIDC_CLIENT_SECRET
+OIDC_AUTH_URI
+OIDC_TOKEN_URI
+OIDC_JWKS_URI
+OIDC_REDIRECT_URI
+```
+
+The Quarkus application reads these variables at startup to configure its
+OpenID Connect client. Ensure they are available at runtime, for example by
+creating the `google-oauth` secret and passing it to the container.
+
+Set `https://eventflow.opensourcesantiago.io/callback` as an authorized redirect URI
+for the Google OAuth2 client. Quarkus will redirect the browser to this path
+after the user authenticates.
+Also add `https://eventflow.opensourcesantiago.io` to the list of authorized JavaScript origins so that the login page can initiate the OAuth flow from the browser.

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -23,13 +23,33 @@ spec:
           env:
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:+UseContainerSupport"
-            - name: GOOGLE_CLIENT_ID
+            - name: OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
                   name: google-oauth
                   key: client-id
-            - name: GOOGLE_CLIENT_SECRET
+            - name: OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: google-oauth
                   key: client-secret
+            - name: OIDC_AUTH_URI
+              valueFrom:
+                secretKeyRef:
+                  name: google-oauth
+                  key: auth-uri
+            - name: OIDC_TOKEN_URI
+              valueFrom:
+                secretKeyRef:
+                  name: google-oauth
+                  key: token-uri
+            - name: OIDC_JWKS_URI
+              valueFrom:
+                secretKeyRef:
+                  name: google-oauth
+                  key: jwks-uri
+            - name: OIDC_REDIRECT_URI
+              valueFrom:
+                secretKeyRef:
+                  name: google-oauth
+                  key: redirect-uri

--- a/deployment/google-oauth-secret.yaml
+++ b/deployment/google-oauth-secret.yaml
@@ -6,3 +6,7 @@ metadata:
 stringData:
   client-id: "YOUR_CLIENT_ID"
   client-secret: "YOUR_CLIENT_SECRET"
+  auth-uri: "https://accounts.google.com/o/oauth2/v2/auth"
+  token-uri: "https://oauth2.googleapis.com/token"
+  jwks-uri: "https://www.googleapis.com/oauth2/v1/certs"
+  redirect-uri: "https://eventflow.opensourcesantiago.io/callback"

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -81,7 +81,7 @@ After getting a cup of coffee, you'll be able to run this executable directly:
 
 ## Google Login Demo
 
-1. Set the environment variables `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` with the credentials of your OAuth client.
+1. Set the environment variables `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` and the rest of the OAuth values listed in the project root README.
 2. Start the application in dev mode:
 
 ```bash

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -1,9 +1,13 @@
-# Google OAuth configuration
-quarkus.oidc.auth-server-url=https://accounts.google.com
+# Google OAuth configuration using Authorization Code Flow
+quarkus.oidc.discovery-enabled=false
 quarkus.oidc.application-type=web-app
-quarkus.oidc.client-id=${google.client-id}
-quarkus.oidc.credentials.secret=${google.client-secret}
-quarkus.oidc.authentication.scopes=openid email profile
+quarkus.oidc.client-id=${OIDC_CLIENT_ID}
+quarkus.oidc.credentials.client-secret.value=${OIDC_CLIENT_SECRET}
+quarkus.oidc.authorization-path=${OIDC_AUTH_URI}
+quarkus.oidc.token-path=${OIDC_TOKEN_URI}
+quarkus.oidc.jwks-path=${OIDC_JWKS_URI}
+quarkus.oidc.authentication.scopes=openid profile email
+quarkus.oidc.authentication.redirect-path=/callback
 
 quarkus.http.auth.permission.protected.paths=/private
 quarkus.http.auth.permission.protected.policy=authenticated


### PR DESCRIPTION
## Summary
- load Google OAuth vars from environment in application.properties
- clarify OAuth env vars usage in root README
- instruct Quarkus app README to set all OAuth variables
- mount new OAuth secrets in Deployment and GitHub Actions

## Testing
- `mvn -f quarkus-app/pom.xml test -q` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687ba5959e948333b66571ae98ad1233