### PR TITLE
fix: clean git directory before clone

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventGitWriterService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventGitWriterService.java
@@ -37,11 +37,18 @@ public class EventGitWriterService {
     @PostConstruct
     void init() {
         var cfg = ConfigProvider.getConfig();
-        String dir = cfg.getOptionalValue("eventflow.sync.localDir", String.class)
-                .orElse(System.getProperty("java.io.tmpdir") + "/eventflow-repo");
+        String repoUrl = cfg.getOptionalValue("eventflow.sync.repoUrl", String.class).orElse(null);
         dataDir = cfg.getOptionalValue("eventflow.sync.dataDir", String.class)
                 .orElse("event-data");
-        localDir = Path.of(dir);
+
+        String repoName = (repoUrl != null && !repoUrl.isBlank())
+                ? repoUrl.substring(repoUrl.lastIndexOf('/') + 1)
+                : "event-repo";
+        if (repoName.endsWith(".git")) {
+            repoName = repoName.substring(0, repoName.length() - 4);
+        }
+        localDir = Path.of(System.getProperty("java.io.tmpdir"), repoName);
+
         gitLog.log("Git writer init path=" + localDir + " dataDir=" + dataDir);
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventLoaderService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventLoaderService.java
@@ -58,10 +58,16 @@ public class EventLoaderService {
         repoUrl = cfg.getOptionalValue("eventflow.sync.repoUrl", String.class).orElse(null);
         branch = cfg.getOptionalValue("eventflow.sync.branch", String.class).orElse("main");
         token = cfg.getOptionalValue("eventflow.sync.token", String.class).orElse(null);
-        String dir = cfg.getOptionalValue("eventflow.sync.localDir", String.class)
-                .orElse(System.getProperty("java.io.tmpdir") + "/eventflow-repo");
         dataDir = cfg.getOptionalValue("eventflow.sync.dataDir", String.class).orElse("event-data");
-        localDir = Path.of(dir);
+
+        String repoName = (repoUrl != null && !repoUrl.isBlank())
+                ? repoUrl.substring(repoUrl.lastIndexOf('/') + 1)
+                : "event-repo";
+        if (repoName.endsWith(".git")) {
+            repoName = repoName.substring(0, repoName.length() - 4);
+        }
+        localDir = Path.of(System.getProperty("java.io.tmpdir"), repoName);
+
         status.setRepoUrl(repoUrl);
         status.setBranch(branch);
 
@@ -131,6 +137,9 @@ public class EventLoaderService {
                 LOG.warnf(PREFIX + "Local repository at %s missing or corrupted, recloning", localDir);
                 deleteDirectory(localDir);
             }
+        } else {
+            // Ensure the target directory is clean before cloning
+            deleteDirectory(localDir);
         }
 
         Files.createDirectories(localDir);

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -34,7 +34,6 @@ ADMIN_LIST=sergio.canales.e@gmail.com
 eventflow.sync.repoUrl=https://github.com/scanalesespinoza/eventflow-event-as-code.git
 eventflow.sync.branch=main
 eventflow.sync.token=
-eventflow.sync.localDir=${java.io.tmpdir}/eventflow-repo
 eventflow.sync.dataDir=.
 
 # JGit requires some classes to be initialized at runtime when building a native image


### PR DESCRIPTION
## Summary
- remove stale local repo data before cloning to avoid corrupt git state
- derive the local repo directory name from the Git URL to match the cloned folder

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688da66ba580833396eebef9b707f1d4