### PR TITLE
Handle JGit native-image init and document troubleshooting

### DIFF
--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -86,3 +86,17 @@ mvn quarkus:dev
 3. Visit [https://eventflow.opensourcesantiago.io/private](https://eventflow.opensourcesantiago.io/private). You will be redirected to authenticate with Google.
 4. After login the private page shows your name, email and profile picture.
 
+# Native build troubleshooting
+
+If the native build fails with messages about `JGit-WorkQueue` threads or cached `Random` values, the JGit classes may have been
+initialized during the image build. The application enables run time initialization for the problematic classes via the
+`quarkus.native.additional-build-args` property, but new failures can be diagnosed by tracing object instantiations:
+
+```bash
+mvn package -Dnative \
+  -Dquarkus.native.additional-build-args="--trace-object-instantiation=java.lang.Thread,java.util.Random,java.security.SecureRandom"
+```
+
+The output lists the classes responsible for creating threads or random number generators during the build so they can be added
+to the run time initialization list.
+

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -41,8 +41,4 @@ eventflow.sync.token=
 eventflow.sync.dataDir=.
 
 # JGit requires runtime initialization to avoid starting threads or Random instances during native builds
-quarkus.native.additional-build-args=\
---initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,\
-org.eclipse.jgit.transport.HttpAuthMethod$Digest,\
-org.eclipse.jgit.internal.storage.file.WindowCache,\
-org.eclipse.jgit.util.FileUtils
+quarkus.native.additional-build-args=--initialize-at-run-time=org.eclipse.jgit.lib.internal.WorkQueue,org.eclipse.jgit.transport.HttpAuthMethod$Digest,org.eclipse.jgit.internal.storage.file.WindowCache,org.eclipse.jgit.util.FileUtils


### PR DESCRIPTION
## Summary
- pass all JGit classes to `--initialize-at-run-time` as one build arg to prevent threads and RNGs from leaking into the image heap
- document how to trace object instantiations when GraalVM native image fails

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c6c22f88333a0c2887a07e6c778