### PR TITLE
feat: redesign home page with event cards

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -130,6 +130,18 @@ public class Event {
     }
 
     /**
+     * Returns the creation date formatted for display in the UI.
+     * If the date is not available, an empty string is returned.
+     */
+    public String getFormattedCreatedAt() {
+        if (createdAt == null) {
+            return "";
+        }
+        var formatter = java.time.format.DateTimeFormatter.ofPattern("MMMM d, yyyy", new java.util.Locale("es"));
+        return createdAt.format(formatter);
+    }
+
+    /**
      * Returns a list with values from 1 to {@code days} to easily iterate in templates.
      */
     public java.util.List<Integer> getDayList() {

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -105,19 +105,82 @@ body {
     color: #555;
 }
 
-.event-list {
-    list-style: none;
+.no-events {
+    margin-top: 2rem;
+}
+
+/* Grid of event cards on the home page */
+.event-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1.5rem;
     padding: 0;
-    margin: 1rem 0 0;
+    margin-top: 2rem;
 }
 
-.event-item {
-    margin: 0.5rem 0;
+.event-card {
+    background-color: var(--color-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.2s ease;
 }
 
-.event-item a {
-    color: var(--color-primary);
+.event-card:hover {
+    transform: translateY(-4px);
+}
+
+.event-image {
+    width: 100%;
+    height: 150px;
+    background-color: var(--color-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.event-image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.event-content {
+    padding: 1rem;
+    text-align: left;
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.event-name {
+    font-size: 1.25rem;
+    margin: 0 0 0.5rem;
+    color: var(--color-dark);
+}
+
+.event-date {
+    font-size: 0.9rem;
+    color: #555;
+    margin: 0 0 1rem;
+}
+
+.event-button {
+    margin-top: auto;
+    display: inline-block;
+    background-color: var(--color-primary);
+    color: var(--color-light);
     text-decoration: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    align-self: flex-start;
+    transition: background-color 0.3s ease;
+}
+
+.event-button:hover {
+    background-color: var(--color-accent);
 }
 
 footer {

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -14,7 +14,7 @@
                 </div>
                 <div class="event-content">
                     <h2 class="event-name">{e.title}</h2>
-                    <p class="event-date">{e.createdAt != null ? java.time.format.DateTimeFormatter.ofPattern("MMMM d, yyyy", new java.util.Locale("es")).format(e.createdAt) : ''}</p>
+                    <p class="event-date">{e.formattedCreatedAt}</p>
                     <a href="/event/{e.id}" class="event-button">Ver detalles</a>
                 </div>
             </article>

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -4,13 +4,22 @@
 <section class="home-section">
     <h1 class="section-title">Eventos disponibles</h1>
     {#if events.isEmpty()}
-        <p class="section-subtitle">No hay eventos disponibles.</p>
+        <p class="section-subtitle no-events">No hay eventos disponibles.</p>
     {#else}
-        <ul class="event-list">
+        <div class="event-grid">
         {#for e in events}
-            <li class="event-item"><a href="/event/{e.id}">{e.title}</a></li>
+            <article class="event-card">
+                <div class="event-image">
+                    <img src="/img/eventflow-logo.png" alt="Imagen de {e.title}">
+                </div>
+                <div class="event-content">
+                    <h2 class="event-name">{e.title}</h2>
+                    <p class="event-date">{e.createdAt != null ? java.time.format.DateTimeFormatter.ofPattern("MMMM d, yyyy", new java.util.Locale("es")).format(e.createdAt) : ''}</p>
+                    <a href="/event/{e.id}" class="event-button">Ver detalles</a>
+                </div>
+            </article>
         {/for}
-        </ul>
+        </div>
     {/if}
 </section>
 {/main}


### PR DESCRIPTION
## Summary
- show home events as responsive cards with image, date and detail link
- add styles for grid layout and card components

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688ffa79d2c88333866152dd537c3a74