### PR TITLE
Enable event admin views

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -26,7 +26,8 @@ public class AdminEventResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance edit(String id);
+        static native TemplateInstance list(java.util.List<Event> events);
+        static native TemplateInstance edit(Event event);
     }
 
     @Inject
@@ -40,6 +41,18 @@ public class AdminEventResource {
     }
 
     @GET
+    @Path("/events")
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public Response listEvents() {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        var events = eventService.listEvents();
+        return Response.ok(Templates.list(events)).build();
+    }
+
+    @GET
     @Path("create")
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
@@ -47,7 +60,7 @@ public class AdminEventResource {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        return Response.ok(Templates.edit(null)).build();
+        return Response.ok(Templates.edit(new Event())).build();
     }
 
     @GET
@@ -58,7 +71,11 @@ public class AdminEventResource {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        return Response.ok(Templates.edit(id)).build();
+        Event event = eventService.getEvent(id);
+        if (event == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        return Response.ok(Templates.edit(event)).build();
     }
 
     @POST
@@ -73,7 +90,7 @@ public class AdminEventResource {
         Event event = new Event(id, title, description);
         eventService.saveEvent(event);
         return Response.status(Response.Status.SEE_OTHER)
-                .header("Location", "/private/admin")
+                .header("Location", "/private/admin/events")
                 .build();
     }
 
@@ -86,7 +103,7 @@ public class AdminEventResource {
         }
         eventService.deleteEvent(id);
         return Response.status(Response.Status.SEE_OTHER)
-                .header("Location", "/private/admin")
+                .header("Location", "/private/admin/events")
                 .build();
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
@@ -9,20 +9,30 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.model.Event;
+import jakarta.inject.Inject;
 
 @Path("/event")
 public class EventResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(String id);
+        static native TemplateInstance detail(Event event);
     }
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("{id}")
     @PermitAll
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance event(@PathParam("id") String id) {
-        return Templates.detail(id);
+        Event event = eventService.getEvent(id);
+        if (event == null) {
+            return Templates.detail(null);
+        }
+        return Templates.detail(event);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -8,19 +8,25 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import com.scanales.eventflow.service.EventService;
+import jakarta.inject.Inject;
 
 @Path("/")
 public class HomeResource {
 
+    @Inject
+    EventService eventService;
+
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance home();
+        static native TemplateInstance home(java.util.List<com.scanales.eventflow.model.Event> events);
     }
 
     @GET
     @PermitAll
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance home() {
-        return Templates.home();
+        var events = eventService.listEvents();
+        return Templates.home(events);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
@@ -9,20 +9,27 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.model.Scenario;
+import jakarta.inject.Inject;
 
 @Path("/scenario")
 public class ScenarioResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(String id);
+        static native TemplateInstance detail(Scenario scenario);
     }
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("{id}")
     @PermitAll
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance detail(@PathParam("id") String id) {
-        return Templates.detail(id);
+        Scenario s = eventService.findScenario(id);
+        return Templates.detail(s);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -9,20 +9,27 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.model.Talk;
+import jakarta.inject.Inject;
 
 @Path("/talk")
 public class TalkResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(String id);
+        static native TemplateInstance detail(Talk talk);
     }
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("{id}")
     @PermitAll
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance detail(@PathParam("id") String id) {
-        return Templates.detail(id);
+        Talk talk = eventService.findTalk(id);
+        return Templates.detail(talk);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -64,4 +64,20 @@ public class EventService {
             event.getAgenda().removeIf(t -> t.getId().equals(talkId));
         }
     }
+
+    public Scenario findScenario(String scenarioId) {
+        return events.values().stream()
+                .flatMap(e -> e.getScenarios().stream())
+                .filter(s -> s.getId().equals(scenarioId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public Talk findTalk(String talkId) {
+        return events.values().stream()
+                .flatMap(e -> e.getAgenda().stream())
+                .filter(t -> t.getId().equals(talkId))
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -1,11 +1,72 @@
 {#include layout/base}
-{#title}Crear/Editar Evento{/title}
+{#title}{event.id?`Editar Evento`:`Nuevo Evento`}{/title}
 {#main}
-<h1>Crear/Editar Evento</h1>
-<form>
-    <label for="name">Nombre</label>
-    <input id="name" name="name" type="text">
+<h1>{event.id?`Editar Evento`:`Nuevo Evento`}</h1>
+<form method="post" action="/private/admin/event/create">
+    <label for="id">ID</label>
+    <input id="id" name="id" type="text" value="{event.id}" {#if event.id}readonly{/if}>
+    <label for="title">Titulo</label>
+    <input id="title" name="title" type="text" value="{event.title}">
+    <label for="description">Descripcion</label>
+    <textarea id="description" name="description">{event.description}</textarea>
     <button type="submit">Guardar</button>
 </form>
+{#if event.id}
+<h2>Escenarios</h2>
+<table>
+<thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
+<tbody>
+{#for sc in event.scenarios}
+<tr>
+<form method="post" action="/private/admin/event/{event.id}/scenario">
+<td><input name="scenarioId" value="{sc.id}"></td>
+<td><input name="name" value="{sc.name}"></td>
+<td>
+<button type="submit">Guardar</button>
+</form>
+<form method="post" action="/private/admin/event/{event.id}/scenario/{sc.id}/delete" style="display:inline">
+<button type="submit">Eliminar</button>
+</form>
+</td>
+</tr>
+{/for}
+<tr>
+<form method="post" action="/private/admin/event/{event.id}/scenario">
+<td><input name="scenarioId"></td>
+<td><input name="name"></td>
+<td><button type="submit">Agregar</button></td>
+</form>
+</tr>
+</tbody>
+</table>
+<h2>Charlas</h2>
+<table>
+<thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
+<tbody>
+{#for t in event.agenda}
+<tr>
+<form method="post" action="/private/admin/event/{event.id}/talk">
+<td><input name="talkId" value="{t.id}"></td>
+<td><input name="name" value="{t.name}"></td>
+<td>
+<button type="submit">Guardar</button>
+</form>
+<form method="post" action="/private/admin/event/{event.id}/talk/{t.id}/delete" style="display:inline">
+<button type="submit">Eliminar</button>
+</form>
+</td>
+</tr>
+{/for}
+<tr>
+<form method="post" action="/private/admin/event/{event.id}/talk">
+<td><input name="talkId"></td>
+<td><input name="name"></td>
+<td><button type="submit">Agregar</button></td>
+</form>
+</tr>
+</tbody>
+</table>
+{/if}
+<p><a href="/private/admin/events">Volver</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -1,0 +1,29 @@
+{#include layout/base}
+{#title}Eventos{/title}
+{#main}
+<h1>Eventos</h1>
+<p><a href="/private/admin/event/create">Nuevo evento</a></p>
+{#if events.isEmpty()}
+<p>No hay eventos registrados.</p>
+{#else}
+<table>
+<thead><tr><th>ID</th><th>Titulo</th><th>Acciones</th></tr></thead>
+<tbody>
+{#for ev in events}
+<tr>
+<td>{ev.id}</td>
+<td>{ev.title}</td>
+<td>
+<a href="/private/admin/event/{ev.id}/edit">Editar</a>
+<form method="post" action="/private/admin/event/{ev.id}/delete" style="display:inline">
+<button type="submit">Eliminar</button>
+</form>
+</td>
+</tr>
+{/for}
+</tbody>
+</table>
+{/if}
+<p><a href="/private/admin">Volver</a></p>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -2,7 +2,8 @@
 {#title}Panel de administraci\u00f3n{/title}
 {#main}
 <h1>Admin Panel</h1>
-<p>Bienvenido {name}. Gestiona los eventos aqu\u00ed.</p>
+<p>Bienvenido {name}. Gestiona los eventos aquí.</p>
+<p><a href="/private/admin/events">Administrar eventos</a></p>
 <p><a href="/private/profile">Volver a perfil</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -1,8 +1,28 @@
 {#include layout/base}
-{#title}Detalle del evento{/title}
+{#title}{event?.title ?: 'Evento'}{/title}
 {#main}
-<h1>Evento {id}</h1>
-<p>Detalles pr\u00f3ximamente.</p>
+{#if event}
+<h1>{event.title}</h1>
+<p>{event.description}</p>
+{#if !event.scenarios.isEmpty()}
+<h2>Escenarios</h2>
+<ul>
+{#for s in event.scenarios}
+<li>{s.name}</li>
+{/for}
+</ul>
+{/if}
+{#if !event.agenda.isEmpty()}
+<h2>Charlas</h2>
+<ul>
+{#for t in event.agenda}
+<li>{t.name}</li>
+{/for}
+</ul>
+{/if}
+{#else}
+<p>Evento no encontrado.</p>
+{/if}
 <p><a href="/">Volver al inicio</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -2,7 +2,15 @@
 {#title}Inicio{/title}
 {#main}
 <h1>Eventos disponibles</h1>
-<p>No events available yet.</p>
+{#if events.isEmpty()}
+<p>No hay eventos disponibles.</p>
+{#else}
+<ul>
+{#for e in events}
+<li><a href="/event/{e.id}">{e.title}</a></li>
+{/for}
+</ul>
+{/if}
 <p><a href="/login">Login</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -1,7 +1,12 @@
 {#include layout/base}
-{#title}Escenario{/title}
+{#title}{scenario?.name ?: 'Escenario'}{/title}
 {#main}
-<h1>Escenario {id}</h1>
-<p>Informaci\u00f3n pr\u00f3ximamente.</p>
+{#if scenario}
+<h1>{scenario.name}</h1>
+{#if scenario.location}<p>Ubicacion: {scenario.location}</p>{/if}
+{#if scenario.features}<p>{scenario.features}</p>{/if}
+{#else}
+<p>Escenario no encontrado.</p>
+{/if}
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -1,7 +1,12 @@
 {#include layout/base}
-{#title}Charla{/title}
+{#title}{talk?.name ?: 'Charla'}{/title}
 {#main}
-<h1>Charla {id}</h1>
-<p>Detalles de la charla pr\u00f3ximamente.</p>
+{#if talk}
+<h1>{talk.name}</h1>
+{#if talk.description}<p>{talk.description}</p>{/if}
+{#if talk.time}<p>{talk.time}</p>{/if}
+{#else}
+<p>Charla no encontrada.</p>
+{/if}
 {/main}
 {/include}


### PR DESCRIPTION
## Summary
- add admin pages to list, create, edit and delete events
- expose scenario and talk search helpers
- show events on home and event details publicly
- secure admin navigation link

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_687fbbec42708333b259726f73ad3e9f