### PR TITLE
fix native build args

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -32,4 +32,4 @@ eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
 eventflow.sync.dataDir=event-data
 
 # JGit requires some classes to be initialized at runtime when building a native image
-quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,org.eclipse.jgit.transport.HttpAuthMethod$Digest,org.eclipse.jgit.internal.storage.file.WindowCache,org.eclipse.jgit.util.FileUtils
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue\,org.eclipse.jgit.transport.HttpAuthMethod\$Digest\,org.eclipse.jgit.internal.storage.file.WindowCache\,org.eclipse.jgit.util.FileUtils


### PR DESCRIPTION
## Summary
- fix JGit native args formatting

## Testing
- `mvn -B -f quarkus-app/pom.xml package` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68835d0e07548333a27dc37c2050f491