### PR TITLE
Add troubleshooting utilities for Git sync

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/GitStatusResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/GitStatusResource.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.private_;
 
 import com.scanales.eventflow.service.EventLoaderService;
 import com.scanales.eventflow.service.GitLoadStatus;
+import com.scanales.eventflow.service.GitTroubleshootResult;
 import com.scanales.eventflow.util.AdminUtils;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
@@ -47,5 +48,17 @@ public class GitStatusResource {
         }
         GitLoadStatus status = loader.reload();
         return Response.ok(status).build();
+    }
+
+    @GET
+    @Path("/git-troubleshoot")
+    @Authenticated
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response troubleshoot() {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        GitTroubleshootResult result = loader.troubleshoot();
+        return Response.ok(result).build();
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/GitTroubleshootResult.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/GitTroubleshootResult.java
@@ -1,0 +1,35 @@
+package com.scanales.eventflow.service;
+
+import java.util.List;
+
+/** Result details for Git troubleshooting operations. */
+public class GitTroubleshootResult {
+    private boolean repoAccessible;
+    private boolean cloneSuccess;
+    private int jsonFiles;
+    private int validJson;
+    private List<String> invalidFiles;
+    private String message;
+    private String errorDetails;
+
+    public boolean isRepoAccessible() { return repoAccessible; }
+    public void setRepoAccessible(boolean repoAccessible) { this.repoAccessible = repoAccessible; }
+
+    public boolean isCloneSuccess() { return cloneSuccess; }
+    public void setCloneSuccess(boolean cloneSuccess) { this.cloneSuccess = cloneSuccess; }
+
+    public int getJsonFiles() { return jsonFiles; }
+    public void setJsonFiles(int jsonFiles) { this.jsonFiles = jsonFiles; }
+
+    public int getValidJson() { return validJson; }
+    public void setValidJson(int validJson) { this.validJson = validJson; }
+
+    public List<String> getInvalidFiles() { return invalidFiles; }
+    public void setInvalidFiles(List<String> invalidFiles) { this.invalidFiles = invalidFiles; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getErrorDetails() { return errorDetails; }
+    public void setErrorDetails(String errorDetails) { this.errorDetails = errorDetails; }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -32,6 +32,10 @@ window.addEventListener('DOMContentLoaded', () => {
     if (reloadBtn) {
         reloadBtn.addEventListener('click', reloadGit);
     }
+    const troubleshootBtn = document.getElementById('git-troubleshoot-btn');
+    if (troubleshootBtn) {
+        troubleshootBtn.addEventListener('click', troubleshootGit);
+    }
 });
 window.addEventListener('resize', adjustLayout);
 window.addEventListener('scroll', bannerParallax);
@@ -136,5 +140,48 @@ async function reloadGit() {
             btn.textContent = 'Volver a cargar desde Git';
         }
         loadGitStatus();
+    }
+}
+
+async function troubleshootGit() {
+    const btn = document.getElementById('git-troubleshoot-btn');
+    const msg = document.getElementById('git-troubleshoot-msg');
+    if (btn) {
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner"></span> Diagnosticando...';
+    }
+    if (msg) {
+        msg.textContent = '';
+        msg.style.color = 'gray';
+    }
+    try {
+        const resp = await fetch('/private/api/git-troubleshoot');
+        if (resp.ok) {
+            const data = await resp.json();
+            if (msg) {
+                msg.innerHTML = '<pre>' + escapeHtml(JSON.stringify(data, null, 2)) + '</pre>';
+            } else {
+                alert(JSON.stringify(data, null, 2));
+            }
+        } else {
+            if (msg) {
+                msg.textContent = 'Error al diagnosticar';
+                msg.style.color = 'red';
+            } else {
+                alert('Error al diagnosticar');
+            }
+        }
+    } catch (e) {
+        if (msg) {
+            msg.textContent = 'Error al diagnosticar';
+            msg.style.color = 'red';
+        } else {
+            alert('Error al diagnosticar');
+        }
+    } finally {
+        if (btn) {
+            btn.disabled = false;
+            btn.textContent = 'Diagnosticar Git';
+        }
     }
 }

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -10,6 +10,8 @@
     <div id="git-status-container">Cargando...</div>
     <button id="git-reload-btn">Volver a cargar desde Git</button>
     <div id="git-reload-msg" role="status" aria-live="polite"></div>
+    <button id="git-troubleshoot-btn">Diagnosticar Git</button>
+    <div id="git-troubleshoot-msg" role="status" aria-live="polite"></div>
     <p class="git-help">¿Se modificó un evento en Git y no aparece actualizado? Usa 'Volver a cargar desde Git' para forzar sincronización.</p>
 </section>
 <p><a href="/private/profile">Volver a perfil</a></p>


### PR DESCRIPTION
## Summary
- add a `GitTroubleshootResult` object to convey troubleshooting details
- extend `EventLoaderService` with detailed reload logs and new troubleshooting method
- expose `/private/api/git-troubleshoot` endpoint
- show diagnostics button in admin UI and wire it with new JS function

## Testing
- `mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d449998408333a56915dfa5ae1521