### PR TITLE
Add logout endpoint

### DIFF
--- a/quarkus-app/src/main/java/org/acme/logout/LogoutResource.java
+++ b/quarkus-app/src/main/java/org/acme/logout/LogoutResource.java
@@ -1,0 +1,22 @@
+package org.acme.logout;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * Simple endpoint to clear the q_session cookie and redirect the user
+ * to the home page.
+ */
+@Path("/logout")
+public class LogoutResource {
+
+    @GET
+    public Response logout() {
+        return Response.seeOther(URI.create("/") )
+                .header("Set-Cookie", "q_session=; Path=/; Max-Age=0; HttpOnly; Secure")
+                .build();
+    }
+}

--- a/quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html
+++ b/quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html
@@ -12,7 +12,7 @@
     <p><strong>Name:</strong> {name}</p>
     <p><strong>Email:</strong> {email}</p>
     <p><strong>Sub:</strong> {sub}</p>
-    <p><a href="/q/logout">Logout</a></p>
+    <p><a href="/logout">Logout</a></p>
 </div>
 </body>
 </html>

--- a/quarkus-app/src/test/java/org/acme/logout/LogoutResourceIT.java
+++ b/quarkus-app/src/test/java/org/acme/logout/LogoutResourceIT.java
@@ -1,0 +1,8 @@
+package org.acme.logout;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+@QuarkusIntegrationTest
+public class LogoutResourceIT extends LogoutResourceTest {
+    // Runs the same tests in native mode
+}

--- a/quarkus-app/src/test/java/org/acme/logout/LogoutResourceTest.java
+++ b/quarkus-app/src/test/java/org/acme/logout/LogoutResourceTest.java
@@ -1,0 +1,22 @@
+package org.acme.logout;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class LogoutResourceTest {
+
+    @Test
+    public void logoutRedirectsAndClearsCookie() {
+        given()
+            .when().get("/logout")
+            .then()
+            .statusCode(303)
+            .header("Location", equalTo("/"))
+            .header("Set-Cookie", equalTo("q_session=; Path=/; Max-Age=0; HttpOnly; Secure"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement `/logout` Jakarta REST endpoint to clear `q_session` cookie
- test logout behavior
- update private page link to use new `/logout` endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom)*

------
https://chatgpt.com/codex/tasks/task_e_687c6c286d8483339be191e1d866ab5e