### PR TITLE
Add OAuth troubleshooting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Smart event management platform: spaces, activities, speakers, attendees, and personalized planning.
 
-This demo uses Google Sign-In (OAuth 2.0) through the Quarkus OIDC extension.
-Configure the application by providing the following properties:
+This demo uses Google Sign-In (OAuth 2.0) through the Quarkus OIDC extension. Configure the application by providing the following properties:
 
 ```
 quarkus.oidc.provider=google
@@ -15,11 +14,13 @@ quarkus.oidc.authentication.scopes=openid profile email
 quarkus.oidc.logout.post-logout-path=/
 ```
 
-The `provider=google` setting enables automatic discovery of all Google OAuth2
-endpoints as well as JWKS. Set the client id and secret obtained from the
-Google Cloud console. After starting the application you can navigate to
-`/private` to trigger the login flow.
+The `provider=google` setting enables automatic discovery of all Google OAuth2 endpoints as well as JWKS. Set the client id and secret obtained from the Google Cloud console. After starting the application you can navigate to `/private` to trigger the login flow.
 
-Ensure `https://eventflow.opensourcesantiago.io/private` is registered as an
-authorized redirect URI in the Google OAuth2 client configuration if running in
-production.
+Ensure `https://eventflow.opensourcesantiago.io/private` is registered as an authorized redirect URI in the Google OAuth2 client configuration if running in production.
+
+You can also configure these values using environment variables. The included `application.properties` expects `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` along with the rest of the OIDC URLs, as shown in `deployment/google-oauth-secret.yaml`.
+
+## Troubleshooting
+
+- **Error 401: invalid_client**  
+  This indicates that the OAuth client credentials are incorrect. Verify that `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` (or the values in `google-oauth-secret.yaml`) match the client configuration in the Google Cloud console and that the redirect URI is registered correctly.

--- a/quarkus-app/src/main/java/org/acme/oauth/logging/AuthorizationRedirectLoggingFilter.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/logging/AuthorizationRedirectLoggingFilter.java
@@ -1,0 +1,39 @@
+package org.acme.oauth.logging;
+
+import java.io.IOException;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+/**
+ * Logs the redirect URL when the user is sent to the OIDC authorization endpoint
+ * and any error responses produced during authentication.
+ */
+@Provider
+@Priority(Priorities.USER)
+public class AuthorizationRedirectLoggingFilter implements ContainerResponseFilter {
+
+    private static final Logger LOG = Logger.getLogger(AuthorizationRedirectLoggingFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        if (responseContext.getStatusInfo().getFamily() == Response.Status.Family.REDIRECTION) {
+            String location = responseContext.getHeaderString(javax.ws.rs.core.HttpHeaders.LOCATION);
+            if (location != null && !location.isEmpty()) {
+                LOG.infov("Redirecting user to authorization endpoint: {0}", location);
+            }
+        }
+        if (responseContext.getStatus() >= 400) {
+            LOG.infov("Authentication error: status={0}, message={1}",
+                    responseContext.getStatus(),
+                    responseContext.getStatusInfo().getReasonPhrase());
+        }
+    }
+}
+

