### PR TITLE
Fix export validation to match public event data

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -333,23 +333,26 @@ public class AdminEventResource {
     }
 
     private boolean hasRequiredData(Event event) {
-        if (event.getId() == null || event.getId().isBlank()) return false;
+        if (event == null) return false;
         if (event.getTitle() == null || event.getTitle().isBlank()) return false;
         if (event.getDescription() == null || event.getDescription().isBlank()) return false;
-        if (event.getCreatedAt() == null) return false;
         if (event.getCreator() == null || event.getCreator().isBlank()) return false;
-        if (event.getScenarios() == null || event.getScenarios().isEmpty()) return false;
-        for (Scenario sc : event.getScenarios()) {
-            if (sc.getId() == null || sc.getId().isBlank()) return false;
-            if (sc.getName() == null || sc.getName().isBlank()) return false;
-            if (sc.getLocation() == null || sc.getLocation().isBlank()) return false;
+        if (event.getCreatedAt() == null) return false;
+
+        // Validate scenarios only if present
+        if (event.getScenarios() != null) {
+            for (Scenario sc : event.getScenarios()) {
+                if (sc.getId() == null || sc.getId().isBlank()) return false;
+                if (sc.getName() == null || sc.getName().isBlank()) return false;
+            }
         }
+
         if (event.getAgenda() == null || event.getAgenda().isEmpty()) return false;
         for (Talk t : event.getAgenda()) {
             if (t.getId() == null || t.getId().isBlank()) return false;
             if (t.getName() == null || t.getName().isBlank()) return false;
-            if (t.getSpeaker() != null && (t.getSpeaker().getName() == null || t.getSpeaker().getName().isBlank())) return false;
         }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
- ensure export checks only basic required event fields
- allow exporting events even if scenarios lack location or features

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68804268ac508333a65d951334a66168