### PR TITLE
Implement admin event management

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ You can also configure these values using environment variables. The included `a
 
 When deploying through GitHub Actions, the workflow populates these values from repository secrets and creates the `google-oauth` secret in the cluster. The manifest in `deployment/google-oauth-secret.yaml` is only a template and is not applied directly during deployment.
 
+## Admin access
+
+Endpoints under `/private/admin` are restricted to authenticated users whose
+email address is present in the comma separated list defined by the
+`ADMIN_LIST` configuration property or environment variable. Example:
+
+```
+ADMIN_LIST=sergio.canales.e@gmail.com,alice@example.org
+```
+
+Only users included in this list can create, edit or delete events and their
+associated scenarios and talks.
+
 ## Troubleshooting
 
 - **Error 401: invalid_client**

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminResource.java
@@ -4,9 +4,7 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
-
-import java.util.Optional;
+import com.scanales.eventflow.util.AdminUtils;
 
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
@@ -15,12 +13,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.util.List;
-
 @Path("/private/admin")
 public class AdminResource {
-
-    private static final List<String> adminList = List.of("sergio.canales.e@gmail.com");
 
     @CheckedTemplate
     static class Templates {
@@ -34,25 +28,14 @@ public class AdminResource {
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
     public Response admin() {
-        String email = getClaim("email");
-        if (email == null || !adminList.contains(email)) {
+        String email = AdminUtils.getClaim(identity, "email");
+        if (email == null || !AdminUtils.getAdminList().contains(email)) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        String name = getClaim("name");
+        String name = AdminUtils.getClaim(identity, "name");
         if (name == null) {
             name = email;
         }
         return Response.ok(Templates.admin(name)).build();
-    }
-
-    private String getClaim(String claimName) {
-        Object value = null;
-        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
-            value = oidc.getClaim(claimName);
-        }
-        if (value == null) {
-            value = identity.getAttribute(claimName);
-        }
-        return Optional.ofNullable(value).map(Object::toString).orElse(null);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -1,0 +1,67 @@
+package com.scanales.eventflow.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Talk;
+
+/** Simple in-memory store for events. */
+@ApplicationScoped
+public class EventService {
+
+    private final Map<String, Event> events = new ConcurrentHashMap<>();
+
+    public List<Event> listEvents() {
+        return new ArrayList<>(events.values());
+    }
+
+    public Event getEvent(String id) {
+        return events.get(id);
+    }
+
+    public void saveEvent(Event event) {
+        events.put(event.getId(), event);
+    }
+
+    public void deleteEvent(String id) {
+        events.remove(id);
+    }
+
+    public void saveScenario(String eventId, Scenario scenario) {
+        Event event = events.get(eventId);
+        if (event == null) {
+            return;
+        }
+        event.getScenarios().removeIf(s -> s.getId().equals(scenario.getId()));
+        event.getScenarios().add(scenario);
+    }
+
+    public void deleteScenario(String eventId, String scenarioId) {
+        Event event = events.get(eventId);
+        if (event != null) {
+            event.getScenarios().removeIf(s -> s.getId().equals(scenarioId));
+        }
+    }
+
+    public void saveTalk(String eventId, Talk talk) {
+        Event event = events.get(eventId);
+        if (event == null) {
+            return;
+        }
+        event.getAgenda().removeIf(t -> t.getId().equals(talk.getId()));
+        event.getAgenda().add(talk);
+    }
+
+    public void deleteTalk(String eventId, String talkId) {
+        Event event = events.get(eventId);
+        if (event != null) {
+            event.getAgenda().removeIf(t -> t.getId().equals(talkId));
+        }
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AdminUtils.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AdminUtils.java
@@ -1,0 +1,60 @@
+package com.scanales.eventflow.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+
+/** Utility methods for admin checks. */
+public final class AdminUtils {
+
+    private AdminUtils() {
+    }
+
+    /**
+     * Returns the list of admin emails configured in the {@code ADMIN_LIST}
+     * configuration property. The value is expected to be a comma separated list
+     * of email addresses.
+     */
+    public static List<String> getAdminList() {
+        String raw = ConfigProvider.getConfig().getOptionalValue("ADMIN_LIST", String.class).orElse("");
+        if (raw.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(raw.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    /**
+     * Returns {@code true} if the provided identity represents an authenticated
+     * user whose email is present in the admin list.
+     */
+    public static boolean isAdmin(SecurityIdentity identity) {
+        if (identity == null || identity.isAnonymous()) {
+            return false;
+        }
+        String email = getClaim(identity, "email");
+        if (email == null) {
+            email = identity.getPrincipal().getName();
+        }
+        return email != null && getAdminList().contains(email);
+    }
+
+    /** Obtains a claim or attribute from the identity. */
+    public static String getClaim(SecurityIdentity identity, String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
+        return Optional.ofNullable(value).map(Object::toString).orElse(null);
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -8,9 +8,8 @@ import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import io.quarkus.qute.TemplateExtension;
 import io.quarkus.security.identity.SecurityIdentity;
-import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
 
-import java.util.Optional;
+import com.scanales.eventflow.util.AdminUtils;
 
 @TemplateExtension(namespace = "app")
 public class AppTemplateExtensions {
@@ -33,25 +32,8 @@ public class AppTemplateExtensions {
         return identity != null && !identity.isAnonymous();
     }
 
-    private static final List<String> adminList = List.of("sergio.canales.e@gmail.com");
-
     public static boolean isAdmin() {
         SecurityIdentity identity = Arc.container().instance(SecurityIdentity.class).get();
-        if (identity == null || identity.isAnonymous()) {
-            return false;
-        }
-        String email = getClaim(identity, "email");
-        return email != null && adminList.contains(email);
-    }
-
-    private static String getClaim(SecurityIdentity identity, String claimName) {
-        Object value = null;
-        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
-            value = oidc.getClaim(claimName);
-        }
-        if (value == null) {
-            value = identity.getAttribute(claimName);
-        }
-        return Optional.ofNullable(value).map(Object::toString).orElse(null);
+        return AdminUtils.isAdmin(identity);
     }
 }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -21,3 +21,6 @@ quarkus.log.console.enable=true
 
 quarkus.http.auth.permission.protected.paths=/private
 quarkus.http.auth.permission.protected.policy=authenticated
+
+# Comma separated list of admin emails
+ADMIN_LIST=sergio.canales.e@gmail.com

--- a/quarkus-app/src/test/java/com/scanales/eventflow/admin/AdminAccessTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/admin/AdminAccessTest.java
@@ -1,0 +1,30 @@
+package com.scanales.eventflow.admin;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class AdminAccessTest {
+
+    @Test
+    @TestSecurity(user = "alice")
+    public void nonAdminCannotAccess() {
+        given()
+                .when().get("/private/admin/event/create")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    @TestSecurity(user = "sergio.canales.e@gmail.com")
+    public void adminCanAccess() {
+        given()
+                .when().get("/private/admin/event/create")
+                .then()
+                .statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add ADMIN_LIST explanation
- implement AdminUtils for configurable admin check
- update admin resources to use AdminUtils
- add in-memory EventService and CRUD endpoints
- add unit test for admin access
- expose ADMIN_LIST in application.properties
- **update default ADMIN_LIST value**

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Could not transfer artifact quarkus-bom: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687fb364b2688333b649d6664a6693fa