### PR TITLE
Add talk status computation and event base date

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -26,7 +26,7 @@ public class Event {
     /** URL or identifier for the venue map. */
     private String mapUrl;
     /** Base date for the event used to compute talk schedules. */
-    private java.time.LocalDate eventDate;
+    private java.time.LocalDate startDate;
     private List<Talk> agenda = new ArrayList<>();
     /** Time when the event was created. */
     private LocalDateTime createdAt;
@@ -108,12 +108,12 @@ public class Event {
         this.mapUrl = mapUrl;
     }
 
-    public java.time.LocalDate getEventDate() {
-        return eventDate;
+    public java.time.LocalDate getStartDate() {
+        return startDate;
     }
 
-    public void setEventDate(java.time.LocalDate eventDate) {
-        this.eventDate = eventDate;
+    public void setStartDate(java.time.LocalDate startDate) {
+        this.startDate = startDate;
     }
 
     public List<Talk> getAgenda() {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -110,18 +110,18 @@ public class AdminEventResource {
                               @FormParam("description") String description,
                               @FormParam("mapUrl") String mapUrl,
                               @FormParam("days") int days,
-                              @FormParam("eventDate") String eventDateStr) {
+                              @FormParam("startDate") String startDateStr) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        if (eventDateStr == null || eventDateStr.isBlank()) {
+        if (startDateStr == null || startDateStr.isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST).entity("Fecha requerida").build();
         }
         var now = java.time.LocalDateTime.now();
         String id = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(now);
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
         event.setMapUrl(mapUrl);
-        event.setEventDate(java.time.LocalDate.parse(eventDateStr));
+        event.setStartDate(java.time.LocalDate.parse(startDateStr));
         eventService.saveEvent(event);
         boolean gitOk = gitWriter.persistEventToGit(event, identity.getAttribute("email"));
         String location = "/private/admin/events";
@@ -142,7 +142,7 @@ public class AdminEventResource {
                                 @FormParam("description") String description,
                                 @FormParam("mapUrl") String mapUrl,
                                 @FormParam("days") int days,
-                                @FormParam("eventDate") String eventDateStr) {
+                                @FormParam("startDate") String startDateStr) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
@@ -150,14 +150,14 @@ public class AdminEventResource {
         if (event == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         }
-        if (eventDateStr == null || eventDateStr.isBlank()) {
+        if (startDateStr == null || startDateStr.isBlank()) {
             return Response.status(Response.Status.BAD_REQUEST).entity("Fecha requerida").build();
         }
         event.setTitle(title);
         event.setDescription(description);
         event.setDays(days);
         event.setMapUrl(mapUrl);
-        event.setEventDate(java.time.LocalDate.parse(eventDateStr));
+        event.setStartDate(java.time.LocalDate.parse(startDateStr));
         eventService.saveEvent(event);
         boolean gitOk = gitWriter.persistEventToGit(event, identity.getAttribute("email"));
         String location = gitOk ? "/event/" + id

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -39,24 +39,19 @@ public class ProfileResource {
 
     /** Helper record containing a talk and its parent event. */
     public record TalkEntry(Talk talk, com.scanales.eventflow.model.Event event) {
-        public String status() {
-            if (talk == null || event == null) return "";
-            java.time.LocalDate base = event.getEventDate();
-            if (base == null) {
-                base = event.getCreatedAt() == null
-                        ? java.time.LocalDate.now()
-                        : event.getCreatedAt().toLocalDate();
-            }
-            java.time.LocalDate startDate = base;
-            java.time.LocalDateTime start = java.time.LocalDateTime.of(
-                    startDate.plusDays(talk.getDay() - 1),
-                    talk.getStartTime());
-            java.time.LocalDateTime end = start.plusMinutes(talk.getDurationMinutes());
-            java.time.LocalDateTime now = java.time.LocalDateTime.now();
-            if (now.isBefore(start.minusMinutes(30))) return "A tiempo";
-            if (now.isBefore(start)) return "Pronto a comenzar";
-            if (!now.isAfter(end)) return "En curso";
-            return "Finalizada";
+        private Talk.Status status() {
+            if (talk == null || event == null) return null;
+            return talk.getStatus(event.getStartDate(), java.time.LocalDateTime.now());
+        }
+
+        public String statusLabel() {
+            Talk.Status s = status();
+            return s == null ? "" : s.getLabel();
+        }
+
+        public String statusCss() {
+            Talk.Status s = status();
+            return s == null ? "" : s.getCssClass();
         }
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventLoaderService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventLoaderService.java
@@ -177,6 +177,10 @@ public class EventLoaderService {
                 LOG.errorf(PREFIX + "File %s missing id", file);
                 return false;
             }
+            if (event.getStartDate() == null) {
+                LOG.errorf(PREFIX + "File %s missing startDate", file);
+                return false;
+            }
             if (eventService.getEvent(event.getId()) != null) {
                 LOG.warnf(PREFIX + "Event %s already loaded, skipping", event.getId());
                 return false;

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/EventUtils.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/EventUtils.java
@@ -20,7 +20,7 @@ public final class EventUtils {
         if (event.getTitle() == null) event.setTitle("VACIO");
         if (event.getDescription() == null) event.setDescription("VACIO");
         if (event.getMapUrl() == null) event.setMapUrl("VACIO");
-        if (event.getEventDate() == null) event.setEventDate(java.time.LocalDate.now());
+        if (event.getStartDate() == null) event.setStartDate(java.time.LocalDate.now());
         if (event.getCreator() == null) event.setCreator("VACIO");
         if (event.getCreatedAt() == null) event.setCreatedAt(java.time.LocalDateTime.now());
 

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -204,6 +204,29 @@ footer {
     vertical-align: middle;
 }
 
+.status::before {
+    content: '●';
+    margin-right: 0.25rem;
+}
+
+.status-on-time::before {
+    color: #2ecc71;
+}
+
+.status-soon::before {
+    color: #f1c40f;
+}
+
+.status-in-progress::before {
+    color: #ffffff;
+    border: 1px solid #ccc;
+    border-radius: 50%;
+}
+
+.status-finished::before {
+    color: #000000;
+}
+
 @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -25,8 +25,8 @@ Nuevo Evento
     <label for="mapUrl">Mapa (URL)</label>
     <input id="mapUrl" name="mapUrl" type="text" value="{event.mapUrl}">
     <small class="input-help">Se recomienda utilizar imágenes de 800x600 px.</small>
-    <label for="eventDate">Fecha del evento</label>
-    <input id="eventDate" name="eventDate" type="date" value="{event.eventDate}">
+    <label for="startDate">Fecha del evento</label>
+    <input id="startDate" name="startDate" type="date" value="{event.startDate}">
     <label for="days">Días del evento</label>
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <button type="submit">Guardar</button>

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -24,7 +24,7 @@
         <td>{e.talk.startTimeStr}</td>
         <td>{e.talk.durationMinutes}</td>
         <td>{#if e.event && e.event.getScenarioMapUrl(e.talk.location)}<a href="{e.event.getScenarioMapUrl(e.talk.location)}" target="_blank">🧭 Cómo llegar</a>{/if}</td>
-        <td>{e.status()}</td>
+        <td><span class="status {e.statusCss()}">{e.statusLabel()}</span></td>
         <td><a href="/private/profile/remove/{e.talk.id}">Eliminar de mis charlas</a></td>
     </tr>
 {/for}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/model/TalkStatusTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/model/TalkStatusTest.java
@@ -1,0 +1,30 @@
+package com.scanales.eventflow.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.Test;
+
+public class TalkStatusTest {
+
+    @Test
+    public void testStatuses() {
+        Talk talk = new Talk("t1", "Test");
+        talk.setDay(1);
+        talk.setStartTime(LocalTime.of(10, 0));
+        talk.setDurationMinutes(60);
+        LocalDate eventStart = LocalDate.of(2024, 1, 1);
+
+        assertEquals(Talk.Status.ON_TIME,
+                talk.getStatus(eventStart, LocalDateTime.of(2024, 1, 1, 9, 0)));
+        assertEquals(Talk.Status.SOON,
+                talk.getStatus(eventStart, LocalDateTime.of(2024, 1, 1, 9, 45)));
+        assertEquals(Talk.Status.IN_PROGRESS,
+                talk.getStatus(eventStart, LocalDateTime.of(2024, 1, 1, 10, 15)));
+        assertEquals(Talk.Status.FINISHED,
+                talk.getStatus(eventStart, LocalDateTime.of(2024, 1, 1, 11, 5)));
+    }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/UserScheduleTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/UserScheduleTest.java
@@ -27,6 +27,7 @@ public class UserScheduleTest {
     @BeforeEach
     public void setup() {
         Event e = new Event("evt", "Test Event", "desc", 1);
+        e.setStartDate(java.time.LocalDate.now());
         Scenario sc = new Scenario("s1", "Main");
         e.getScenarios().add(sc);
         Talk t = new Talk("t1", "Talk 1");


### PR DESCRIPTION
## Summary
- add `startDate` to events and require it when loading from JSON
- compute talk status with new `getStatus` method and show colored status on profile page
- style status badges and update admin form

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d791cd29c833397d5cd4bdfc4e1f4