### PR TITLE
Fix JGit enum initialization

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  }
+]

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -38,4 +38,10 @@ eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
 eventflow.sync.dataDir=event-data
 
 # JGit requires some classes to be initialized at runtime when building a native image
-quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,--initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,--initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,--initialize-at-run-time=org.eclipse.jgit.util.FileUtils
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,\
+    --initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,\
+    --initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,\
+    --initialize-at-run-time=org.eclipse.jgit.util.FileUtils,\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat,\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat,\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustStat


### PR DESCRIPTION
## Summary
- initialize JGit trust enums at run time to keep values method available

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d494cc50c8333b8855428d4b7e35c