### PR TITLE
Fix profile talks messages with proper punctuation

### DIFF
--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -7,9 +7,9 @@
 <p><strong>Apellido:</strong> {familyName}</p>
 <p><strong>Email:</strong> {email}</p>
 <p><strong>Sub:</strong> {sub}</p>
-<h2>Mis charlas</h2>
+<h2>Mis charlas:</h2>
 {#if talks.isEmpty()}
-<p>A\u00fan no hay charlas.</p>
+<p>Aún no hay charlas.</p>
 {#else}
 <ul>
 {#for e in talks}


### PR DESCRIPTION
## Summary
- Add colon to "Mis charlas" heading
- Use proper accent in empty talks message

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68911b22903c8333acabbb15913c2189