### PR TITLE
Show agenda inline on event page

### DIFF
--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -20,7 +20,14 @@ Evento
 {/if}
 {#if !event.agenda.isEmpty()}
 <h2>Agenda</h2>
-<p><a href="/event/{event.id}/agenda">Ver agenda completa</a></p>
+{#for d in event.dayList}
+<h3>Día {d}</h3>
+<ul>
+{#for t in event.getAgendaForDay(d)}
+<li>{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+{/for}
+</ul>
+{/for}
 {/if}
 {#else}
 <p>Evento no encontrado.</p>


### PR DESCRIPTION
## Summary
- display the event agenda directly within the event page

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6880d1b7b40c83338ae9133f38e5af31