### PR TITLE
Add initial Qute pages and layout

### DIFF
--- a/quarkus-app/src/main/java/org/acme/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/private_/AdminEventResource.java
@@ -1,0 +1,57 @@
+package org.acme.eventflow.private_;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+
+@Path("/private/admin/event")
+public class AdminEventResource {
+
+    private static final List<String> adminList = List.of("admin@example.com");
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance edit(String id);
+    }
+
+    @Inject
+    SecurityIdentity identity;
+
+    private boolean isAdmin() {
+        String email = identity.getAttribute("email");
+        return email != null && adminList.contains(email);
+    }
+
+    @GET
+    @Path("create")
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public Response create() {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return Response.ok(Templates.edit(null)).build();
+    }
+
+    @GET
+    @Path("{id}/edit")
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public Response edit(@PathParam("id") String id) {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return Response.ok(Templates.edit(id)).build();
+    }
+}

--- a/quarkus-app/src/main/java/org/acme/eventflow/public_/ResourcesPage.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/public_/ResourcesPage.java
@@ -1,0 +1,26 @@
+package org.acme.eventflow.public_;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/resources")
+public class ResourcesPage {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance index();
+    }
+
+    @GET
+    @PermitAll
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance index() {
+        return Templates.index();
+    }
+}

--- a/quarkus-app/src/main/java/org/acme/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/public_/ScenarioResource.java
@@ -1,0 +1,28 @@
+package org.acme.eventflow.public_;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/scenario")
+public class ScenarioResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance detail(String id);
+    }
+
+    @GET
+    @Path("{id}")
+    @PermitAll
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance detail(@PathParam("id") String id) {
+        return Templates.detail(id);
+    }
+}

--- a/quarkus-app/src/main/java/org/acme/eventflow/public_/SpeakerResource.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/public_/SpeakerResource.java
@@ -1,0 +1,28 @@
+package org.acme.eventflow.public_;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/speaker")
+public class SpeakerResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance detail(String id);
+    }
+
+    @GET
+    @Path("{id}")
+    @PermitAll
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance detail(@PathParam("id") String id) {
+        return Templates.detail(id);
+    }
+}

--- a/quarkus-app/src/main/java/org/acme/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/public_/TalkResource.java
@@ -1,0 +1,28 @@
+package org.acme.eventflow.public_;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/talk")
+public class TalkResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance detail(String id);
+    }
+
+    @GET
+    @Path("{id}")
+    @PermitAll
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance detail(@PathParam("id") String id) {
+        return Templates.detail(id);
+    }
+}

--- a/quarkus-app/src/main/java/org/acme/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/util/AppTemplateExtensions.java
@@ -1,0 +1,12 @@
+package org.acme.eventflow.util;
+
+import java.time.LocalDate;
+
+import io.quarkus.qute.TemplateExtension;
+
+@TemplateExtension(namespace = "app")
+public class AppTemplateExtensions {
+    public static int currentYear() {
+        return LocalDate.now().getYear();
+    }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -5,5 +5,19 @@ function adjustLayout() {
         document.body.classList.remove('mobile');
     }
 }
-window.addEventListener('load', adjustLayout);
+
+function setupMenu() {
+    const toggle = document.getElementById('menuToggle');
+    const nav = document.querySelector('nav');
+    if (toggle && nav) {
+        toggle.addEventListener('click', () => {
+            nav.classList.toggle('active');
+        });
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    setupMenu();
+    adjustLayout();
+});
 window.addEventListener('resize', adjustLayout);

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1,13 +1,69 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    background-color: #f6f8fa;
+    color: #333;
     margin: 0;
-    padding: 0;
 }
+
+header {
+    background-color: #0d47a1;
+    color: #fff;
+}
+
+.header-content {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 1rem;
+}
+
+.logo {
+    font-weight: bold;
+    color: #fff;
+    text-decoration: none;
+}
+
+nav {
+    display: flex;
+    gap: 1rem;
+}
+
+nav a {
+    color: #fff;
+    text-decoration: none;
+}
+
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.5rem;
+}
+
 .container {
-    max-width: 800px;
+    max-width: 960px;
     margin: auto;
     padding: 1rem;
 }
