### PR TITLE
Rework native build args

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -32,4 +32,4 @@ eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
 eventflow.sync.dataDir=event-data
 
 # JGit requires some classes to be initialized at runtime when building a native image
-quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,org.eclipse.jgit.transport.HttpAuthMethod$Digest,org.eclipse.jgit.internal.storage.file.WindowCache,org.eclipse.jgit.util.FileUtils
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,--initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,--initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,--initialize-at-run-time=org.eclipse.jgit.util.FileUtils


### PR DESCRIPTION
## Summary
- list JGit classes as individual `--initialize-at-run-time` options for native builds

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688365ee48588333a24281cf56e388ed