### PR TITLE
Add personal talk schedule

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -63,7 +63,10 @@ public class ProfileResource {
             name = identity.getPrincipal().getName();
         }
 
-        String sub = identity.getPrincipal().getName();
+        String sub = getClaim("sub");
+        if (sub == null) {
+            sub = identity.getPrincipal().getName();
+        }
 
         if (email == null) {
             email = sub;

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -65,6 +65,10 @@ public class ProfileResource {
 
         String sub = identity.getPrincipal().getName();
 
+        if (email == null) {
+            email = sub;
+        }
+
         var talkIds = userSchedule.getTalksForUser(email);
         java.util.List<TalkEntry> talks = talkIds.stream()
                 .map(tid -> {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -1,0 +1,36 @@
+package com.scanales.eventflow.service;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Simple in-memory store mapping user emails to talk ids. */
+@ApplicationScoped
+public class UserScheduleService {
+
+    private final Map<String, Set<String>> schedules = new ConcurrentHashMap<>();
+
+    /** Adds the talk id to the schedule for the given user email. */
+    public void addTalkForUser(String email, String talkId) {
+        schedules.computeIfAbsent(email, k -> ConcurrentHashMap.newKeySet())
+                .add(talkId);
+    }
+
+    /** Returns the set of talk ids registered by the user. */
+    public Set<String> getTalksForUser(String email) {
+        return schedules.getOrDefault(email, java.util.Set.of());
+    }
+
+    /** Removes the talk id from the user schedule. */
+    public void removeTalkForUser(String email, String talkId) {
+        Set<String> talks = schedules.get(email);
+        if (talks != null) {
+            talks.remove(talkId);
+            if (talks.isEmpty()) {
+                schedules.remove(email);
+            }
+        }
+    }
+}

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -8,7 +8,21 @@
 <p><strong>Email:</strong> {email}</p>
 <p><strong>Sub:</strong> {sub}</p>
 <h2>Mis charlas</h2>
+{#if talks.isEmpty()}
 <p>A\u00fan no hay charlas.</p>
+{#else}
+<ul>
+{#for e in talks}
+    <li>Día {e.talk.day} - {e.talk.startTimeStr} ({e.talk.durationMinutes} min) -
+        <a href="/talk/{e.talk.id}">{e.talk.name}</a>
+        {#if e.event}
+            - <a href="/scenario/{e.talk.location}">{e.event.getScenarioName(e.talk.location)}</a>
+        {/if}
+        - <a href="/private/profile/remove/{e.talk.id}">Eliminar de mis charlas</a>
+    </li>
+{/for}
+</ul>
+{/if}
 <p><a href="/private/admin">Admin Panel</a></p>
 <p><a href="/logout">Salir</a></p>
 {/main}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -10,6 +10,9 @@ Charla
 {#if talk}
 <h1>{talk.name}</h1>
 {#if talk.description}<p>{talk.description}</p>{/if}
+{#if app:isAuthenticated()}
+<p><a href="/private/profile/add/{talk.id}">Agregar a mis charlas</a></p>
+{/if}
 {#if !occurrences.isEmpty()}
 <h2>Horarios</h2>
 <ul>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/UserScheduleTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/UserScheduleTest.java
@@ -1,0 +1,74 @@
+package com.scanales.eventflow.private_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class UserScheduleTest {
+
+    @Inject
+    EventService eventService;
+
+    @BeforeEach
+    public void setup() {
+        Event e = new Event("evt", "Test Event", "desc", 1);
+        Scenario sc = new Scenario("s1", "Main");
+        e.getScenarios().add(sc);
+        Talk t = new Talk("t1", "Talk 1");
+        t.setLocation("s1");
+        t.setDay(1);
+        t.setDurationMinutes(30);
+        t.setStartTime(LocalTime.of(10, 0));
+        e.getAgenda().add(t);
+        eventService.saveEvent(e);
+    }
+
+    @Test
+    public void addRequiresAuth() {
+        given()
+                .when().get("/private/profile/add/t1")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    @TestSecurity(user = "user@example.com")
+    public void addAndRemoveTalk() {
+        given()
+                .when().get("/private/profile/add/t1")
+                .then()
+                .statusCode(303);
+
+        given()
+                .when().get("/private/profile")
+                .then()
+                .statusCode(200)
+                .body(containsString("Talk 1"));
+
+        given()
+                .when().get("/private/profile/remove/t1")
+                .then()
+                .statusCode(303);
+
+        given()
+                .when().get("/private/profile")
+                .then()
+                .statusCode(200)
+                .body(not(containsString("Talk 1")));
+    }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/UserScheduleTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/UserScheduleTest.java
@@ -50,6 +50,7 @@ public class UserScheduleTest {
     @TestSecurity(user = "user@example.com")
     public void addAndRemoveTalk() {
         given()
+                .redirects().follow(false)
                 .when().get("/private/profile/add/t1")
                 .then()
                 .statusCode(303);
@@ -61,6 +62,7 @@ public class UserScheduleTest {
                 .body(containsString("Talk 1"));
 
         given()
+                .redirects().follow(false)
                 .when().get("/private/profile/remove/t1")
                 .then()
                 .statusCode(303);


### PR DESCRIPTION
## Summary
- implement `UserScheduleService` to store user's selected talks
- extend profile page to show and manage personal talks
- add buttons for adding/removing talks
- cover new functionality with tests

## Testing
- `mvn -q test` *(fails: Could not resolve artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_6880dc48e9348333a6fde7d67d2eaff8