### PR TITLE
chore: ensure native build initializes jgit at runtime

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -40,8 +40,5 @@ eventflow.sync.branch=main
 eventflow.sync.token=
 eventflow.sync.dataDir=.
 
-# JGit requires some classes to be initialized at runtime when building a native image
-quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,\
-    --initialize-at-run-time=org.eclipse.jgit.transport.HttpAuthMethod$Digest,\
-    --initialize-at-run-time=org.eclipse.jgit.internal.storage.file.WindowCache,\
-    --initialize-at-run-time=org.eclipse.jgit.util.FileUtils
+# JGit requires runtime initialization to avoid starting threads or Random instances during native builds
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit


### PR DESCRIPTION
## Summary
- initialize all JGit classes at runtime to avoid threads or Random instances during native-image build

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `mvn -q package -Pnative -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688e4a3124e083338fa5cd7f0fe028da