### PR TITLE
Fix OAuth secret deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,5 +59,9 @@ jobs:
 
       - name: Apply Kubernetes manifests
         run: |
-          kubectl apply -n "$GKE_NAMESPACE" -f deployment/
+          kubectl apply -n "$GKE_NAMESPACE" -f deployment/namespace.yaml
+          kubectl apply -n "$GKE_NAMESPACE" -f deployment/managed-cert.yaml
+          kubectl apply -n "$GKE_NAMESPACE" -f deployment/service.yaml
+          kubectl apply -n "$GKE_NAMESPACE" -f deployment/deployment.yaml
+          kubectl apply -n "$GKE_NAMESPACE" -f deployment/ingress.yaml
           kubectl rollout restart deployment eventflow -n "$GKE_NAMESPACE"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Ensure `https://eventflow.opensourcesantiago.io/private` is registered as an aut
 
 You can also configure these values using environment variables. The included `application.properties` expects `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` along with the rest of the OIDC URLs, as shown in `deployment/google-oauth-secret.yaml`.
 
+When deploying through GitHub Actions, the workflow populates these values from repository secrets and creates the `google-oauth` secret in the cluster. The manifest in `deployment/google-oauth-secret.yaml` is only a template and is not applied directly during deployment.
+
 ## Troubleshooting
 
 - **Error 401: invalid_client**  

--- a/deployment/google-oauth-secret.yaml
+++ b/deployment/google-oauth-secret.yaml
@@ -1,3 +1,5 @@
+# Example secret manifest. Values are populated from GitHub Actions during
+# deployment, so this file serves only as a reference.
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## Summary
- avoid overwriting the Kubernetes secret by applying manifests individually
- document that Google OAuth secret is created from repository secrets
- mark secret manifest as a template only

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c2a906270833396b34059cbf0d361