### PR TITLE
Mirror JGit runtime init settings in test configuration

### DIFF
--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -1,1 +1,10 @@
 quarkus.oidc.tenant-enabled=false
+
+# JGit requires some classes to be initialized at runtime when building a native image
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,\\
+    --initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,\\
+    --initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,\\
+    --initialize-at-run-time=org.eclipse.jgit.util.FileUtils,\\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat,\\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustPackedRefsStat,\\
+    --initialize-at-run-time=org.eclipse.jgit.lib.CoreConfig$TrustStat


### PR DESCRIPTION
## Summary
- ensure native tests initialize JGit classes at run time to avoid GraalVM thread and PRNG issues

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e3bb8203c8333a68ff227be1b6c73