### PR TITLE
feat: track git sync status and persist admin updates to git

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -17,7 +17,6 @@ import com.scanales.eventflow.util.EventUtils;
 import org.jboss.logging.Logger;
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
-import jakarta.json.bind.JsonbConfig;
 import org.jboss.resteasy.reactive.multipart.FileUpload;
 
 import jakarta.inject.Inject;
@@ -213,7 +212,7 @@ public class AdminEventResource {
                     .type(MediaType.TEXT_PLAIN + ";charset=UTF-8")
                     .build();
         }
-        if (!hasRequiredData(event)) {
+        if (!EventUtils.hasRequiredData(event)) {
             LOG.warnf(PREFIX + "AdminEventResource.exportEvent(): Event %s has no data to export", id);
             return Response.status(Response.Status.BAD_REQUEST)
                     .entity("\u274c Error: El evento no contiene datos para exportar.")
@@ -404,27 +403,6 @@ public class AdminEventResource {
                     .entity(Templates.list(events, "Importaci\u00f3n fallida: error interno"))
                     .build();
         }
-    }
-
-    private boolean hasRequiredData(Event event) {
-        if (event == null) {
-            return false;
-        }
-
-        JsonbConfig cfg = new JsonbConfig().withFormatting(true);
-        try (Jsonb jsonb = JsonbBuilder.create(cfg)) {
-            String eventJson = jsonb.toJson(event);
-            LOG.debug(PREFIX + "AdminEventResource.hasRequiredData(): contenido del evento\n" + eventJson);
-        } catch (jakarta.json.bind.JsonbException e) {
-            LOG.warn(PREFIX + "AdminEventResource.hasRequiredData(): No se pudo serializar evento", e);
-        } catch (Exception e) {
-            LOG.warn(PREFIX + "AdminEventResource.hasRequiredData(): Error cerrando recurso", e);
-        }
-
-        boolean hasLists = (event.getScenarios() != null && !event.getScenarios().isEmpty())
-                || (event.getAgenda() != null && !event.getAgenda().isEmpty());
-
-        return event.getId() != null && !event.getId().isBlank() && hasLists;
     }
 
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/GitStatusResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/GitStatusResource.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.private_;
 
 import com.scanales.eventflow.service.EventLoaderService;
+import com.scanales.eventflow.service.GitEventSyncService;
 import com.scanales.eventflow.service.GitLoadStatus;
 import com.scanales.eventflow.service.GitTroubleshootResult;
 import com.scanales.eventflow.util.AdminUtils;
@@ -23,6 +24,9 @@ public class GitStatusResource {
     @Inject
     EventLoaderService loader;
 
+    @Inject
+    GitEventSyncService gitSync;
+
     private boolean isAdmin() {
         return AdminUtils.isAdmin(identity);
     }
@@ -35,7 +39,7 @@ public class GitStatusResource {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        return Response.ok(loader.getStatus()).build();
+        return Response.ok(gitSync.getStatus()).build();
     }
 
     @POST
@@ -46,7 +50,8 @@ public class GitStatusResource {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        GitLoadStatus status = loader.reload();
+        gitSync.reloadEventsFromGit();
+        GitLoadStatus status = gitSync.getStatus();
         return Response.ok(status).build();
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/EventUtils.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/EventUtils.java
@@ -42,4 +42,23 @@ public final class EventUtils {
             }
         }
     }
+
+    /**
+     * Checks that the event contains the minimum required data before being
+     * exported or persisted to Git. An event must have a non-blank identifier
+     * and at least one scenario or talk defined.
+     *
+     * @param event event to validate
+     * @return {@code true} if the event has enough data, {@code false} otherwise
+     */
+    public static boolean hasRequiredData(Event event) {
+        if (event == null) {
+            return false;
+        }
+
+        boolean hasLists = (event.getScenarios() != null && !event.getScenarios().isEmpty())
+                || (event.getAgenda() != null && !event.getAgenda().isEmpty());
+
+        return event.getId() != null && !event.getId().isBlank() && hasLists;
+    }
 }


### PR DESCRIPTION
## Summary
- track git repository synchronization with an in-memory status object
- expose synchronization status and reload through admin API
- commit admin event changes to git with validation and push

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d86c15784833399109afaa8c4e9fc