### PR TITLE
Fix admin edit flow and auto ids

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -96,6 +96,27 @@ public class AdminEventResource {
     }
 
     @POST
+    @Path("{id}/edit")
+    @Authenticated
+    public Response updateEvent(@PathParam("id") String id,
+                                @FormParam("title") String title,
+                                @FormParam("description") String description) {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        Event event = eventService.getEvent(id);
+        if (event == null) {
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+        event.setTitle(title);
+        event.setDescription(description);
+        eventService.saveEvent(event);
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/event/" + id)
+                .build();
+    }
+
+    @POST
     @Path("{id}/delete")
     @Authenticated
     public Response deleteEvent(@PathParam("id") String id) {
@@ -113,13 +134,24 @@ public class AdminEventResource {
     @Authenticated
     public Response saveScenario(@PathParam("id") String eventId,
                                  @FormParam("scenarioId") String scenarioId,
-                                 @FormParam("name") String name) {
+                                 @FormParam("name") String name,
+                                 @FormParam("features") String features,
+                                 @FormParam("location") String location) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
+        if (scenarioId == null || scenarioId.isBlank()) {
+            var ts = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+                    .format(java.time.LocalDateTime.now());
+            scenarioId = eventId + "-sala-" + ts;
+        }
         Scenario scenario = new Scenario(scenarioId, name);
+        scenario.setFeatures(features);
+        scenario.setLocation(location);
         eventService.saveScenario(eventId, scenario);
-        return Response.ok().build();
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/private/admin/events/" + eventId + "/edit")
+                .build();
     }
 
     @POST
@@ -131,7 +163,9 @@ public class AdminEventResource {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
         eventService.deleteScenario(eventId, scenarioId);
-        return Response.ok().build();
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/private/admin/events/" + eventId + "/edit")
+                .build();
     }
 
     @POST
@@ -139,13 +173,24 @@ public class AdminEventResource {
     @Authenticated
     public Response saveTalk(@PathParam("id") String eventId,
                              @FormParam("talkId") String talkId,
-                             @FormParam("name") String name) {
+                             @FormParam("name") String name,
+                             @FormParam("description") String description,
+                             @FormParam("location") String location) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
+        if (talkId == null || talkId.isBlank()) {
+            var ts = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+                    .format(java.time.LocalDateTime.now());
+            talkId = eventId + "-charla-" + ts;
+        }
         Talk talk = new Talk(talkId, name);
+        talk.setDescription(description);
+        talk.setLocation(location);
         eventService.saveTalk(eventId, talk);
-        return Response.ok().build();
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/private/admin/events/" + eventId + "/edit")
+                .build();
     }
 
     @POST
@@ -157,6 +202,8 @@ public class AdminEventResource {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
         eventService.deleteTalk(eventId, talkId);
-        return Response.ok().build();
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/private/admin/events/" + eventId + "/edit")
+                .build();
     }
 }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -14,7 +14,7 @@ Editar Evento
 Nuevo Evento
 {/if}
 </h1>
-<form method="post" action="/private/admin/events/new">
+<form method="post" action="{#if event.id}/private/admin/events/{event.id}/edit{#else}/private/admin/events/new{/if}">
     {#if event.id}
         <p>ID: {event.id}</p>
     {/if}
@@ -32,9 +32,11 @@ Nuevo Evento
 {#for sc in event.scenarios}
 <tr>
 <form method="post" action="/private/admin/events/{event.id}/scenario">
-<td><input name="scenarioId" value="{sc.id}"></td>
+<td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
 <td><input name="name" value="{sc.name}"></td>
 <td>
+<input name="features" value="{sc.features}" placeholder="Caracteristicas">
+<input name="location" value="{sc.location}" placeholder="Ubicacion">
 <button type="submit">Guardar</button>
 </form>
 <form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline">
@@ -45,9 +47,13 @@ Nuevo Evento
 {/for}
 <tr>
 <form method="post" action="/private/admin/events/{event.id}/scenario">
-<td><input name="scenarioId"></td>
+<td>Nuevo</td>
 <td><input name="name"></td>
-<td><button type="submit">Agregar</button></td>
+<td>
+<input name="features" placeholder="Caracteristicas">
+<input name="location" placeholder="Ubicacion">
+<button type="submit">Agregar</button>
+</td>
 </form>
 </tr>
 </tbody>
@@ -59,9 +65,11 @@ Nuevo Evento
 {#for t in event.agenda}
 <tr>
 <form method="post" action="/private/admin/events/{event.id}/talk">
-<td><input name="talkId" value="{t.id}"></td>
+<td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
 <td><input name="name" value="{t.name}"></td>
 <td>
+<input name="description" value="{t.description}" placeholder="Descripcion">
+<input name="location" value="{t.location}" placeholder="Ubicacion">
 <button type="submit">Guardar</button>
 </form>
 <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline">
@@ -72,9 +80,13 @@ Nuevo Evento
 {/for}
 <tr>
 <form method="post" action="/private/admin/events/{event.id}/talk">
-<td><input name="talkId"></td>
+<td>Nuevo</td>
 <td><input name="name"></td>
-<td><button type="submit">Agregar</button></td>
+<td>
+<input name="description" placeholder="Descripcion">
+<input name="location" placeholder="Ubicacion">
+<button type="submit">Agregar</button>
+</td>
 </form>
 </tr>
 </tbody>


### PR DESCRIPTION
## Summary
- fix saving existing events by adding update endpoint
- redirect after saving scenarios and talks
- auto-generate scenario/talk IDs and include more fields
- adjust admin edit template to remove manual ID entry

## Testing
- `./quarkus-app/mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688002eada408333bab7fb1b4b916b1c