### PR TITLE
feat: add admin git reload

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/GitSyncResult.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/GitSyncResult.java
@@ -1,0 +1,12 @@
+package com.scanales.eventflow.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GitSyncResult {
+    public boolean success;
+    public String message;
+    public List<String> filesLoaded = new ArrayList<>();
+    public List<String> errors = new ArrayList<>();
+}
+

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -101,6 +101,7 @@ function escapeHtml(str) {
 async function reloadGit() {
     const btn = document.getElementById('git-reload-btn');
     const msg = document.getElementById('git-reload-msg');
+    const details = document.getElementById('git-reload-details');
     if (btn) {
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner"></span> Cargando...';
@@ -109,19 +110,33 @@ async function reloadGit() {
         msg.textContent = '';
         msg.style.color = 'gray';
     }
+    if (details) {
+        details.innerHTML = '';
+    }
     try {
-        const resp = await fetch('/private/api/git-reload', {method: 'POST'});
+        const resp = await fetch('/private/admin/events/reload-git', {method: 'POST'});
         if (resp.ok) {
             const data = await resp.json();
             if (msg) {
-                msg.textContent = data.success ? 'Carga exitosa' : 'Error: ' + data.message;
-                msg.style.color = data.success ? 'green' : 'red';
+                if (data.success) {
+                    msg.innerHTML = `✅ ${data.message}`;
+                    msg.style.color = 'green';
+                } else if (data.errors && data.errors.length > 0) {
+                    msg.innerHTML = `⚠️ ${data.message}`;
+                    msg.style.color = 'orange';
+                    if (details) {
+                        details.innerHTML = '<ul>' + data.errors.map(e => `<li>${escapeHtml(e)}</li>`).join('') + '</ul>';
+                    }
+                } else {
+                    msg.innerHTML = `❌ ${data.message}`;
+                    msg.style.color = 'red';
+                }
             } else {
                 alert(data.success ? 'Carga exitosa' : 'Error: ' + data.message);
             }
         } else {
             if (msg) {
-                msg.textContent = 'Error al recargar';
+                msg.innerHTML = '❌ Error al recargar';
                 msg.style.color = 'red';
             } else {
                 alert('Error al recargar');
@@ -129,7 +144,7 @@ async function reloadGit() {
         }
     } catch (e) {
         if (msg) {
-            msg.textContent = 'Error al recargar';
+            msg.innerHTML = '❌ Error al recargar';
             msg.style.color = 'red';
         } else {
             alert('Error al recargar');

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -10,6 +10,7 @@
     <div id="git-status-container">Cargando...</div>
     <button id="git-reload-btn">Volver a cargar desde Git</button>
     <div id="git-reload-msg" role="status" aria-live="polite"></div>
+    <div id="git-reload-details"></div>
     <button id="git-troubleshoot-btn">Diagnosticar Git</button>
     <div id="git-troubleshoot-msg" role="status" aria-live="polite"></div>
     <p class="git-help">¿Se modificó un evento en Git y no aparece actualizado? Usa 'Volver a cargar desde Git' para forzar sincronización.</p>


### PR DESCRIPTION
## Summary
- add GitSyncResult object
- support reloading events from git with result details
- expose admin endpoint and UI feedback for git reload

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d6e7bf8b08333882cffd64dabb959