### PR TITLE
chore: use release version in native build workflow

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-native:
     runs-on: ubuntu-latest
+    env:
+      IMAGE_VERSION: v2.0.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,7 +37,7 @@ jobs:
       - name: Build Docker image
         working-directory: quarkus-app
         run: |
-          docker build -f src/main/docker/Dockerfile.native -t quay.io/sergio_canales_e/eventflow:latest .
+          docker build -f src/main/docker/Dockerfile.native -t quay.io/sergio_canales_e/eventflow:${{ env.IMAGE_VERSION }} .
 
       - name: Push Docker image
         env:
@@ -43,4 +45,4 @@ jobs:
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
         run: |
           echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
-          docker push quay.io/sergio_canales_e/eventflow:latest
+          docker push quay.io/sergio_canales_e/eventflow:${{ env.IMAGE_VERSION }}


### PR DESCRIPTION
## Summary
- build and push Docker image using the project's v2.0.0 release tag

## Testing
- `mvn -f quarkus-app/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fa92e7af88333a5be20999ecc8103