### PR TITLE
Implement event schedule fields and UI

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -14,6 +14,8 @@ public class Event {
     private String title;
     private String description;
     private List<Scenario> scenarios = new ArrayList<>();
+    /** Number of days the event lasts. */
+    private int days = 1;
     /** URL or identifier for the venue map. */
     private String mapUrl;
     private List<Talk> agenda = new ArrayList<>();
@@ -37,6 +39,16 @@ public class Event {
         this.description = description;
         this.createdAt = createdAt;
         this.creator = creator;
+    }
+
+    public Event(String id, String title, String description, int days) {
+        this(id, title, description);
+        this.days = days;
+    }
+
+    public Event(String id, String title, String description, int days, LocalDateTime createdAt, String creator) {
+        this(id, title, description, createdAt, creator);
+        this.days = days;
     }
 
     public String getId() {
@@ -71,6 +83,14 @@ public class Event {
         this.scenarios = scenarios;
     }
 
+    public int getDays() {
+        return days;
+    }
+
+    public void setDays(int days) {
+        this.days = days;
+    }
+
     public String getMapUrl() {
         return mapUrl;
     }
@@ -101,5 +121,35 @@ public class Event {
 
     public void setCreator(String creator) {
         this.creator = creator;
+    }
+
+    /**
+     * Returns a list with values from 1 to {@code days} to easily iterate in templates.
+     */
+    public java.util.List<Integer> getDayList() {
+        return java.util.stream.IntStream.rangeClosed(1, days)
+                .boxed()
+                .toList();
+    }
+
+    /**
+     * Retrieves the name of a scenario given its id, or {@code null} if not found.
+     */
+    public String getScenarioName(String scenarioId) {
+        return scenarios.stream()
+                .filter(s -> s.getId().equals(scenarioId))
+                .map(Scenario::getName)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Returns the list of talks for the given day ordered by start time.
+     */
+    public java.util.List<Talk> getAgendaForDay(int day) {
+        return agenda.stream()
+                .filter(t -> t.getDay() == day)
+                .sorted(java.util.Comparator.comparing(Talk::getStartTime))
+                .toList();
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -1,6 +1,6 @@
 package com.scanales.eventflow.model;
 
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 /**
  * Describes a talk within an event.
@@ -14,7 +14,11 @@ public class Talk {
     private Speaker coSpeaker;
     /** Room or scenario where the talk happens. */
     private String location;
-    private LocalDateTime time;
+    /** Day within the event when the talk occurs (1-based). */
+    private int day = 1;
+    private LocalTime startTime;
+    /** Duration in minutes. */
+    private int durationMinutes;
 
     public Talk() {
     }
@@ -72,11 +76,48 @@ public class Talk {
         this.location = location;
     }
 
-    public LocalDateTime getTime() {
-        return time;
+    public int getDay() {
+        return day;
     }
 
-    public void setTime(LocalDateTime time) {
-        this.time = time;
+    public void setDay(int day) {
+        this.day = day;
+    }
+
+    public LocalTime getStartTime() {
+        return startTime;
+    }
+
+    public String getStartTimeStr() {
+        return startTime == null ? "" : startTime.toString();
+    }
+
+    public void setStartTime(LocalTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public void setStartTimeStr(String value) {
+        if (value != null && !value.isBlank()) {
+            this.startTime = LocalTime.parse(value);
+        } else {
+            this.startTime = null;
+        }
+    }
+
+    public int getDurationMinutes() {
+        return durationMinutes;
+    }
+
+    public void setDurationMinutes(int durationMinutes) {
+        this.durationMinutes = durationMinutes;
+    }
+
+    public LocalTime getEndTime() {
+        return startTime == null ? null : startTime.plusMinutes(durationMinutes);
+    }
+
+    public String getEndTimeStr() {
+        LocalTime end = getEndTime();
+        return end == null ? "" : end.toString();
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -18,7 +18,7 @@ public class TalkResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(Talk talk);
+        static native TemplateInstance detail(Talk talk, com.scanales.eventflow.model.Scenario scenario);
     }
 
     @Inject
@@ -30,6 +30,10 @@ public class TalkResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance detail(@PathParam("id") String id) {
         Talk talk = eventService.findTalk(id);
-        return Templates.detail(talk);
+        com.scanales.eventflow.model.Scenario sc = null;
+        if (talk != null) {
+            sc = eventService.findScenario(talk.getLocation());
+        }
+        return Templates.detail(talk, sc);
     }
 }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -22,6 +22,8 @@ Nuevo Evento
     <input id="title" name="title" type="text" value="{event.title}">
     <label for="description">Descripcion</label>
     <textarea id="description" name="description">{event.description}</textarea>
+    <label for="days">Días del evento</label>
+    <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <button type="submit">Guardar</button>
 </form>
 {#if event.id}
@@ -69,7 +71,18 @@ Nuevo Evento
 <td><input name="name" value="{t.name}"></td>
 <td>
 <input name="description" value="{t.description}" placeholder="Descripcion">
-<input name="location" value="{t.location}" placeholder="Ubicacion">
+<select name="location">
+{#for sc in event.scenarios}
+<option value="{sc.id}"{#if sc.id==t.location} selected{/if}>{sc.name}</option>
+{/for}
+</select>
+<input name="startTime" type="time" value="{t.startTimeStr}">
+<input name="duration" type="number" min="1" value="{t.durationMinutes}">
+<select name="day">
+{#for d in event.dayList}
+<option value="{d}"{#if t.day==d} selected{/if}>Día {d}</option>
+{/for}
+</select>
 <button type="submit">Guardar</button>
 </form>
 <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline">
@@ -84,14 +97,34 @@ Nuevo Evento
 <td><input name="name"></td>
 <td>
 <input name="description" placeholder="Descripcion">
-<input name="location" placeholder="Ubicacion">
+<select name="location">
+{#for sc in event.scenarios}
+<option value="{sc.id}">{sc.name}</option>
+{/for}
+</select>
+<input name="startTime" type="time">
+<input name="duration" type="number" min="1">
+<select name="day">
+{#for d in event.dayList}
+<option value="{d}">Día {d}</option>
+{/for}
+</select>
 <button type="submit">Agregar</button>
 </td>
 </form>
 </tr>
 </tbody>
 </table>
+<h2>Agenda</h2>
+{#for d in event.dayList}
+<h3>Día {d}</h3>
+<ul>
+{#for t in event.getAgendaForDay(d)}
+<li>{t.startTimeStr} - {t.endTimeStr} | {t.name} | {event.getScenarioName(t.location)}</li>
+{/for}
+</ul>
+{/for}
 {/if}
-<p><a href="/private/admin/events">Volver</a></p>
+<p><a href="/private/admin/events">Volver a la administración de Eventos</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -73,14 +73,14 @@ Nuevo Evento
 <input name="description" value="{t.description}" placeholder="Descripcion">
 <select name="location">
 {#for sc in event.scenarios}
-<option value="{sc.id}"{#if sc.id==t.location} selected{/if}>{sc.name}</option>
+<option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
 {/for}
 </select>
 <input name="startTime" type="time" value="{t.startTimeStr}">
 <input name="duration" type="number" min="1" value="{t.durationMinutes}">
 <select name="day">
 {#for d in event.dayList}
-<option value="{d}"{#if t.day==d} selected{/if}>Día {d}</option>
+<option value="{d}"{#if t.day == d} selected{/if}>Día {d}</option>
 {/for}
 </select>
 <button type="submit">Guardar</button>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -19,12 +19,15 @@ Evento
 </ul>
 {/if}
 {#if !event.agenda.isEmpty()}
-<h2>Charlas</h2>
+<h2>Agenda</h2>
+{#for d in event.dayList}
+<h3>Día {d}</h3>
 <ul>
-{#for t in event.agenda}
-<li>{t.name}</li>
+{#for t in event.getAgendaForDay(d)}
+<li>{t.startTimeStr} - {t.endTimeStr} | {t.name} | {event.getScenarioName(t.location)}</li>
 {/for}
 </ul>
+{/for}
 {/if}
 {#else}
 <p>Evento no encontrado.</p>

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -11,6 +11,5 @@
 {/for}
 </ul>
 {/if}
-<p><a href="/login">Login</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -10,7 +10,10 @@ Charla
 {#if talk}
 <h1>{talk.name}</h1>
 {#if talk.description}<p>{talk.description}</p>{/if}
-{#if talk.time}<p>{talk.time}</p>{/if}
+{#if talk.startTimeStr}
+<p>{talk.startTimeStr} - {talk.endTimeStr} | Día {talk.day}</p>
+{/if}
+{#if scenario}<p>Escenario: {scenario.name}</p>{/if}
 {#else}
 <p>Charla no encontrada.</p>
 {/if}


### PR DESCRIPTION
## Summary
- add `days` to events with helpers for agenda generation
- extend talk model with start time, duration and day fields
- support editing the new fields in the admin UI
- link talks to scenarios using dropdowns and show an autogenerated agenda
- remove obsolete login link from home page
- expose talk details with schedule and scenario name

## Testing
- `mvn -q test -DskipITs` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_688018e6aebc833393a997bc3411f8d8