### PR TITLE
feat: release v2.0.0 Gitless

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Smart event management platform: spaces, activities, speakers, attendees, and personalized planning.
 
+## v2.0.0 – Gitless & Stable
+
+Esta versión elimina completamente la sincronización con repositorios Git introducida en versiones experimentales posteriores a v1.0.0.
+
+### Cambios clave
+- Eliminada toda dependencia de JGit
+- Removida funcionalidad de sincronización automática
+- Panel de administración simplificado
+- Mejora en estabilidad y compatibilidad con compilación nativa
+
+> **Nota:** Las versiones `v1.1.x` fueron experimentales y no deben usarse en producción.
+
 This demo uses Google Sign-In (OAuth 2.0) through the Quarkus OIDC extension. Configure the application by providing the following properties:
 
 ```

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: eventflow
-          image: quay.io/sergio_canales_e/eventflow:latest
+            image: quay.io/sergio_canales_e/eventflow:v2.0.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -71,7 +71,7 @@ native executable:
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 
-> ./target/getting-started-1.0.0-SNAPSHOT-runner
+> ./target/eventflow-2.0.0-runner
 
 
 ## Google Login Demo

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -3,8 +3,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.scanales</groupId>
-    <artifactId>getting-started</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <artifactId>eventflow</artifactId>
+    <version>2.0.0</version>
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/quarkus-app/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t quarkus/getting-started-jvm .
+# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:v2.0.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
+# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started-jvm
+# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.legacy-jar
+++ b/quarkus-app/src/main/docker/Dockerfile.legacy-jar
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t quarkus/getting-started-legacy-jar .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:v2.0.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started-legacy-jar
+# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started-legacy-jar
+# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t quarkus/getting-started .
+# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:v2.0.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started
+# docker run -i --rm -p 8080:8080 eventflow-native:v2.0.0
 #
 # The `registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image provides
 # GLIBC 2.34+ and is compatible with binaries built on newer systems. If you

--- a/quarkus-app/src/main/docker/Dockerfile.native-micro
+++ b/quarkus-app/src/main/docker/Dockerfile.native-micro
@@ -10,11 +10,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t quarkus/getting-started .
+# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:v2.0.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 quarkus/getting-started
+# docker run -i --rm -p 8080:8080 eventflow-native:v2.0.0
 #
 # The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -12,6 +12,8 @@ quarkus.oidc.authentication.user-info-required=false
 # Rely on the ID token for user attributes
 quarkus.oidc.authentication.id-token-required=true
 quarkus.oidc.token.principal-claim=id_token
+# Application version
+quarkus.application.version=2.0.0
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings
 quarkus.log.category."io.quarkus.oidc".level=INFO


### PR DESCRIPTION
## Summary
- document v2.0.0 Gitless & Stable release
- bump project version to 2.0.0
- align deployment and Docker instructions with new image tag
- replace legacy image and artifact names with `eventflow`

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fa34fe86c8333a123505586051075