### PR TITLE
Fix user info retrieval

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -4,6 +4,9 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -29,8 +32,14 @@ public class AdminEventResource {
     SecurityIdentity identity;
 
     private boolean isAdmin() {
-        String email = identity.getAttribute("email");
+        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
+        String email = getClaim(principal, "email");
         return email != null && adminList.contains(email);
+    }
+
+    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
+        Object value = principal.getClaim(claimName);
+        return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 
     @GET

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -32,13 +32,18 @@ public class AdminEventResource {
     SecurityIdentity identity;
 
     private boolean isAdmin() {
-        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-        String email = getClaim(principal, "email");
+        String email = getClaim("email");
         return email != null && adminList.contains(email);
     }
 
-    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
-        Object value = principal.getClaim(claimName);
+    private String getClaim(String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
         return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminResource.java
@@ -34,20 +34,25 @@ public class AdminResource {
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
     public Response admin() {
-        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-        String email = getClaim(principal, "email");
+        String email = getClaim("email");
         if (email == null || !adminList.contains(email)) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        String name = getClaim(principal, "name");
+        String name = getClaim("name");
         if (name == null) {
             name = email;
         }
         return Response.ok(Templates.admin(name)).build();
     }
 
-    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
-        Object value = principal.getClaim(claimName);
+    private String getClaim(String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
         return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -37,23 +37,28 @@ public class ProfileResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance profile() {
         identity.getAttributes().forEach((k, v) -> LOG.infov("{0} = {1}", k, v));
-        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
 
-        String name = getClaim(principal, "name");
-        String givenName = getClaim(principal, "given_name");
-        String familyName = getClaim(principal, "family_name");
-        String email = getClaim(principal, "email");
+        String name = getClaim("name");
+        String givenName = getClaim("given_name");
+        String familyName = getClaim("family_name");
+        String email = getClaim("email");
 
         if (name == null) {
-            name = principal.getName();
+            name = identity.getPrincipal().getName();
         }
 
-        String sub = principal.getName();
+        String sub = identity.getPrincipal().getName();
         return Templates.profile(name, givenName, familyName, email, sub);
     }
 
-    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
-        Object value = principal.getClaim(claimName);
+    private String getClaim(String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
         return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -8,6 +8,9 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import io.quarkus.qute.TemplateExtension;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+
+import java.util.Optional;
 
 @TemplateExtension(namespace = "app")
 public class AppTemplateExtensions {
@@ -37,7 +40,13 @@ public class AppTemplateExtensions {
         if (identity == null || identity.isAnonymous()) {
             return false;
         }
-        String email = identity.getAttribute("email");
+        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
+        String email = getClaim(principal, "email");
         return email != null && adminList.contains(email);
+    }
+
+    private static String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
+        Object value = principal.getClaim(claimName);
+        return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -40,13 +40,18 @@ public class AppTemplateExtensions {
         if (identity == null || identity.isAnonymous()) {
             return false;
         }
-        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-        String email = getClaim(principal, "email");
+        String email = getClaim(identity, "email");
         return email != null && adminList.contains(email);
     }
 
-    private static String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
-        Object value = principal.getClaim(claimName);
+    private static String getClaim(SecurityIdentity identity, String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
         return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/oauth/PrivateResource.java
+++ b/quarkus-app/src/main/java/com/scanales/oauth/PrivateResource.java
@@ -4,6 +4,9 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -37,19 +40,26 @@ public class PrivateResource {
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance privatePage() {
-        String sub = identity.getPrincipal().getName();
-        String preferredUsername = identity.getAttribute("preferred_username");
-        String name = identity.getAttribute("name");
+        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
+
+        String sub = getClaim(principal, "sub");
+        String preferredUsername = getClaim(principal, "preferred_username");
+        String name = getClaim(principal, "name");
         if (name == null) {
             name = sub;
         }
-        String givenName = identity.getAttribute("given_name");
-        String familyName = identity.getAttribute("family_name");
-        String email = identity.getAttribute("email");
-        String locale = identity.getAttribute("locale");
-        String picture = identity.getAttribute("picture");
+        String givenName = getClaim(principal, "given_name");
+        String familyName = getClaim(principal, "family_name");
+        String email = getClaim(principal, "email");
+        String locale = getClaim(principal, "locale");
+        String picture = getClaim(principal, "picture");
 
         return Templates.privatePage(sub, preferredUsername, name, givenName,
                 familyName, email, locale, picture);
+    }
+
+    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
+        Object value = principal.getClaim(claimName);
+        return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/oauth/PrivateResource.java
+++ b/quarkus-app/src/main/java/com/scanales/oauth/PrivateResource.java
@@ -40,26 +40,33 @@ public class PrivateResource {
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance privatePage() {
-        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-
-        String sub = getClaim(principal, "sub");
-        String preferredUsername = getClaim(principal, "preferred_username");
-        String name = getClaim(principal, "name");
+        String sub = getClaim("sub");
+        if (sub == null) {
+            sub = identity.getPrincipal().getName();
+        }
+        String preferredUsername = getClaim("preferred_username");
+        String name = getClaim("name");
         if (name == null) {
             name = sub;
         }
-        String givenName = getClaim(principal, "given_name");
-        String familyName = getClaim(principal, "family_name");
-        String email = getClaim(principal, "email");
-        String locale = getClaim(principal, "locale");
-        String picture = getClaim(principal, "picture");
+        String givenName = getClaim("given_name");
+        String familyName = getClaim("family_name");
+        String email = getClaim("email");
+        String locale = getClaim("locale");
+        String picture = getClaim("picture");
 
         return Templates.privatePage(sub, preferredUsername, name, givenName,
                 familyName, email, locale, picture);
     }
 
-    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
-        Object value = principal.getClaim(claimName);
+    private String getClaim(String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
         return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/oauth/logging/PostAuthenticationLoggingFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/oauth/logging/PostAuthenticationLoggingFilter.java
@@ -12,6 +12,9 @@ import jakarta.ws.rs.ext.Provider;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.oidc.IdTokenCredential;
 import io.quarkus.oidc.AccessTokenCredential;
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+
+import java.util.Optional;
 import org.jboss.logging.Logger;
 
 /**
@@ -48,14 +51,16 @@ public class PostAuthenticationLoggingFilter implements ContainerRequestFilter {
             LOG.infov("Access Token: {0}", accessToken.getToken());
         }
 
-        String sub = identity.getPrincipal().getName();
-        String preferredUsername = identity.getAttribute("preferred_username");
-        String name = identity.getAttribute("name");
-        String givenName = identity.getAttribute("given_name");
-        String familyName = identity.getAttribute("family_name");
-        String email = identity.getAttribute("email");
-        String locale = identity.getAttribute("locale");
-        String picture = identity.getAttribute("picture");
+        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
+
+        String sub = getClaim(principal, "sub");
+        String preferredUsername = getClaim(principal, "preferred_username");
+        String name = getClaim(principal, "name");
+        String givenName = getClaim(principal, "given_name");
+        String familyName = getClaim(principal, "family_name");
+        String email = getClaim(principal, "email");
+        String locale = getClaim(principal, "locale");
+        String picture = getClaim(principal, "picture");
 
         checkAttribute("sub", sub);
         checkAttribute("preferred_username", preferredUsername);
@@ -76,6 +81,11 @@ public class PostAuthenticationLoggingFilter implements ContainerRequestFilter {
                 "locale: %s%n" +
                 "picture: %s",
                 sub, preferredUsername, name, givenName, familyName, email, locale, picture);
+    }
+
+    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
+        Object value = principal.getClaim(claimName);
+        return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 
     private void checkAttribute(String attrName, String value) {

--- a/quarkus-app/src/main/java/com/scanales/oauth/logging/PostAuthenticationLoggingFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/oauth/logging/PostAuthenticationLoggingFilter.java
@@ -51,16 +51,17 @@ public class PostAuthenticationLoggingFilter implements ContainerRequestFilter {
             LOG.infov("Access Token: {0}", accessToken.getToken());
         }
 
-        OidcJwtCallerPrincipal principal = (OidcJwtCallerPrincipal) identity.getPrincipal();
-
-        String sub = getClaim(principal, "sub");
-        String preferredUsername = getClaim(principal, "preferred_username");
-        String name = getClaim(principal, "name");
-        String givenName = getClaim(principal, "given_name");
-        String familyName = getClaim(principal, "family_name");
-        String email = getClaim(principal, "email");
-        String locale = getClaim(principal, "locale");
-        String picture = getClaim(principal, "picture");
+        String sub = getClaim("sub");
+        if (sub == null) {
+            sub = identity.getPrincipal().getName();
+        }
+        String preferredUsername = getClaim("preferred_username");
+        String name = getClaim("name");
+        String givenName = getClaim("given_name");
+        String familyName = getClaim("family_name");
+        String email = getClaim("email");
+        String locale = getClaim("locale");
+        String picture = getClaim("picture");
 
         checkAttribute("sub", sub);
         checkAttribute("preferred_username", preferredUsername);
@@ -83,8 +84,14 @@ public class PostAuthenticationLoggingFilter implements ContainerRequestFilter {
                 sub, preferredUsername, name, givenName, familyName, email, locale, picture);
     }
 
-    private String getClaim(OidcJwtCallerPrincipal principal, String claimName) {
-        Object value = principal.getClaim(claimName);
+    private String getClaim(String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
         return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -8,7 +8,6 @@ quarkus.oidc.logout.post-logout-path=/
 # Disable Quarkus built-in logout as Google does not provide an
 # end_session_endpoint. The application handles logout at /logout.
 quarkus.oidc.logout.path=
-quarkus.oidc.user-info-required=false
 quarkus.oidc.authentication.user-info-required=false
 # Rely on the ID token for user attributes
 quarkus.oidc.authentication.id-token-required=true


### PR DESCRIPTION
## Summary
- read user claims directly from the `OidcJwtCallerPrincipal`
- show user details on private and profile pages
- validate admin access using email claim
- adjust admin template helpers
- log claims using the new approach

## Testing
- `mvn -q test` *(fails: Could not transfer artifact quarkus-bom from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_687f8bafcc988333a8c038eead231d5a