### PR TITLE
feat: show logos in header

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/index.html
+++ b/quarkus-app/src/main/resources/META-INF/resources/index.html
@@ -16,12 +16,6 @@
             <img src="/img/oss-logo.png" alt="Open Source Santiago" class="logo-oss" />
         </div>
     </div>
-    <div class="header-banner">
-        <span class="banner-title">EventFlow</span>
-    </div>
-    <div class="header-news">
-        Bienvenido a EventFlow
-    </div>
 </header>
 <nav class="nav-menu" id="nav-menu">
     <button id="menuToggle" class="menu-toggle" aria-label="Menú">&#9776;</button>

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -28,7 +28,6 @@ body {
     align-items: center;
 }
 
-
 .logo-main {
     width: 10vw;
     max-width: 10vw;
@@ -44,30 +43,9 @@ body {
     margin-top: 0.5rem;
 }
 
-
 .logo-oss {
     width: 10vw;
     height: auto;
-}
-
-.header-banner {
-    background: linear-gradient(135deg, var(--color-accent), var(--color-primary));
-    background-size: 200% 200%;
-    animation: flow 10s ease-in-out infinite;
-    padding: 1.5rem 1rem;
-    text-align: center;
-}
-
-.banner-title {
-    font-size: 2rem;
-    color: var(--color-light);
-}
-
-.header-news {
-    background-color: var(--color-primary);
-    color: var(--color-light);
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
 }
 
 .nav-menu {

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -16,14 +16,6 @@
             <img src="/img/oss-logo.png" alt="Open Source Santiago" class="logo-oss" />
         </div>
     </div>
-    <div class="header-banner">
-        {#insert banner}
-        <span class="banner-title">EventFlow</span>
-        {/insert}
-    </div>
-    <div class="header-news">
-        {#insert news}Bienvenido a EventFlow{/insert}
-    </div>
 </header>
 <nav class="nav-menu" id="nav-menu">
     <button id="menuToggle" class="menu-toggle" aria-label="Menú">&#9776;</button>


### PR DESCRIPTION
## Summary
- replace header content with EventFlow and Open Source Santiago logos
- restore styles for logo group and remove unused title styles

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ff454852083338b43f87b7336415f