### PR TITLE
Add navigation among agenda, talks and scenarios

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventResource.java
@@ -19,6 +19,7 @@ public class EventResource {
     @CheckedTemplate
     static class Templates {
         static native TemplateInstance detail(Event event);
+        static native TemplateInstance agenda(Event event);
     }
 
     @Inject
@@ -34,5 +35,14 @@ public class EventResource {
             return Templates.detail(null);
         }
         return Templates.detail(event);
+    }
+
+    @GET
+    @Path("{id}/agenda")
+    @PermitAll
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance agenda(@PathParam("id") String id) {
+        Event event = eventService.getEvent(id);
+        return Templates.agenda(event);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
@@ -18,7 +18,9 @@ public class ScenarioResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(Scenario scenario);
+        static native TemplateInstance detail(Scenario scenario,
+                                             com.scanales.eventflow.model.Event event,
+                                             java.util.List<com.scanales.eventflow.model.Talk> talks);
     }
 
     @Inject
@@ -30,6 +32,11 @@ public class ScenarioResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance detail(@PathParam("id") String id) {
         Scenario s = eventService.findScenario(id);
-        return Templates.detail(s);
+        if (s == null) {
+            return Templates.detail(null, null, java.util.List.of());
+        }
+        var event = eventService.findEventByScenario(id);
+        var talks = eventService.findTalksForScenario(id);
+        return Templates.detail(s, event, talks);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -18,7 +18,9 @@ public class TalkResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(Talk talk, com.scanales.eventflow.model.Scenario scenario);
+        static native TemplateInstance detail(Talk talk,
+                                             com.scanales.eventflow.model.Event event,
+                                             java.util.List<Talk> occurrences);
     }
 
     @Inject
@@ -30,10 +32,11 @@ public class TalkResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance detail(@PathParam("id") String id) {
         Talk talk = eventService.findTalk(id);
-        com.scanales.eventflow.model.Scenario sc = null;
-        if (talk != null) {
-            sc = eventService.findScenario(talk.getLocation());
+        if (talk == null) {
+            return Templates.detail(null, null, java.util.List.of());
         }
-        return Templates.detail(talk, sc);
+        var event = eventService.findEventByTalk(id);
+        var occurrences = eventService.findTalkOccurrences(id);
+        return Templates.detail(talk, event, occurrences);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -87,4 +87,47 @@ public class EventService {
                 .findFirst()
                 .orElse(null);
     }
+
+    /** Returns the event that contains the given scenario or {@code null} if none. */
+    public Event findEventByScenario(String scenarioId) {
+        return events.values().stream()
+                .filter(e -> e.getScenarios().stream()
+                        .anyMatch(s -> s.getId().equals(scenarioId)))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** Returns the event that includes the provided talk id or {@code null}. */
+    public Event findEventByTalk(String talkId) {
+        return events.values().stream()
+                .filter(e -> e.getAgenda().stream()
+                        .anyMatch(t -> t.getId().equals(talkId)))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Returns all talk instances matching the given id across all events.
+     * Useful when the same talk is scheduled multiple times.
+     */
+    public List<Talk> findTalkOccurrences(String talkId) {
+        return events.values().stream()
+                .flatMap(e -> e.getAgenda().stream()
+                        .filter(t -> t.getId().equals(talkId)))
+                .sorted(java.util.Comparator
+                        .comparingInt(Talk::getDay)
+                        .thenComparing(Talk::getStartTime))
+                .toList();
+    }
+
+    /** Returns the list of talks scheduled in the given scenario ordered by day and time. */
+    public List<Talk> findTalksForScenario(String scenarioId) {
+        return events.values().stream()
+                .flatMap(e -> e.getAgenda().stream())
+                .filter(t -> scenarioId.equals(t.getLocation()))
+                .sorted(java.util.Comparator
+                        .comparingInt(Talk::getDay)
+                        .thenComparing(Talk::getStartTime))
+                .toList();
+    }
 }

--- a/quarkus-app/src/main/resources/templates/EventResource/agenda.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/agenda.html
@@ -1,0 +1,21 @@
+{#include layout/base}
+{#title}
+{#if event}{event.title} - Agenda{#else}Agenda{/if}
+{/title}
+{#main}
+{#if event}
+<h1>Agenda de {event.title}</h1>
+{#for d in event.dayList}
+<h2>Día {d}</h2>
+<ul>
+{#for t in event.getAgendaForDay(d)}
+<li>{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+{/for}
+</ul>
+{/for}
+<p><a href="/event/{event.id}">Volver al evento</a></p>
+{#else}
+<p>Evento no encontrado.</p>
+{/if}
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -14,20 +14,13 @@ Evento
 <h2>Escenarios</h2>
 <ul>
 {#for s in event.scenarios}
-<li>{s.name}</li>
+<li><a href="/scenario/{s.id}">{s.name}</a></li>
 {/for}
 </ul>
 {/if}
 {#if !event.agenda.isEmpty()}
 <h2>Agenda</h2>
-{#for d in event.dayList}
-<h3>Día {d}</h3>
-<ul>
-{#for t in event.getAgendaForDay(d)}
-<li>{t.startTimeStr} - {t.endTimeStr} | {t.name} | {event.getScenarioName(t.location)}</li>
-{/for}
-</ul>
-{/for}
+<p><a href="/event/{event.id}/agenda">Ver agenda completa</a></p>
 {/if}
 {#else}
 <p>Evento no encontrado.</p>

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -11,6 +11,19 @@ Escenario
 <h1>{scenario.name}</h1>
 {#if scenario.location}<p>Ubicacion: {scenario.location}</p>{/if}
 {#if scenario.features}<p>{scenario.features}</p>{/if}
+{#if !talks.isEmpty()}
+<h2>Charlas</h2>
+<ul>
+{#for t in talks}
+    <li>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) :
+        <a href="/talk/{t.id}">{t.name}</a>
+    </li>
+{/for}
+</ul>
+{/if}
+{#if event}
+<p><a href="/event/{event.id}">Volver al evento</a></p>
+{/if}
 {#else}
 <p>Escenario no encontrado.</p>
 {/if}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -10,10 +10,17 @@ Charla
 {#if talk}
 <h1>{talk.name}</h1>
 {#if talk.description}<p>{talk.description}</p>{/if}
-{#if talk.startTimeStr}
-<p>{talk.startTimeStr} - {talk.endTimeStr} | Día {talk.day}</p>
+{#if !occurrences.isEmpty()}
+<h2>Horarios</h2>
+<ul>
+{#for t in occurrences}
+    <li>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) -
+        <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
+    </li>
+{/for}
+</ul>
 {/if}
-{#if scenario}<p>Escenario: {scenario.name}</p>{/if}
+{#if event}<p><a href="/event/{event.id}">Volver al evento</a></p>{/if}
 {#else}
 <p>Charla no encontrada.</p>
 {/if}


### PR DESCRIPTION
## Summary
- add agenda route to `EventResource`
- expose lookup helpers in `EventService`
- enhance talk and scenario resources to include navigation info
- show scenario links from event page
- create agenda template
- update talk and scenario templates with reciprocal links

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880c25298688333b7c92e37ee3b354b