### PR TITLE
Improve mapUrl field UI and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ redirects back to the event list displaying a confirmation banner.
 
 ## Map navigation and talk status
 
-- Events and scenarios can include a `mapUrl` field pointing to an image of their location.
+- Events and scenarios can include a `mapUrl` field pointing to an image of their location. For best results, use 800x600 px images.
 - Scenario pages display this map when available and talk details provide a "🧭 ¿Cómo llegar?" link to highlight the room.
 - The profile page lists all registered talks in a table showing a dynamic status column indicating whether each talk is on time, about to start, in progress or finished.

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -121,8 +121,16 @@ footer {
 
 /* Standard responsive size for map images */
 .map-image {
-    max-width: 100%;
+    max-width: 800px;
+    width: 100%;
     height: auto;
     display: block;
     margin: 0 auto;
+}
+
+.input-help {
+    font-size: 0.85em;
+    color: #555;
+    display: block;
+    margin-top: 0.25rem;
 }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -24,6 +24,7 @@ Nuevo Evento
     <textarea id="description" name="description">{event.description}</textarea>
     <label for="mapUrl">Mapa (URL)</label>
     <input id="mapUrl" name="mapUrl" type="text" value="{event.mapUrl}">
+    <small class="input-help">Se recomienda utilizar imágenes de 800x600 px.</small>
     <label for="eventDate">Fecha del evento</label>
     <input id="eventDate" name="eventDate" type="date" value="{event.eventDate}">
     <label for="days">Días del evento</label>
@@ -40,7 +41,7 @@ Nuevo Evento
 <form method="post" action="/private/admin/events/{event.id}/scenario">
 <td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
 <td><input name="name" value="{sc.name}"></td>
-<td><input name="mapUrl" value="{sc.mapUrl}" placeholder="URL mapa"></td>
+<td><input name="mapUrl" value="{sc.mapUrl}" placeholder="URL mapa (800x600)"></td>
 <td>
 <input name="features" value="{sc.features}" placeholder="Caracteristicas">
 <input name="location" value="{sc.location}" placeholder="Ubicacion">
@@ -56,7 +57,7 @@ Nuevo Evento
 <form method="post" action="/private/admin/events/{event.id}/scenario">
 <td>Nuevo</td>
 <td><input name="name"></td>
-<td><input name="mapUrl" placeholder="URL mapa"></td>
+<td><input name="mapUrl" placeholder="URL mapa (800x600)"></td>
 <td>
 <input name="features" placeholder="Caracteristicas">
 <input name="location" placeholder="Ubicacion">


### PR DESCRIPTION
## Summary
- add recommended image size note on mapUrl field
- update mapUrl placeholders for scenario forms
- limit map-image width to 800px and add input-help style
- document preferred mapUrl image size

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68822d7719bc8333a5d7c91ace7a622b