### PR TITLE
Improve event caching strategy

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -15,7 +15,14 @@ import com.scanales.eventflow.model.Talk;
 @ApplicationScoped
 public class EventService {
 
-    private final Map<String, Event> events = new ConcurrentHashMap<>();
+    /**
+     * Global cache of events shared by all sessions. Using a static map ensures
+     * the same {@code Event} instance is returned for a given id, reducing
+     * memory usage and avoiding unnecessary object duplication. The
+     * ConcurrentHashMap provides lock-free reads and efficient updates for a
+     * high performance setup.
+     */
+    private static final Map<String, Event> events = new ConcurrentHashMap<>();
 
     public List<Event> listEvents() {
         return new ArrayList<>(events.values());


### PR DESCRIPTION
## Summary
- store events in a static concurrent map so the same object is shared by all sessions

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880598568d483338c94e88f20fe4608