### PR TITLE
Register JGit HideDotFiles enum for reflection

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
@@ -9,7 +9,8 @@ import org.eclipse.jgit.lib.CoreConfig;
 @RegisterForReflection(targets = {
         CoreConfig.TrustLooseRefStat.class,
         CoreConfig.TrustPackedRefsStat.class,
-        CoreConfig.TrustStat.class
+        CoreConfig.TrustStat.class,
+        CoreConfig.HideDotFiles.class
 })
 public final class JGitReflectConfig {
     static {
@@ -17,6 +18,7 @@ public final class JGitReflectConfig {
         CoreConfig.TrustLooseRefStat.values();
         CoreConfig.TrustPackedRefsStat.values();
         CoreConfig.TrustStat.values();
+        CoreConfig.HideDotFiles.values();
     }
     // class only used for reflection registration
 }

--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -22,5 +22,13 @@
     "allPublicFields": true,
     "allDeclaredFields": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.lib.CoreConfig$HideDotFiles",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
   }
 ]


### PR DESCRIPTION
## Summary
- register `CoreConfig.HideDotFiles` for GraalVM reflection
- update native-image reflect configuration for `HideDotFiles`

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688dab8673d083338ea582167eb61b40