### PR TITLE
feat: enhance UI feedback and transitions

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -23,10 +23,74 @@ function bannerParallax() {
     }
 }
 
+function showLoading() {
+    document.body.classList.remove('loaded');
+    const loader = document.getElementById('loading');
+    if (loader) loader.classList.remove('hidden');
+}
+
+function hideLoading() {
+    const loader = document.getElementById('loading');
+    if (loader) loader.classList.add('hidden');
+}
+
+function showNotification(type, message) {
+    const note = document.getElementById('notification');
+    if (!note) return;
+    note.textContent = message;
+    note.className = 'notification ' + type;
+    note.classList.add('show');
+    setTimeout(() => {
+        note.classList.remove('show');
+        setTimeout(() => {
+            note.className = 'notification hidden';
+            note.textContent = '';
+        }, 300);
+    }, 3000);
+}
+
+function handleForms() {
+    document.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', e => {
+            if (form.classList.contains('needs-confirm') && !confirm('¿Estás seguro?')) {
+                e.preventDefault();
+                return;
+            }
+            showLoading();
+            const btn = form.querySelector('button[type="submit"]');
+            if (btn) btn.disabled = true;
+        });
+    });
+}
+
+function highlightNav() {
+    const links = document.querySelectorAll('.nav-links a');
+    links.forEach(link => {
+        if (link.getAttribute('href') === window.location.pathname) {
+            link.classList.add('active');
+        }
+    });
+}
+
+function handleNotificationsFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('success')) {
+        showNotification('success', params.get('success'));
+    }
+    if (params.has('error')) {
+        showNotification('error', params.get('error'));
+    }
+}
+
 window.addEventListener('DOMContentLoaded', () => {
     setupMenu();
     adjustLayout();
     bannerParallax();
+    handleForms();
+    highlightNav();
+    handleNotificationsFromUrl();
+    document.body.classList.add('loaded');
 });
 window.addEventListener('resize', adjustLayout);
 window.addEventListener('scroll', bannerParallax);
+window.addEventListener('beforeunload', showLoading);

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -8,11 +8,25 @@
     --color-light: #fff;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 body {
     font-family: 'Helvetica Neue', Arial, sans-serif;
     background-color: var(--color-bg);
     color: var(--color-text);
     margin: 0;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+body.loaded {
+    opacity: 1;
+}
+
+.hidden {
+    display: none;
 }
 
 /* --- Header refresh --- */
@@ -77,6 +91,10 @@ body {
     background-color: var(--color-accent);
 }
 
+.nav-links a.active {
+    background-color: var(--color-accent);
+}
+
 .menu-toggle {
     display: none;
     background: none;
@@ -99,6 +117,7 @@ body {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     padding: 1rem;
     margin-bottom: 1.5rem;
+    animation: fadeInUp 0.3s ease;
 }
 
 .page-title {
@@ -124,11 +143,20 @@ body {
     border-radius: 4px;
     border: none;
     cursor: pointer;
-    transition: background-color 0.3s ease;
+    transition: background-color 0.3s ease, transform 0.1s ease;
 }
 
 .btn:hover {
     background-color: var(--color-accent);
+}
+
+.btn:active {
+    transform: scale(0.97);
+}
+
+.btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
 }
 
 .btn-secondary {
@@ -216,6 +244,7 @@ body {
     display: flex;
     flex-direction: column;
     transition: transform 0.2s ease;
+    animation: fadeInUp 0.3s ease;
 }
 
 .event-card:hover {
@@ -274,6 +303,65 @@ footer {
     0% { background-position: 0 50%; }
     50% { background-position: 100% 50%; }
     100% { background-position: 0 50%; }
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+.notification {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    background-color: var(--color-light);
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    z-index: 1100;
+}
+
+.notification.success {
+    border-left: 4px solid #4caf50;
+}
+
+.notification.error {
+    border-left: 4px solid #f44336;
+}
+
+.notification.show {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.loading {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.spinner {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid var(--color-primary);
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    animation: spin 1s linear infinite;
 }
 
 @media (max-width: 600px) {

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -41,7 +41,7 @@ Nuevo Evento
 <input name="location" value="{sc.location}" placeholder="Ubicacion">
 <button type="submit">Guardar</button>
 </form>
-<form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline">
+<form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline" class="needs-confirm">
 <button type="submit">Eliminar</button>
 </form>
 </td>
@@ -85,7 +85,7 @@ Nuevo Evento
 </select>
 <button type="submit">Guardar</button>
 </form>
-<form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline">
+<form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline" class="needs-confirm">
 <button type="submit">Eliminar</button>
 </form>
 </td>

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -26,7 +26,7 @@
           <td>{ev.title}</td>
           <td class="action-group">
             <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary">Editar</a>
-            <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline">
+            <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline" class="needs-confirm">
               <button type="submit" class="btn btn-secondary">Eliminar</button>
             </form>
             <a href="/private/admin/events/{ev.id}/export" class="btn btn-secondary">Exportar</a>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -32,6 +32,8 @@
         {/if}
     </div>
 </nav>
+<div id="notification" class="notification hidden" role="alert"></div>
+<div id="loading" class="loading hidden"><div class="spinner"></div></div>
 <main id="main-content" class="container">
     {#insert main}{/}
 </main>


### PR DESCRIPTION
## Summary
- add global notification and loading overlays
- integrate loaders, nav highlighting and URL-based alerts via JS
- animate cards and buttons with smooth page transitions
- confirm admin deletes to avoid mistakes

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68915b66c40483338fd9eef32a6bf44c