### PR TITLE
Fix JGit enum initialization

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
@@ -1,0 +1,22 @@
+package com.scanales.eventflow.config;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import org.eclipse.jgit.lib.CoreConfig;
+
+/**
+ * Ensures JGit enums used during native image build are available via reflection.
+ */
+@RegisterForReflection(targets = {
+        CoreConfig.TrustLooseRefStat.class,
+        CoreConfig.TrustPackedRefsStat.class,
+        CoreConfig.TrustStat.class
+})
+public final class JGitReflectConfig {
+    static {
+        // Touch the enums so GraalVM keeps the values() methods
+        CoreConfig.TrustLooseRefStat.values();
+        CoreConfig.TrustPackedRefsStat.values();
+        CoreConfig.TrustStat.values();
+    }
+    // class only used for reflection registration
+}

--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$TrustStat",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  }
+]

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -38,4 +38,10 @@ eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
 eventflow.sync.dataDir=event-data
 
 # JGit requires some classes to be initialized at runtime when building a native image
-quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,--initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,--initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,--initialize-at-run-time=org.eclipse.jgit.util.FileUtils
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,\
+    --initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,\
+    --initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,\
+    --initialize-at-run-time=org.eclipse.jgit.util.FileUtils,\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat,\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat,\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustStat


### PR DESCRIPTION
## Summary
- register JGit trust enums for reflection
- force load `CoreConfig` enums so their `values()` method is included

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d494cc50c8333b8855428d4b7e35c