### PR TITLE
Improve profile page details

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ quarkus.oidc.logout.post-logout-path=/
 
 The `provider=google` setting enables automatic discovery of all Google OAuth2 endpoints as well as JWKS. Set the client id and secret obtained from the Google Cloud console. After starting the application you can navigate to `/private` to trigger the login flow.
 
+After authenticating you will be redirected to `/private/profile` where the application displays your profile information (name, given and family names, email, and sub) extracted from the ID token.
+
 Ensure `https://eventflow.opensourcesantiago.io/private` is registered as an authorized redirect URI in the Google OAuth2 client configuration if running in production.
 
 You can also configure these values using environment variables. The included `application.properties` expects `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` along with the rest of the OIDC URLs, as shown in `deployment/google-oauth-secret.yaml`.

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security</artifactId>
         </dependency>
         <dependency>

--- a/quarkus-app/src/main/java/org/acme/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/org/acme/eventflow/private_/ProfileResource.java
@@ -4,7 +4,7 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.smallrye.jwt.auth.principal.JsonWebToken;
+import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.jboss.logging.Logger;
 
 import jakarta.inject.Inject;

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -2,7 +2,9 @@
 {#title}Mi perfil{/title}
 {#main}
 <h1>Perfil de usuario</h1>
-<p><strong>Nombre:</strong> {name}</p>
+<p><strong>Nombre completo:</strong> {name}</p>
+<p><strong>Nombre:</strong> {givenName}</p>
+<p><strong>Apellido:</strong> {familyName}</p>
 <p><strong>Email:</strong> {email}</p>
 <p><strong>Sub:</strong> {sub}</p>
 <h2>Mis charlas</h2>


### PR DESCRIPTION
## Summary
- use `JsonWebToken` to access claims
- expand profile page to show given and family names

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom)*

------
https://chatgpt.com/codex/tasks/task_e_687e6de5d18c83339cc1443083c2b6a3