### PR TITLE
Center banner content with flexbox

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -31,6 +31,9 @@ body {
 .logo-container {
     display: flex;
     align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
 .eventflow-logo {
@@ -64,6 +67,9 @@ body {
 }
 
 .container-banner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
     background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
     background-size: 200% 200%;
     animation: flow 10s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- use flexbox in `.container-banner` and `.logo-container` to horizontally center header elements

## Testing
- `mvn test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68829b1dea4c8333a3fe316ac83f5bd8