### PR TITLE
feat: refresh core pages with modern layout

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -92,6 +92,92 @@ body {
     padding: 1rem;
 }
 
+/* --- Generic components --- */
+.card {
+    background-color: var(--color-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.page-title {
+    font-size: 2.25rem;
+    margin-bottom: 1rem;
+    color: var(--color-dark);
+    text-align: center;
+}
+
+.card-title {
+    font-size: 1.5rem;
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    color: var(--color-primary);
+}
+
+.btn {
+    display: inline-block;
+    background-color: var(--color-primary);
+    color: var(--color-light);
+    text-decoration: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.btn:hover {
+    background-color: var(--color-accent);
+}
+
+.btn-secondary {
+    background-color: var(--color-dark);
+}
+
+.btn-secondary:hover {
+    background-color: var(--color-primary);
+}
+
+.agenda-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.agenda-item {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+.agenda-item:last-child {
+    border-bottom: none;
+}
+
+.action-group {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid #eee;
+    text-align: left;
+}
+
+.table th {
+    background-color: var(--color-dark);
+    color: var(--color-light);
+}
+
 /* --- Home page --- */
 .home-section {
     padding: 2rem 0;
@@ -159,6 +245,11 @@ body {
     flex-direction: column;
 }
 
+.event-content .btn {
+    margin-top: auto;
+    align-self: flex-start;
+}
+
 .event-name {
     font-size: 1.25rem;
     margin: 0 0 0.5rem;
@@ -169,22 +260,6 @@ body {
     font-size: 0.9rem;
     color: #555;
     margin: 0 0 1rem;
-}
-
-.event-button {
-    margin-top: auto;
-    display: inline-block;
-    background-color: var(--color-primary);
-    color: var(--color-light);
-    text-decoration: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    align-self: flex-start;
-    transition: background-color 0.3s ease;
-}
-
-.event-button:hover {
-    background-color: var(--color-accent);
 }
 
 footer {

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -1,37 +1,43 @@
 {#include layout/base}
 {#title}Eventos{/title}
 {#main}
-<h1>Eventos</h1>
-{#if message}
-<p>{message}</p>
-{/if}
-<p><a href="/private/admin/events/new">Nuevo evento</a></p>
-<form method="post" action="/private/admin/events/import" enctype="multipart/form-data">
-    <input type="file" name="file" accept="application/json">
-    <button type="submit">Importar evento desde JSON</button>
-</form>
-{#if events.isEmpty()}
-<p>No hay eventos registrados.</p>
-{#else}
-<table>
-<thead><tr><th>ID</th><th>Titulo</th><th>Acciones</th></tr></thead>
-<tbody>
-{#for ev in events}
-<tr>
-<td>{ev.id}</td>
-<td>{ev.title}</td>
-<td>
-<a href="/private/admin/events/{ev.id}/edit">Editar</a>
-<form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline">
-<button type="submit">Eliminar</button>
-</form>
-<a href="/private/admin/events/{ev.id}/export">Exportar</a>
-</td>
-</tr>
-{/for}
-</tbody>
-</table>
-{/if}
-<p><a href="/private/admin">Volver</a></p>
+<section class="event-list-admin">
+  <h1 class="page-title">Eventos</h1>
+  {#if message}
+  <p class="section-subtitle">{message}</p>
+  {/if}
+  <div class="card action-group">
+    <a href="/private/admin/events/new" class="btn">Nuevo evento</a>
+    <form method="post" action="/private/admin/events/import" enctype="multipart/form-data">
+      <input type="file" name="file" accept="application/json">
+      <button type="submit" class="btn btn-secondary">Importar JSON</button>
+    </form>
+  </div>
+  {#if events.isEmpty()}
+  <p class="no-events">No hay eventos registrados.</p>
+  {#else}
+  <div class="card">
+    <table class="table">
+      <thead><tr><th>ID</th><th>Título</th><th>Acciones</th></tr></thead>
+      <tbody>
+      {#for ev in events}
+        <tr>
+          <td>{ev.id}</td>
+          <td>{ev.title}</td>
+          <td class="action-group">
+            <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary">Editar</a>
+            <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline">
+              <button type="submit" class="btn btn-secondary">Eliminar</button>
+            </form>
+            <a href="/private/admin/events/{ev.id}/export" class="btn btn-secondary">Exportar</a>
+          </td>
+        </tr>
+      {/for}
+      </tbody>
+    </table>
+  </div>
+  {/if}
+  <a href="/private/admin" class="btn btn-secondary">Volver</a>
+</section>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -1,9 +1,13 @@
 {#include layout/base}
 {#title}Panel de administraci\u00f3n{/title}
 {#main}
-<h1>Admin Panel</h1>
-<p>Bienvenido {name}. Gestiona los eventos aquí.</p>
-<p><a href="/private/admin/events">Administrar eventos</a></p>
-<p><a href="/private/profile">Volver a perfil</a></p>
+<section class="admin-overview">
+    <h1 class="page-title">Admin Panel</h1>
+    <p class="section-subtitle">Bienvenido {name}. Gestiona los eventos aquí.</p>
+    <div class="card action-group">
+        <a href="/private/admin/events" class="btn">Administrar eventos</a>
+        <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
+    </div>
+</section>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/EventResource/agenda.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/agenda.html
@@ -4,18 +4,22 @@
 {/title}
 {#main}
 {#if event}
-<h1>Agenda de {event.title}</h1>
-{#for d in event.dayList}
-<h2>Día {d}</h2>
-<ul>
-{#for t in event.getAgendaForDay(d)}
-<li>{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
-{/for}
-</ul>
-{/for}
-<p><a href="/event/{event.id}">Volver al evento</a></p>
+<section class="event-agenda">
+  <h1 class="page-title">Agenda de {event.title}</h1>
+  {#for d in event.dayList}
+  <div class="card agenda-day">
+    <h2 class="card-title">Día {d}</h2>
+    <ul class="agenda-list">
+    {#for t in event.getAgendaForDay(d)}
+      <li class="agenda-item">{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+    {/for}
+    </ul>
+  </div>
+  {/for}
+  <a href="/event/{event.id}" class="btn">Volver al evento</a>
+</section>
 {#else}
-<p>Evento no encontrado.</p>
+<p class="no-events">Evento no encontrado.</p>
 {/if}
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -8,30 +8,38 @@ Evento
 {/title}
 {#main}
 {#if event}
-<h1>{event.title}</h1>
-<p>{event.description}</p>
-{#if !event.scenarios.isEmpty()}
-<h2>Escenarios</h2>
-<ul>
-{#for s in event.scenarios}
-<li><a href="/scenario/{s.id}">{s.name}</a></li>
-{/for}
-</ul>
-{/if}
-{#if !event.agenda.isEmpty()}
-<h2>Agenda</h2>
-{#for d in event.dayList}
-<h3>Día {d}</h3>
-<ul>
-{#for t in event.getAgendaForDay(d)}
-<li>{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
-{/for}
-</ul>
-{/for}
-{/if}
+<section class="event-detail">
+  <h1 class="page-title">{event.title}</h1>
+  <div class="card">
+    <p>{event.description}</p>
+  </div>
+  {#if !event.scenarios.isEmpty()}
+  <div class="card">
+    <h2 class="card-title">Escenarios</h2>
+    <ul class="agenda-list">
+    {#for s in event.scenarios}
+      <li class="agenda-item"><a href="/scenario/{s.id}">{s.name}</a></li>
+    {/for}
+    </ul>
+  </div>
+  {/if}
+  {#if !event.agenda.isEmpty()}
+  <div class="card">
+    <h2 class="card-title">Agenda</h2>
+    {#for d in event.dayList}
+      <h3>Día {d}</h3>
+      <ul class="agenda-list">
+      {#for t in event.getAgendaForDay(d)}
+        <li class="agenda-item">{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+      {/for}
+      </ul>
+    {/for}
+  </div>
+  {/if}
+  <a href="/" class="btn">Volver al inicio</a>
+</section>
 {#else}
-<p>Evento no encontrado.</p>
+<p class="no-events">Evento no encontrado.</p>
 {/if}
-<p><a href="/">Volver al inicio</a></p>
 {/main}
 {/include}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -2,7 +2,7 @@
 {#title}Inicio{/title}
 {#main}
 <section class="home-section">
-    <h1 class="section-title">Eventos disponibles</h1>
+    <h1 class="page-title">Eventos disponibles</h1>
     {#if events.isEmpty()}
         <p class="section-subtitle no-events">No hay eventos disponibles.</p>
     {#else}
@@ -15,7 +15,7 @@
                 <div class="event-content">
                     <h2 class="event-name">{e.title}</h2>
                     <p class="event-date">{e.formattedCreatedAt}</p>
-                    <a href="/event/{e.id}" class="event-button">Ver detalles</a>
+                    <a href="/event/{e.id}" class="btn">Ver detalles</a>
                 </div>
             </article>
         {/for}


### PR DESCRIPTION
## Summary
- refactor home, event detail, agenda, and admin pages with card-based layout
- add reusable button, card, and table styles for consistent hierarchy
- streamline admin event list with grouped actions and modern table

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68913fc08e708333800d06276ae3c62a