### PR TITLE
Ensure JGit LogRefUpdates enum is available for reflection

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -25,9 +25,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Generate reflection config with GraalVM agent
+        working-directory: quarkus-app
+        run: |
+          mvn -DskipTests package
+          java -agentlib:native-image-agent=config-output-dir=target/native-image-config -jar target/quarkus-app/quarkus-run.jar &
+          AGENT_PID=$!
+          sleep 5
+          curl -f http://localhost:8080/q/health || true
+          kill $AGENT_PID
+
       - name: Build native binary
         working-directory: quarkus-app
-        run: mvn clean package -Pnative -Dquarkus.native.container-build=true
+        run: mvn package -Pnative -DskipTests -Dquarkus.native.container-build=true "-Dquarkus.native.additional-build-args=-H:ConfigurationFileDirectories=target/native-image-config"
 
       - name: Verify native binary exists
         run: ls quarkus-app/target/*-runner

--- a/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/config/JGitReflectConfig.java
@@ -12,6 +12,7 @@ import org.eclipse.jgit.transport.HttpConfig;
         CoreConfig.TrustPackedRefsStat.class,
         CoreConfig.TrustStat.class,
         CoreConfig.HideDotFiles.class,
+        CoreConfig.LogRefUpdates.class,
         HttpConfig.HttpRedirectMode.class
 })
 public final class JGitReflectConfig {
@@ -21,6 +22,7 @@ public final class JGitReflectConfig {
         CoreConfig.TrustPackedRefsStat.values();
         CoreConfig.TrustStat.values();
         CoreConfig.HideDotFiles.values();
+        CoreConfig.LogRefUpdates.values();
         HttpConfig.HttpRedirectMode.values();
     }
     // class only used for reflection registration


### PR DESCRIPTION
## Summary
- register JGit's CoreConfig.LogRefUpdates enum for reflection
- touch enum so GraalVM retains its values()
- run the application with the native-image agent in the build-native workflow using the correct quarkus-run.jar to generate reflection configuration for the native build

## Testing
- `mvn -DskipTests package` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e258e51848333baef09dbad5a506f