### PR TITLE
Implement Google OAuth example using Quarkus OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,24 @@
 
 Smart event management platform: spaces, activities, speakers, attendees, and personalized planning.
 
-This demo uses Google Sign-In (OAuth 2.0) through Quarkus OIDC. Provide your OAuth credentials via the following environment variables:
+This demo uses Google Sign-In (OAuth 2.0) through the Quarkus OIDC extension.
+Configure the application by providing the following properties:
 
 ```
-OIDC_CLIENT_ID
-OIDC_CLIENT_SECRET
-OIDC_AUTH_SERVER_URL
-OIDC_AUTH_URI
-OIDC_TOKEN_URI
-OIDC_JWKS_URI
-OIDC_REDIRECT_URI
+quarkus.oidc.provider=google
+quarkus.oidc.client-id=<CLIENT_ID>
+quarkus.oidc.credentials.secret=<CLIENT_SECRET>
+quarkus.oidc.application-type=web-app
+quarkus.oidc.authentication.redirect-path=/private
+quarkus.oidc.authentication.scopes=openid profile email
+quarkus.oidc.logout.post-logout-path=/
 ```
 
-The Quarkus application reads these variables at startup to configure its
-OpenID Connect client. Ensure they are available at runtime, for example by
-creating the `google-oauth` secret and passing it to the container.
+The `provider=google` setting enables automatic discovery of all Google OAuth2
+endpoints as well as JWKS. Set the client id and secret obtained from the
+Google Cloud console. After starting the application you can navigate to
+`/private` to trigger the login flow.
 
-Set `https://eventflow.opensourcesantiago.io/callback` as an authorized redirect URI
-for the Google OAuth2 client. Quarkus will redirect the browser to this path
-after the user authenticates.
-Also add `https://eventflow.opensourcesantiago.io` to the list of authorized JavaScript origins so that the login page can initiate the OAuth flow from the browser.
+Ensure `https://eventflow.opensourcesantiago.io/private` is registered as an
+authorized redirect URI in the Google OAuth2 client configuration if running in
+production.

--- a/quarkus-app/src/main/java/org/acme/oauth/PrivateResource.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/PrivateResource.java
@@ -20,7 +20,7 @@ public class PrivateResource {
 
     @CheckedTemplate
     public static class Templates {
-        public static native TemplateInstance privatePage(String name, String email, String picture);
+        public static native TemplateInstance privatePage(String name, String email, String sub);
     }
 
     @Inject
@@ -35,7 +35,7 @@ public class PrivateResource {
             name = identity.getPrincipal().getName();
         }
         String email = identity.getAttribute("email");
-        String picture = identity.getAttribute("picture");
-        return Templates.privatePage(name, email, picture);
+        String sub = identity.getPrincipal().getName();
+        return Templates.privatePage(name, email, sub);
     }
 }

--- a/quarkus-app/src/main/java/org/acme/oauth/PublicResource.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/PublicResource.java
@@ -1,0 +1,29 @@
+package org.acme.oauth;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Public endpoint showing a login link.
+ */
+@Path("/public")
+public class PublicResource {
+
+    @CheckedTemplate
+    public static class Templates {
+        public static native TemplateInstance publicPage();
+    }
+
+    @GET
+    @PermitAll
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance get() {
+        return Templates.publicPage();
+    }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/login.html
+++ b/quarkus-app/src/main/resources/META-INF/resources/login.html
@@ -10,7 +10,7 @@
 <div class="container">
     <h1>Login</h1>
     <p>
-        <a href="/q/login"><img alt="Sign in with Google" src="https://developers.google.com/identity/images/btn_google_signin_dark_normal_web.png"></a>
+        <a href="/private"><img alt="Sign in with Google" src="https://developers.google.com/identity/images/btn_google_signin_dark_normal_web.png"></a>
     </p>
     <p><a href="/">Back to home</a></p>
 </div>

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -1,14 +1,11 @@
-# Google OAuth configuration using Authorization Code Flow
-quarkus.oidc.discovery-enabled=false
+# Google OAuth configuration using OIDC automatic discovery
+quarkus.oidc.provider=google
 quarkus.oidc.application-type=web-app
 quarkus.oidc.client-id=${OIDC_CLIENT_ID}
-quarkus.oidc.credentials.client-secret.value=${OIDC_CLIENT_SECRET}
-quarkus.oidc.auth-server-url=${OIDC_AUTH_SERVER_URL}
-quarkus.oidc.authorization-path=${OIDC_AUTH_URI}
-quarkus.oidc.token-path=${OIDC_TOKEN_URI}
-quarkus.oidc.jwks-path=${OIDC_JWKS_URI}
+quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET}
 quarkus.oidc.authentication.scopes=openid profile email
-quarkus.oidc.authentication.redirect-path=/callback
+quarkus.oidc.authentication.redirect-path=/private
+quarkus.oidc.logout.post-logout-path=/
 
 quarkus.http.auth.permission.protected.paths=/private
 quarkus.http.auth.permission.protected.policy=authenticated

--- a/quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html
+++ b/quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html
@@ -11,9 +11,7 @@
     <h1>Private Page</h1>
     <p><strong>Name:</strong> {name}</p>
     <p><strong>Email:</strong> {email}</p>
-    {#if picture}
-    <p><img src="{picture}" alt="profile" width="100"></p>
-    {/if}
+    <p><strong>Sub:</strong> {sub}</p>
     <p><a href="/q/logout">Logout</a></p>
 </div>
 </body>

--- a/quarkus-app/src/main/resources/templates/PublicResource/publicPage.html
+++ b/quarkus-app/src/main/resources/templates/PublicResource/publicPage.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Quarkus Home</title>
+    <title>Public</title>
     <script src="/js/app.js"></script>
     <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
 <div class="container">
-    <h1>Welcome</h1>
-    <p>This is a public page. <a href="/public">Public content</a>.</p>
-    <p><a href="/private">Login</a> to access private content.</p>
+    <h1>Public Page</h1>
+    <p>Everyone can see this page.</p>
+    <p><a href="/private">Login with Google</a></p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- configure OIDC using `quarkus.oidc.provider=google`
- add `/public` endpoint with login link
- enhance `/private` endpoint to show email, name and sub
- update templates and login button
- document required configuration in `README.md`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bbd443f6c8333b047f021a992f183