### PR TITLE
Register HttpRedirectMode for native reflection

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.config;
 
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import org.eclipse.jgit.lib.CoreConfig;
+import org.eclipse.jgit.transport.HttpConfig;
 
 /**
  * Ensures JGit enums used during native image build are available via reflection.
@@ -10,7 +11,8 @@ import org.eclipse.jgit.lib.CoreConfig;
         CoreConfig.TrustLooseRefStat.class,
         CoreConfig.TrustPackedRefsStat.class,
         CoreConfig.TrustStat.class,
-        CoreConfig.HideDotFiles.class
+        CoreConfig.HideDotFiles.class,
+        HttpConfig.HttpRedirectMode.class
 })
 public final class JGitReflectConfig {
     static {
@@ -19,6 +21,7 @@ public final class JGitReflectConfig {
         CoreConfig.TrustPackedRefsStat.values();
         CoreConfig.TrustStat.values();
         CoreConfig.HideDotFiles.values();
+        HttpConfig.HttpRedirectMode.values();
     }
     // class only used for reflection registration
 }

--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -30,5 +30,13 @@
     "allPublicFields": true,
     "allDeclaredFields": true,
     "allPublicMethods": true
+  },
+  {
+    "name": "org.eclipse.jgit.transport.HttpConfig$HttpRedirectMode",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
   }
 ]


### PR DESCRIPTION
## Summary
- include HttpConfig.HttpRedirectMode in reflection config to avoid missing enum values during native runs

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688db20a7ef88333a9d0780d84e66c55