### PR TITLE
Add admin Git reload status

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -5,6 +5,7 @@ import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.EventLoaderService;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Scenario;
 import com.scanales.eventflow.model.Talk;
@@ -47,7 +48,7 @@ public class AdminEventResource {
     EventService eventService;
 
     @Inject
-    com.scanales.eventflow.service.GitEventSyncService gitSync;
+    EventLoaderService gitSync;
 
     private boolean isAdmin() {
         return AdminUtils.isAdmin(identity);

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/GitStatusResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/GitStatusResource.java
@@ -1,0 +1,51 @@
+package com.scanales.eventflow.private_;
+
+import com.scanales.eventflow.service.EventLoaderService;
+import com.scanales.eventflow.service.GitLoadStatus;
+import com.scanales.eventflow.util.AdminUtils;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/private/api")
+public class GitStatusResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    EventLoaderService loader;
+
+    private boolean isAdmin() {
+        return AdminUtils.isAdmin(identity);
+    }
+
+    @GET
+    @Path("/git-status")
+    @Authenticated
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response status() {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return Response.ok(loader.getStatus()).build();
+    }
+
+    @POST
+    @Path("/git-reload")
+    @Authenticated
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response reload() {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        GitLoadStatus status = loader.reload();
+        return Response.ok(status).build();
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/GitLoadStatus.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/GitLoadStatus.java
@@ -1,0 +1,38 @@
+package com.scanales.eventflow.service;
+
+import java.time.LocalDateTime;
+
+public class GitLoadStatus {
+    private boolean success;
+    private String message;
+    private int filesRead;
+    private int eventsImported;
+    private String repoUrl;
+    private String branch;
+    private LocalDateTime lastAttempt;
+    private LocalDateTime lastSuccess;
+
+    public boolean isSuccess() { return success; }
+    public void setSuccess(boolean success) { this.success = success; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public int getFilesRead() { return filesRead; }
+    public void setFilesRead(int filesRead) { this.filesRead = filesRead; }
+
+    public int getEventsImported() { return eventsImported; }
+    public void setEventsImported(int eventsImported) { this.eventsImported = eventsImported; }
+
+    public String getRepoUrl() { return repoUrl; }
+    public void setRepoUrl(String repoUrl) { this.repoUrl = repoUrl; }
+
+    public String getBranch() { return branch; }
+    public void setBranch(String branch) { this.branch = branch; }
+
+    public LocalDateTime getLastAttempt() { return lastAttempt; }
+    public void setLastAttempt(LocalDateTime lastAttempt) { this.lastAttempt = lastAttempt; }
+
+    public LocalDateTime getLastSuccess() { return lastSuccess; }
+    public void setLastSuccess(LocalDateTime lastSuccess) { this.lastSuccess = lastSuccess; }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -27,6 +27,64 @@ window.addEventListener('DOMContentLoaded', () => {
     setupMenu();
     adjustLayout();
     bannerParallax();
+    loadGitStatus();
+    const reloadBtn = document.getElementById('git-reload-btn');
+    if (reloadBtn) {
+        reloadBtn.addEventListener('click', reloadGit);
+    }
 });
 window.addEventListener('resize', adjustLayout);
 window.addEventListener('scroll', bannerParallax);
+
+async function loadGitStatus() {
+    const container = document.getElementById('git-status-container');
+    if (!container) return;
+    try {
+        const resp = await fetch('/private/api/git-status');
+        if (!resp.ok) {
+            container.textContent = 'Error al obtener estado';
+            return;
+        }
+        const data = await resp.json();
+        container.innerHTML = renderGitStatus(data);
+    } catch (e) {
+        container.textContent = 'Error al obtener estado';
+    }
+}
+
+function renderGitStatus(data) {
+    const icon = data.success ? '✅' : '❌';
+    const color = data.success ? 'green' : 'red';
+    let html = `<p style="color:${color}">${icon} `;
+    html += data.success ? 'Configuración cargada correctamente desde Git.' : 'Error al cargar configuración desde Git.';
+    html += '</p><ul>';
+    if (data.message && !data.success) {
+        html += `<li>${data.message}</li>`;
+    }
+    if (data.repoUrl) html += `<li>Repo: ${data.repoUrl}</li>`;
+    if (data.branch) html += `<li>Branch: ${data.branch}</li>`;
+    if (data.filesRead !== undefined) html += `<li>Archivos JSON: ${data.filesRead}</li>`;
+    if (data.eventsImported !== undefined) html += `<li>Eventos cargados: ${data.eventsImported}</li>`;
+    if (data.lastSuccess) html += `<li>Última carga exitosa: ${data.lastSuccess}</li>`;
+    html += '</ul>';
+    return html;
+}
+
+async function reloadGit() {
+    const btn = document.getElementById('git-reload-btn');
+    if (btn) btn.disabled = true;
+    try {
+        const resp = await fetch('/private/api/git-reload', {method: 'POST'});
+        if (resp.ok) {
+            const data = await resp.json();
+            alert(data.success ? 'Cargado exitosamente' : 'Error: ' + data.message);
+        } else {
+            alert('Error al recargar');
+        }
+    } catch (e) {
+        alert('Error al recargar');
+    } finally {
+        if (btn) btn.disabled = false;
+        loadGitStatus();
+    }
+}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -4,6 +4,11 @@
 <h1>Admin Panel</h1>
 <p>Bienvenido {name}. Gestiona los eventos aquí.</p>
 <p><a href="/private/admin/events">Administrar eventos</a></p>
+<section>
+    <h2>Estado de carga desde Git</h2>
+    <div id="git-status-container">Cargando...</div>
+    <button id="git-reload-btn">Volver a cargar desde Git</button>
+</section>
 <p><a href="/private/profile">Volver a perfil</a></p>
 {/main}
 {/include}


### PR DESCRIPTION
## Summary
- rename `GitEventSyncService` to `EventLoaderService`
- track load attempts in new `GitLoadStatus` class
- expose `/private/api/git-status` and `/private/api/git-reload` endpoints
- show Git load status and reload button on admin page
- update frontend logic to query new API endpoints

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_688948214f2483338fc41a5d53a402d0