--- a/quarkus-app/src/main/java/org/acme/oauth/logging/AuthorizationRedirectLoggingFilter.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/logging/AuthorizationRedirectLoggingFilter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
@@ -24,7 +25,7 @@ public class AuthorizationRedirectLoggingFilter implements ContainerResponseFilt
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
         if (responseContext.getStatusInfo().getFamily() == Response.Status.Family.REDIRECTION) {
-            String location = responseContext.getHeaderString(javax.ws.rs.core.HttpHeaders.LOCATION);
+            String location = responseContext.getHeaderString(HttpHeaders.LOCATION);
             if (location != null && !location.isEmpty()) {
                 LOG.infov("Redirecting user to authorization endpoint: {0}", location);
             }

--- a/quarkus-app/src/main/java/org/acme/oauth/logging/OidcCallbackLoggingFilter.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/logging/OidcCallbackLoggingFilter.java
@@ -1,0 +1,34 @@
+package org.acme.oauth.logging;
+
+import java.io.IOException;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.jboss.logging.Logger;
+
+/**
+ * Logs all parameters received on the OIDC callback endpoint.
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION)
+public class OidcCallbackLoggingFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(OidcCallbackLoggingFilter.class);
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        String path = requestContext.getUriInfo().getPath();
+        if (path.startsWith("q/oauth2/callback") || path.startsWith("q/oidc/callback")) {
+            String params = requestContext.getUriInfo().getQueryParameters().entrySet()
+                    .stream()
+                    .map(e -> e.getKey() + "=" + String.join(",", e.getValue()))
+                    .collect(Collectors.joining(", "));
+            LOG.infov("OAuth callback parameters: {0}", params);
+        }
+    }
+}
+

--- a/quarkus-app/src/main/java/org/acme/oauth/logging/PostAuthenticationLoggingFilter.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/logging/PostAuthenticationLoggingFilter.java
@@ -1,0 +1,52 @@
+package org.acme.oauth.logging;
+
+import java.io.IOException;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.oidc.IdTokenCredential;
+import io.quarkus.oidc.AccessTokenCredential;
+import org.jboss.logging.Logger;
+
+/**
+ * Logs token information and user details after a successful authentication.
+ */
+@Provider
+@Priority(Priorities.AUTHENTICATION + 1)
+public class PostAuthenticationLoggingFilter implements ContainerRequestFilter {
+
+    private static final Logger LOG = Logger.getLogger(PostAuthenticationLoggingFilter.class);
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (identity == null || identity.isAnonymous()) {
+            return;
+        }
+
+        IdTokenCredential idToken = identity.getCredential(IdTokenCredential.class);
+        if (idToken != null) {
+            LOG.infov("ID Token: {0}", idToken.getToken());
+            LOG.infov("ID Token claims: {0}", idToken.getClaims());
+        }
+
+        AccessTokenCredential accessToken = identity.getCredential(AccessTokenCredential.class);
+        if (accessToken != null) {
+            LOG.infov("Access Token: {0}", accessToken.getToken());
+        }
+
+        String email = identity.getAttribute("email");
+        String name = identity.getAttribute("name");
+        String sub = identity.getPrincipal().getName();
+        LOG.infov("Authenticated user: sub={0}, name={1}, email={2}", sub, name, email);
+    }
+}
+

--- a/quarkus-app/src/main/java/org/acme/oauth/logging/PostAuthenticationLoggingFilter.java
+++ b/quarkus-app/src/main/java/org/acme/oauth/logging/PostAuthenticationLoggingFilter.java
@@ -35,7 +35,12 @@ public class PostAuthenticationLoggingFilter implements ContainerRequestFilter {
         IdTokenCredential idToken = identity.getCredential(IdTokenCredential.class);
         if (idToken != null) {
             LOG.infov("ID Token: {0}", idToken.getToken());
-            LOG.infov("ID Token claims: {0}", idToken.getClaims());
+            String token = idToken.getToken();
+            String[] parts = token.split("\\.");
+            if (parts.length >= 2) {
+                String claimsJson = new String(java.util.Base64.getUrlDecoder().decode(parts[1]), java.nio.charset.StandardCharsets.UTF_8);
+                LOG.infov("ID Token claims: {0}", claimsJson);
+            }
         }
 
         AccessTokenCredential accessToken = identity.getCredential(AccessTokenCredential.class);

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -7,5 +7,9 @@ quarkus.oidc.authentication.scopes=openid profile email
 quarkus.oidc.authentication.redirect-path=/private
 quarkus.oidc.logout.post-logout-path=/
 
+# Enable DEBUG logging for OIDC and Vert.x internals for troubleshooting
+quarkus.log.category."io.quarkus.oidc".level=DEBUG
+quarkus.log.category."io.vertx".level=DEBUG
+
 quarkus.http.auth.permission.protected.paths=/private
 quarkus.http.auth.permission.protected.policy=authenticated


### PR DESCRIPTION
## Summary
- document environment variables for Google OAuth
- add troubleshooting info for 401 `invalid_client`
- add filters to log OIDC redirect, callback parameters, tokens and user info

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687c1ced72b08333bef78f995e30cc4c