### PR TITLE
feat: show venue maps with how-to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ redirects back to the event list displaying a confirmation banner.
 
 ## Map navigation and talk status
 
-- Events and scenarios can include a `mapUrl` field pointing to an image of their location. For best results, use 800x600 px images.
-- Scenario pages display this map when available and talk details provide a "🧭 ¿Cómo llegar?" link to highlight the room.
+- Events can define a `mapImageUrl` pointing to the general venue map while each scenario may specify a `highlightedMapImageUrl` to highlight its position. If not set, the application builds a default path under `/img/events/{eventId}`. For best results, use 800x600 px images.
+- Scenario pages display this map when available and show "Imagen de ubicación no disponible." otherwise. Talk details and the profile page provide a "🧭 ¿Cómo llegar?" link directing to the scenario page.
 - The profile page lists all registered talks in a table showing a dynamic status column indicating whether each talk is on time, about to start, in progress or finished.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Scenario.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Scenario.java
@@ -15,7 +15,7 @@ public class Scenario {
     private String features;
     private String location;
     /** Specific map image for this scenario highlighting its position. */
-    private String mapUrl;
+    private String highlightedMapImageUrl;
 
     public Scenario() {
     }
@@ -57,11 +57,17 @@ public class Scenario {
         this.location = location;
     }
 
-    public String getMapUrl() {
-        return mapUrl;
+    public String getHighlightedMapImageUrl() {
+        return highlightedMapImageUrl;
     }
 
+    public void setHighlightedMapImageUrl(String highlightedMapImageUrl) {
+        this.highlightedMapImageUrl = highlightedMapImageUrl;
+    }
+
+    /** Backward compatibility with legacy field name. */
+    @jakarta.json.bind.annotation.JsonbProperty("mapUrl")
     public void setMapUrl(String mapUrl) {
-        this.mapUrl = mapUrl;
+        this.highlightedMapImageUrl = mapUrl;
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -108,7 +108,7 @@ public class AdminEventResource {
     @Authenticated
     public Response saveEvent(@FormParam("title") String title,
                               @FormParam("description") String description,
-                              @FormParam("mapUrl") String mapUrl,
+                              @FormParam("mapImageUrl") String mapImageUrl,
                               @FormParam("days") int days,
                               @FormParam("startDate") String startDateStr) {
         if (!isAdmin()) {
@@ -120,7 +120,7 @@ public class AdminEventResource {
         var now = java.time.LocalDateTime.now();
         String id = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(now);
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
-        event.setMapUrl(mapUrl);
+        event.setMapImageUrl(mapImageUrl);
         event.setStartDate(java.time.LocalDate.parse(startDateStr));
         eventService.saveEvent(event);
         boolean gitOk = gitWriter.persistEventToGit(event, identity.getAttribute("email"));
@@ -140,7 +140,7 @@ public class AdminEventResource {
     public Response updateEvent(@PathParam("id") String id,
                                 @FormParam("title") String title,
                                 @FormParam("description") String description,
-                                @FormParam("mapUrl") String mapUrl,
+                                @FormParam("mapImageUrl") String mapImageUrl,
                                 @FormParam("days") int days,
                                 @FormParam("startDate") String startDateStr) {
         if (!isAdmin()) {
@@ -156,7 +156,7 @@ public class AdminEventResource {
         event.setTitle(title);
         event.setDescription(description);
         event.setDays(days);
-        event.setMapUrl(mapUrl);
+        event.setMapImageUrl(mapImageUrl);
         event.setStartDate(java.time.LocalDate.parse(startDateStr));
         eventService.saveEvent(event);
         boolean gitOk = gitWriter.persistEventToGit(event, identity.getAttribute("email"));
@@ -246,7 +246,7 @@ public class AdminEventResource {
                                  @FormParam("name") String name,
                                  @FormParam("features") String features,
                                  @FormParam("location") String location,
-                                 @FormParam("mapUrl") String mapUrl) {
+                                 @FormParam("highlightedMapImageUrl") String highlightedMapImageUrl) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
@@ -258,7 +258,7 @@ public class AdminEventResource {
         Scenario scenario = new Scenario(scenarioId, name);
         scenario.setFeatures(features);
         scenario.setLocation(location);
-        scenario.setMapUrl(mapUrl);
+        scenario.setHighlightedMapImageUrl(highlightedMapImageUrl);
         eventService.saveScenario(eventId, scenario);
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/private/admin/events/" + eventId + "/edit")

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -22,8 +22,8 @@ Nuevo Evento
     <input id="title" name="title" type="text" value="{event.title}">
     <label for="description">Descripcion</label>
     <textarea id="description" name="description">{event.description}</textarea>
-    <label for="mapUrl">Mapa (URL)</label>
-    <input id="mapUrl" name="mapUrl" type="text" value="{event.mapUrl}">
+    <label for="mapImageUrl">Mapa (URL)</label>
+    <input id="mapImageUrl" name="mapImageUrl" type="text" value="{event.mapImageUrl}">
     <small class="input-help">Se recomienda utilizar imágenes de 800x600 px.</small>
     <label for="startDate">Fecha del evento</label>
     <input id="startDate" name="startDate" type="date" value="{event.startDate}">
@@ -41,7 +41,7 @@ Nuevo Evento
 <form method="post" action="/private/admin/events/{event.id}/scenario">
 <td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
 <td><input name="name" value="{sc.name}"></td>
-<td><input name="mapUrl" value="{sc.mapUrl}" placeholder="URL mapa (800x600)"></td>
+<td><input name="highlightedMapImageUrl" value="{sc.highlightedMapImageUrl}" placeholder="URL mapa (800x600)"></td>
 <td>
 <input name="features" value="{sc.features}" placeholder="Caracteristicas">
 <input name="location" value="{sc.location}" placeholder="Ubicacion">
@@ -57,7 +57,7 @@ Nuevo Evento
 <form method="post" action="/private/admin/events/{event.id}/scenario">
 <td>Nuevo</td>
 <td><input name="name"></td>
-<td><input name="mapUrl" placeholder="URL mapa (800x600)"></td>
+<td><input name="highlightedMapImageUrl" placeholder="URL mapa (800x600)"></td>
 <td>
 <input name="features" placeholder="Caracteristicas">
 <input name="location" placeholder="Ubicacion">

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -23,7 +23,7 @@
         <td>{e.talk.day}</td>
         <td>{e.talk.startTimeStr}</td>
         <td>{e.talk.durationMinutes}</td>
-        <td>{#if e.event && e.event.getScenarioMapUrl(e.talk.location)}<a href="{e.event.getScenarioMapUrl(e.talk.location)}" target="_blank">🧭 Cómo llegar</a>{/if}</td>
+        <td>{#if e.event}<a href="/scenario/{e.talk.location}#map">🧭 Cómo llegar</a>{/if}</td>
         <td><span class="status {e.statusCss()}">{e.statusLabel()}</span></td>
         <td><a href="/private/profile/remove/{e.talk.id}">Eliminar de mis charlas</a></td>
     </tr>

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -11,9 +11,13 @@ Escenario
 <h1>{scenario.name}</h1>
 {#if scenario.location}<p>Ubicacion: {scenario.location}</p>{/if}
 {#if scenario.features}<p>{scenario.features}</p>{/if}
-{#if scenario.mapUrl}
-<p><img src="{scenario.mapUrl}" alt="Mapa" class="map-image"></p>
+<div id="map">
+{#if event.getScenarioMapUrl(scenario.id)}
+    <p><img src="{event.getScenarioMapUrl(scenario.id)}" alt="Mapa" class="map-image"></p>
+{#else}
+    <p>Imagen de ubicación no disponible.</p>
 {/if}
+</div>
 {#if !talks.isEmpty()}
 <h2>Charlas</h2>
 <ul>

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -19,9 +19,7 @@ Charla
 {#for t in occurrences}
     <li>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) -
         <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
-        {#if event.getScenarioMapUrl(t.location)}
-            - <a href="{event.getScenarioMapUrl(t.location)}" target="_blank">🧭 ¿Cómo llegar?</a>
-        {/if}
+        - <a href="/scenario/{t.location}#map">🧭 ¿Cómo llegar?</a>
     </li>
 {/for}
 </ul>


### PR DESCRIPTION
## Summary
- support `mapImageUrl` for events and `highlightedMapImageUrl` for scenarios
- display venue maps with fallback message and provide "Cómo llegar" links
- extend admin forms to manage event and scenario map images

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d80e3872c833399faa3c4da28ab3f