### PR TITLE
Fix JGit enum reflection in native build

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true
+  }
+]


### PR DESCRIPTION
## Summary
- register `CoreConfig$TrustStat` for reflection

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d494cc50c8333b8855428d4b7e35c