### PR TITLE
Fix JGit enum reflection config

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  }
+]


### PR DESCRIPTION
## Summary
- expand native-image reflection config to include JGit trust enums

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d494cc50c8333b8855428d4b7e35c