### PR TITLE
Fix native build args for JGit

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -32,4 +32,4 @@ eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
 eventflow.sync.dataDir=event-data
 
 # JGit requires some classes to be initialized at runtime when building a native image
-quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue\,org.eclipse.jgit.transport.HttpAuthMethod\$Digest\,org.eclipse.jgit.internal.storage.file.WindowCache\,org.eclipse.jgit.util.FileUtils
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,org.eclipse.jgit.transport.HttpAuthMethod$Digest,org.eclipse.jgit.internal.storage.file.WindowCache,org.eclipse.jgit.util.FileUtils


### PR DESCRIPTION
## Summary
- fix `quarkus.native.additional-build-args` so the classes are passed as one argument

## Testing
- `mvn -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883607e88348333a6530d18705580dd