### PR TITLE
Register JGit LogRefUpdates enum for native image

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/quarkus-app/src/main/resources/META-INF/native-image/reflect-config.json
@@ -32,6 +32,14 @@
     "allPublicMethods": true
   },
   {
+    "name": "org.eclipse.jgit.lib.CoreConfig$LogRefUpdates",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allPublicFields": true,
+    "allDeclaredFields": true,
+    "allPublicMethods": true
+  },
+  {
     "name": "org.eclipse.jgit.transport.HttpConfig$HttpRedirectMode",
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,


### PR DESCRIPTION
## Summary
- include `org.eclipse.jgit.lib.CoreConfig$LogRefUpdates` in reflection config to allow enum access in native builds

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e236f5dbc8333902d53ed0c9c0d03