### PR TITLE
Stop Google RP logout

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -7,6 +7,8 @@ quarkus.oidc.authentication.scopes=openid profile email
 quarkus.oidc.logout.post-logout-path=/
 # Move the OIDC logout endpoint so /logout can be handled locally
 quarkus.oidc.logout.path=/oidc-logout
+# Disable RP-Initiated Logout since Google does not expose an end_session_endpoint
+quarkus.oidc.end-session-path=
 
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings


### PR DESCRIPTION
## Summary
- disable OIDC RP-Initiated logout when using Google

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687d12c929688333ab5b26eca3223276