### PR TITLE
Allow application to start without OAuth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Smart event management platform: spaces, activities, speakers, attendees, and personalized planning.
 
-This demo uses Google Sign-In (OAuth 2.0) through the Quarkus OIDC extension. Configure the application by providing the following properties:
+This demo uses Google Sign-In (OAuth 2.0) through the Quarkus OIDC extension. OAuth support is disabled by default so the application can run without credentials. Configure the application by providing the following properties:
 
 ```
 quarkus.oidc.provider=google
+quarkus.oidc.enabled=true
 quarkus.oidc.client-id=<CLIENT_ID>
 quarkus.oidc.credentials.secret=<CLIENT_SECRET>
 quarkus.oidc.application-type=web-app
@@ -24,7 +25,7 @@ After authenticating you will be redirected to `/private/profile` where the appl
 
 Ensure `https://eventflow.opensourcesantiago.io/private` is registered as an authorized redirect URI in the Google OAuth2 client configuration if running in production.
 
-You can also configure these values using environment variables. The included `application.properties` expects `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` along with the rest of the OIDC URLs, as shown in `deployment/google-oauth-secret.yaml`.
+You can also configure these values using environment variables. The included `application.properties` expects `OIDC_ENABLED=true`, `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` along with the rest of the OIDC URLs, as shown in `deployment/google-oauth-secret.yaml`.
 
 When deploying through GitHub Actions, the workflow populates these values from repository secrets and creates the `google-oauth` secret in the cluster. The manifest in `deployment/google-oauth-secret.yaml` is only a template and is not applied directly during deployment.
 

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -76,7 +76,7 @@ After getting a cup of coffee, you'll be able to run this executable directly:
 
 ## Google Login Demo
 
-1. Set the environment variables `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` and the rest of the OAuth values listed in the project root README.
+1. Set the environment variables `OIDC_ENABLED=true`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` and the rest of the OAuth values listed in the project root README. Without these variables the application starts with OAuth disabled which is useful for local development and automated builds.
 2. Start the application in dev mode:
 
 ```bash

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -1,8 +1,12 @@
 # Google OAuth configuration using OIDC automatic discovery
 quarkus.oidc.provider=google
 quarkus.oidc.application-type=web-app
-quarkus.oidc.client-id=${OIDC_CLIENT_ID}
-quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET}
+# Allow the application to start even if the OAuth credentials are not
+# provided.  The defaults can be overridden through environment variables
+# when running in a real OAuth enabled environment.
+quarkus.oidc.enabled=${OIDC_ENABLED:false}
+quarkus.oidc.client-id=${OIDC_CLIENT_ID:dummy-client}
+quarkus.oidc.credentials.secret=${OIDC_CLIENT_SECRET:dummy-secret}
 quarkus.oidc.authentication.scopes=openid profile email
 quarkus.oidc.logout.post-logout-path=/
 # Disable Quarkus built-in logout as Google does not provide an


### PR DESCRIPTION
## Summary
- disable OIDC extension unless `OIDC_ENABLED=true`
- document enabling OAuth login

## Testing
- `mvn -DskipTests package` *(fails: Non-resolvable import POM: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e371608588333817ad7b13dda6d5f