### PR TITLE
Add header logos

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -20,6 +20,36 @@ body {
     text-align: center;
 }
 
+.site-header {
+    background: linear-gradient(to right, #b4e1fa, #d3f3f9);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.logo-container {
+    display: flex;
+    align-items: center;
+}
+
+.eventflow-logo {
+    height: 80px;
+    margin: 0 1rem;
+}
+
+.powered-by {
+    font-family: monospace;
+    font-size: 1rem;
+    color: #555;
+    margin: 0 1rem;
+}
+
+.oss-logo {
+    height: 40px;
+    margin: 0 1rem;
+}
+
 .container-logo {
     padding: 0.5rem 1rem;
     text-align: left;
@@ -116,6 +146,21 @@ footer {
     }
     .menu-toggle {
         display: block;
+    }
+}
+
+@media (max-width: 600px) {
+    .logo-container {
+        flex-direction: column;
+    }
+    .eventflow-logo {
+        height: 60px;
+    }
+    .oss-logo {
+        height: 30px;
+    }
+    .powered-by {
+        margin: 0.5rem 0;
     }
 }
 

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -8,10 +8,14 @@
     <script src="/js/app.js" defer></script>
 </head>
 <body>
-<header class="info-header">
-    <div class="container-logo">
-        <a href="/" class="logo">EventFlow</a>
+<header class="site-header">
+    <div class="logo-container">
+        <img src="/img/eventflow-logo.png" alt="EventFlow Logo" class="eventflow-logo">
+        <span class="powered-by">powered by</span>
+        <img src="/img/oss-logo.png" alt="OpenSourceSantiago Logo" class="oss-logo">
     </div>
+</header>
+<header class="info-header">
     <div class="container-banner">
         {#insert banner}
         <span class="banner-title">EventFlow</span>


### PR DESCRIPTION
## Summary
- add EventFlow and OpenSourceSantiago logos in base header
- style header with gradient and responsive layout

## Testing
- `mvn -q test` *(fails: could not resolve artifacts, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6882619ef9008333b9d1cefd96294a98