### PR TITLE
Load events from repository root

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -35,7 +35,7 @@ eventflow.sync.repoUrl=https://github.com/scanalesespinoza/eventflow-event-as-co
 eventflow.sync.branch=main
 eventflow.sync.token=
 eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
-eventflow.sync.dataDir=event-data
+eventflow.sync.dataDir=.
 
 # JGit requires some classes to be initialized at runtime when building a native image
 quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,\


### PR DESCRIPTION
## Summary
- Adjust git sync data directory to repository root to ensure events are discovered

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688da161edd88333ab0c6b3eadc5190b