### PR TITLE
Add event date for accurate talk status

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -6,6 +6,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.ArrayList;
 import java.util.List;
 import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @RegisterForReflection
@@ -24,6 +25,8 @@ public class Event {
     private int days = 1;
     /** URL or identifier for the venue map. */
     private String mapUrl;
+    /** Base date for the event used to compute talk schedules. */
+    private java.time.LocalDate eventDate;
     private List<Talk> agenda = new ArrayList<>();
     /** Time when the event was created. */
     private LocalDateTime createdAt;
@@ -103,6 +106,14 @@ public class Event {
 
     public void setMapUrl(String mapUrl) {
         this.mapUrl = mapUrl;
+    }
+
+    public java.time.LocalDate getEventDate() {
+        return eventDate;
+    }
+
+    public void setEventDate(java.time.LocalDate eventDate) {
+        this.eventDate = eventDate;
     }
 
     public List<Talk> getAgenda() {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -93,14 +93,19 @@ public class AdminEventResource {
     public Response saveEvent(@FormParam("title") String title,
                               @FormParam("description") String description,
                               @FormParam("mapUrl") String mapUrl,
-                              @FormParam("days") int days) {
+                              @FormParam("days") int days,
+                              @FormParam("eventDate") String eventDateStr) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        if (eventDateStr == null || eventDateStr.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Fecha requerida").build();
         }
         var now = java.time.LocalDateTime.now();
         String id = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(now);
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
         event.setMapUrl(mapUrl);
+        event.setEventDate(java.time.LocalDate.parse(eventDateStr));
         eventService.saveEvent(event);
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/private/admin/events")
@@ -114,7 +119,8 @@ public class AdminEventResource {
                                 @FormParam("title") String title,
                                 @FormParam("description") String description,
                                 @FormParam("mapUrl") String mapUrl,
-                                @FormParam("days") int days) {
+                                @FormParam("days") int days,
+                                @FormParam("eventDate") String eventDateStr) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
@@ -122,10 +128,14 @@ public class AdminEventResource {
         if (event == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
+        if (eventDateStr == null || eventDateStr.isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Fecha requerida").build();
+        }
         event.setTitle(title);
         event.setDescription(description);
         event.setDays(days);
         event.setMapUrl(mapUrl);
+        event.setEventDate(java.time.LocalDate.parse(eventDateStr));
         eventService.saveEvent(event);
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/event/" + id)
@@ -359,6 +369,7 @@ public class AdminEventResource {
         if (event.getTitle() == null) event.setTitle("VACIO");
         if (event.getDescription() == null) event.setDescription("VACIO");
         if (event.getMapUrl() == null) event.setMapUrl("VACIO");
+        if (event.getEventDate() == null) event.setEventDate(java.time.LocalDate.now());
         if (event.getCreator() == null) event.setCreator("VACIO");
         if (event.getCreatedAt() == null) event.setCreatedAt(java.time.LocalDateTime.now());
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -40,9 +40,13 @@ public class ProfileResource {
     public record TalkEntry(Talk talk, com.scanales.eventflow.model.Event event) {
         public String status() {
             if (talk == null || event == null) return "";
-            java.time.LocalDate startDate = event.getCreatedAt() == null
-                    ? java.time.LocalDate.now()
-                    : event.getCreatedAt().toLocalDate();
+            java.time.LocalDate base = event.getEventDate();
+            if (base == null) {
+                base = event.getCreatedAt() == null
+                        ? java.time.LocalDate.now()
+                        : event.getCreatedAt().toLocalDate();
+            }
+            java.time.LocalDate startDate = base;
             java.time.LocalDateTime start = java.time.LocalDateTime.of(
                     startDate.plusDays(talk.getDay() - 1),
                     talk.getStartTime());

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -24,6 +24,8 @@ Nuevo Evento
     <textarea id="description" name="description">{event.description}</textarea>
     <label for="mapUrl">Mapa (URL)</label>
     <input id="mapUrl" name="mapUrl" type="text" value="{event.mapUrl}">
+    <label for="eventDate">Fecha del evento</label>
+    <input id="eventDate" name="eventDate" type="date" value="{event.eventDate}">
     <label for="days">Días del evento</label>
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <button type="submit">Guardar</button>


### PR DESCRIPTION
## Summary
- track event date in `Event`
- enforce event date via admin UI and controllers
- compute talk status based on event date

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68813ad848f083338f93d3f32cc23728