### PR TITLE
Fix missing Quarkus OIDC base URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           OIDC_CLIENT_ID: ${{ secrets.OIDC_CLIENT_ID }}
           OIDC_CLIENT_SECRET: ${{ secrets.OIDC_CLIENT_SECRET }}
+          OIDC_AUTH_SERVER_URL: ${{ secrets.OIDC_AUTH_SERVER_URL }}
           OIDC_AUTH_URI: ${{ secrets.OIDC_AUTH_URI }}
           OIDC_TOKEN_URI: ${{ secrets.OIDC_TOKEN_URI }}
           OIDC_JWKS_URI: ${{ secrets.OIDC_JWKS_URI }}
@@ -49,6 +50,7 @@ jobs:
           kubectl -n "$GKE_NAMESPACE" create secret generic google-oauth \
             --from-literal=client-id="$OIDC_CLIENT_ID" \
             --from-literal=client-secret="$OIDC_CLIENT_SECRET" \
+            --from-literal=auth-server-url="$OIDC_AUTH_SERVER_URL" \
             --from-literal=auth-uri="$OIDC_AUTH_URI" \
             --from-literal=token-uri="$OIDC_TOKEN_URI" \
             --from-literal=jwks-uri="$OIDC_JWKS_URI" \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This demo uses Google Sign-In (OAuth 2.0) through Quarkus OIDC. Provide your OAu
 ```
 OIDC_CLIENT_ID
 OIDC_CLIENT_SECRET
+OIDC_AUTH_SERVER_URL
 OIDC_AUTH_URI
 OIDC_TOKEN_URI
 OIDC_JWKS_URI

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -33,6 +33,11 @@ spec:
                 secretKeyRef:
                   name: google-oauth
                   key: client-secret
+            - name: OIDC_AUTH_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: google-oauth
+                  key: auth-server-url
             - name: OIDC_AUTH_URI
               valueFrom:
                 secretKeyRef:

--- a/deployment/google-oauth-secret.yaml
+++ b/deployment/google-oauth-secret.yaml
@@ -6,6 +6,7 @@ metadata:
 stringData:
   client-id: "YOUR_CLIENT_ID"
   client-secret: "YOUR_CLIENT_SECRET"
+  auth-server-url: "https://accounts.google.com"
   auth-uri: "https://accounts.google.com/o/oauth2/v2/auth"
   token-uri: "https://oauth2.googleapis.com/token"
   jwks-uri: "https://www.googleapis.com/oauth2/v1/certs"

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -3,6 +3,7 @@ quarkus.oidc.discovery-enabled=false
 quarkus.oidc.application-type=web-app
 quarkus.oidc.client-id=${OIDC_CLIENT_ID}
 quarkus.oidc.credentials.client-secret.value=${OIDC_CLIENT_SECRET}
+quarkus.oidc.auth-server-url=${OIDC_AUTH_SERVER_URL}
 quarkus.oidc.authorization-path=${OIDC_AUTH_URI}
 quarkus.oidc.token-path=${OIDC_TOKEN_URI}
 quarkus.oidc.jwks-path=${OIDC_JWKS_URI}


### PR DESCRIPTION
## Summary
- configure `quarkus.oidc.auth-server-url` in application.properties
- add new `OIDC_AUTH_SERVER_URL` variable in README
- propagate new secret field to Kubernetes manifests and GitHub workflow

## Testing
- `mvn test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_687bb6aeab008333baf3a31863df2889