### PR TITLE
Fix JSON export with complete event data

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -154,8 +154,9 @@ public class AdminEventResource {
         }
         try {
             ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
-            String json = mapper.writeValueAsString(event);
-            LOG.infov("Exporting event {0}", id);
+            mapper.configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(event);
+            LOG.infov("Exporting event {0}:\n{1}", id, json);
             return Response.ok(json)
                     .header("Content-Disposition", "attachment; filename=evento_" + id + ".json")
                     .build();


### PR DESCRIPTION
## Summary
- pretty-print exported JSON for easier debugging
- log generated export payload
- configure Jackson to handle dates properly during export

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_688039b8e7148333bd26b3d53fac6bec