### PR TITLE
Fix empty JSON output in native mode

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -1,12 +1,14 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.time.LocalDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 
 /**
  * Represents an event with its basic information, the scenarios where the

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Scenario.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Scenario.java
@@ -1,11 +1,13 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * Defines a scenario or room where the event activities take place.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 public class Scenario {
 
     private String id;

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
@@ -1,11 +1,13 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 
 /**
  * Represents a person giving one or more talks at the event.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -1,10 +1,12 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.LocalTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@RegisterForReflection
 
 /**
  * Describes a talk within an event.


### PR DESCRIPTION
## Summary
- register event model classes for reflection so JSON-B can serialize them in native executables

## Testing
- `mvn -q -f quarkus-app/pom.xml -DskipTests compile` *(fails: could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6880622ccd2c8333ac3609c920aea64e