### PR TITLE
Disable Quarkus logout endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,7 @@ When deploying through GitHub Actions, the workflow populates these values from 
 
 ## Troubleshooting
 
-- **Error 401: invalid_client**  
+- **Error 401: invalid_client**
   This indicates that the OAuth client credentials are incorrect. Verify that `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` (or the values in `google-oauth-secret.yaml`) match the client configuration in the Google Cloud console and that the redirect URI is registered correctly.
+- **The application supports RP-Initiated Logout but the OpenID Provider does not advertise the end_session_endpoint**
+  Google does not publish an RP logout endpoint. Ensure Quarkus' built-in logout is disabled by leaving `quarkus.oidc.logout.path` empty and using the provided `/logout` endpoint instead.

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -5,10 +5,9 @@ quarkus.oidc.client-id=${OIDC_CLIENT_ID}
 quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET}
 quarkus.oidc.authentication.scopes=openid profile email
 quarkus.oidc.logout.post-logout-path=/
-# Move the OIDC logout endpoint so /logout can be handled locally
-quarkus.oidc.logout.path=/oidc-logout
-# Disable RP-Initiated Logout since Google does not expose an end_session_endpoint
-quarkus.oidc.end-session-path=
+# Disable Quarkus built-in logout as Google does not provide an
+# end_session_endpoint. The application handles logout at /logout.
+quarkus.oidc.logout.path=
 
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings


### PR DESCRIPTION
## Summary
- disable the built-in OIDC logout endpoint
- document RP logout warning in README

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d1943a9408333a8c9bffe44295fc3