-body.mobile .container {
-    font-size: 1.2em;
+
+footer {
+    background-color: #0d47a1;
+    color: #fff;
+    text-align: center;
+    padding: 1rem 0;
+}
+
+@media (max-width: 600px) {
+    nav {
+        display: none;
+        flex-direction: column;
+        margin-top: 1rem;
+    }
+    nav.active {
+        display: flex;
+    }
+    .menu-toggle {
+        display: block;
+    }
 }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -1,0 +1,11 @@
+{#include layout/base}
+{#title}Crear/Editar Evento{/title}
+{#main}
+<h1>Crear/Editar Evento</h1>
+<form>
+    <label for="name">Nombre</label>
+    <input id="name" name="name" type="text">
+    <button type="submit">Guardar</button>
+</form>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -1,15 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Admin</title>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>Admin Panel</h1>
-    <p>Welcome {name}. Manage events here.</p>
-    <p><a href="/private/profile">Back to profile</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}Panel de administraci\u00f3n{/title}
+{#main}
+<h1>Admin Panel</h1>
+<p>Bienvenido {name}. Gestiona los eventos aqu\u00ed.</p>
+<p><a href="/private/profile">Volver a perfil</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -1,15 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Event</title>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>Event {id}</h1>
-    <p>Details coming soon.</p>
-    <p><a href="/">Back to home</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}Detalle del evento{/title}
+{#main}
+<h1>Evento {id}</h1>
+<p>Detalles pr\u00f3ximamente.</p>
+<p><a href="/">Volver al inicio</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -1,15 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Home</title>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>EventFlow Home</h1>
-    <p>No events available yet.</p>
-    <p><a href="/login">Login</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}Inicio{/title}
+{#main}
+<h1>Eventos disponibles</h1>
+<p>No events available yet.</p>
+<p><a href="/login">Login</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/LoginPage/login.html
+++ b/quarkus-app/src/main/resources/templates/LoginPage/login.html
@@ -1,15 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Login</title>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>Login</h1>
-    <p><a href="/private/profile">Sign in with Google</a></p>
-    <p><a href="/">Back to home</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}Login{/title}
+{#main}
+<h1>Login</h1>
+<p>
+    <a href="/private/profile"><img alt="Sign in with Google" src="https://developers.google.com/identity/images/btn_google_signin_dark_normal_web.png"></a>
+</p>
+<p><a href="/">Volver al inicio</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html
+++ b/quarkus-app/src/main/resources/templates/PrivateResource/privatePage.html
@@ -1,26 +1,18 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Private</title>
-    <script src="/js/app.js"></script>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>Private Page</h1>
-    <p><strong>Sub:</strong> {sub}</p>
-    <p><strong>Preferred Username:</strong> {preferredUsername}</p>
-    <p><strong>Name:</strong> {name}</p>
-    <p><strong>Given Name:</strong> {givenName}</p>
-    <p><strong>Family Name:</strong> {familyName}</p>
-    <p><strong>Email:</strong> {email}</p>
-    <p><strong>Locale:</strong> {locale}</p>
-    <p><strong>Picture:</strong></p>
-    {#if picture}
-        <img src="{picture}" alt="Profile picture" style="max-width: 150px;">
-    {/if}
-    <p><a href="/logout">Logout</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}P\u00e1gina privada{/title}
+{#main}
+<h1>P\u00e1gina privada</h1>
+<p><strong>Sub:</strong> {sub}</p>
+<p><strong>Preferred Username:</strong> {preferredUsername}</p>
+<p><strong>Name:</strong> {name}</p>
+<p><strong>Given Name:</strong> {givenName}</p>
+<p><strong>Family Name:</strong> {familyName}</p>
+<p><strong>Email:</strong> {email}</p>
+<p><strong>Locale:</strong> {locale}</p>
+<p><strong>Picture:</strong></p>
+{#if picture}
+    <img src="{picture}" alt="Profile picture" style="max-width: 150px;">
+{/if}
+<p><a href="/logout">Logout</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -1,18 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Profile</title>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>User Profile</h1>
-    <p><strong>Name:</strong> {name}</p>
-    <p><strong>Email:</strong> {email}</p>
-    <p><strong>Sub:</strong> {sub}</p>
-    <p><a href="/private/admin">Admin Panel</a></p>
-    <p><a href="/logout">Logout</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}Mi perfil{/title}
+{#main}
+<h1>Perfil de usuario</h1>
+<p><strong>Nombre:</strong> {name}</p>
+<p><strong>Email:</strong> {email}</p>
+<p><strong>Sub:</strong> {sub}</p>
+<h2>Mis charlas</h2>
+<p>A\u00fan no hay charlas.</p>
+<p><a href="/private/admin">Admin Panel</a></p>
+<p><a href="/logout">Salir</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/PublicResource/publicPage.html
+++ b/quarkus-app/src/main/resources/templates/PublicResource/publicPage.html
@@ -1,16 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Public</title>
-    <script src="/js/app.js"></script>
-    <link rel="stylesheet" href="/styles.css">
-</head>
-<body>
-<div class="container">
-    <h1>Public Page</h1>
-    <p>Everyone can see this page.</p>
-    <p><a href="/private">Login with Google</a></p>
-</div>
-</body>
-</html>
+{#include layout/base}
+{#title}P\u00e1gina p\u00fablica{/title}
+{#main}
+<h1>P\u00e1gina p\u00fablica</h1>
+<p>Todos pueden ver esta p\u00e1gina.</p>
+<p><a href="/private">Login con Google</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/ResourcesPage/index.html
+++ b/quarkus-app/src/main/resources/templates/ResourcesPage/index.html
@@ -1,0 +1,7 @@
+{#include layout/base}
+{#title}Recursos{/title}
+{#main}
+<h1>Recursos globales</h1>
+<p>Contenido pendiente.</p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -1,0 +1,7 @@
+{#include layout/base}
+{#title}Escenario{/title}
+{#main}
+<h1>Escenario {id}</h1>
+<p>Informaci\u00f3n pr\u00f3ximamente.</p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -1,0 +1,7 @@
+{#include layout/base}
+{#title}Speaker{/title}
+{#main}
+<h1>Speaker {id}</h1>
+<p>Detalles del speaker pr\u00f3ximamente.</p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -1,0 +1,7 @@
+{#include layout/base}
+{#title}Charla{/title}
+{#main}
+<h1>Charla {id}</h1>
+<p>Detalles de la charla pr\u00f3ximamente.</p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -25,7 +25,7 @@
 </main>
 <footer>
     <div class="container">
-        <p>&copy; {time:format(now,'yyyy')} EventFlow</p>
+        <p>&copy; {app:currentYear()} EventFlow</p>
     </div>
 </footer>
 </body>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -25,7 +25,7 @@
 </main>
 <footer>
     <div class="container">
-        <p>&copy; {#now}{format('yyyy')}{/now} EventFlow</p>
+        <p>&copy; {time:format(now,'yyyy')} EventFlow</p>
     </div>
 </footer>
 </body>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{#insert title}EventFlow{/}</title>
+    <link rel="stylesheet" href="/styles.css">
+    <script src="/js/app.js" defer></script>
+</head>
+<body>
+<header>
+    <div class="container header-content">
+        <a href="/" class="logo">EventFlow</a>
+        <button id="menuToggle" class="menu-toggle" aria-label="Men\u00fa">&#9776;</button>
+        <nav>
+            <a href="/">Home</a>
+            <a href="/private/profile">Perfil</a>
+            <a href="/login">Login</a>
+            <a href="/private/admin">Admin</a>
+        </nav>
+    </div>
+</header>
+<main class="container">
+    {#insert main}{/}
+</main>
+<footer>
+    <div class="container">
+        <p>&copy; {#now}{format('yyyy')}{/now} EventFlow</p>
+    </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a reusable layout template and modern CSS/JS resources
- refactor existing pages to use the new layout
- add detail pages for scenarios, talks, speakers and resources
- add admin event editor resource

## Testing
- `mvn -q test` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d3b5e19a88333a92872e9609eeda1