### PR TITLE
feat: add breadcrumbs and admin navigation

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -121,6 +121,37 @@ button:focus-visible {
     background-color: var(--color-accent);
 }
 
+.breadcrumbs {
+    font-size: 0.9rem;
+    margin: 0.5rem 0 1rem;
+}
+.breadcrumbs a {
+    color: var(--color-dark);
+    text-decoration: none;
+}
+.breadcrumbs .sep {
+    margin: 0 0.25rem;
+    color: #555;
+}
+.breadcrumbs:empty {
+    display: none;
+}
+
+.sub-nav {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+.sub-nav a {
+    text-decoration: none;
+    color: var(--color-dark);
+    font-weight: 500;
+}
+
+.icon {
+    margin-right: 0.25rem;
+}
+
 .menu-toggle {
     display: none;
     background: none;

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -6,6 +6,7 @@ Editar Evento
 Nuevo Evento
 {/if}
 {/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><a href="/private/admin/events">Eventos</a><span class="sep">/</span><span>{#if event.id}{event.title}{#else}Nuevo Evento{/if}</span>{/breadcrumbs}
 {#main}
 <h1>
 {#if event.id}
@@ -14,6 +15,15 @@ Editar Evento
 Nuevo Evento
 {/if}
 </h1>
+<nav class="sub-nav">
+  <a href="#event-info">Evento</a>
+  {#if event.id}
+  <a href="#scenarios">Escenarios</a>
+  <a href="#talks">Charlas</a>
+  <a href="#agenda">Agenda</a>
+  {/if}
+</nav>
+<section id="event-info">
 <form method="post" action="{#if event.id}/private/admin/events/{event.id}/edit{#else}/private/admin/events/new{/if}">
     {#if event.id}
         <p>ID: {event.id}</p>
@@ -26,104 +36,115 @@ Nuevo Evento
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <button type="submit">Guardar</button>
 </form>
+</section>
 {#if event.id}
-<h2>Escenarios</h2>
-<table>
-<thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
-<tbody>
-{#for sc in event.scenarios}
-<tr>
-<form method="post" action="/private/admin/events/{event.id}/scenario">
-<td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
-<td><input name="name" value="{sc.name}"></td>
-<td>
-<input name="features" value="{sc.features}" placeholder="Caracteristicas">
-<input name="location" value="{sc.location}" placeholder="Ubicacion">
-<button type="submit">Guardar</button>
-</form>
-<form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline" class="needs-confirm">
-<button type="submit">Eliminar</button>
-</form>
-</td>
-</tr>
-{/for}
-<tr>
-<form method="post" action="/private/admin/events/{event.id}/scenario">
-<td>Nuevo</td>
-<td><input name="name"></td>
-<td>
-<input name="features" placeholder="Caracteristicas">
-<input name="location" placeholder="Ubicacion">
-<button type="submit">Agregar</button>
-</td>
-</form>
-</tr>
-</tbody>
-</table>
-<h2>Charlas</h2>
-<table>
-<thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
-<tbody>
-{#for t in event.agenda}
-<tr>
-<form method="post" action="/private/admin/events/{event.id}/talk">
-<td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
-<td><input name="name" value="{t.name}"></td>
-<td>
-<input name="description" value="{t.description}" placeholder="Descripcion">
-<select name="location">
-{#for sc in event.scenarios}
-<option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
-{/for}
-</select>
-<input name="startTime" type="time" value="{t.startTimeStr}">
-<input name="duration" type="number" min="1" value="{t.durationMinutes}">
-<select name="day">
-{#for d in event.dayList}
-<option value="{d}"{#if t.day == d} selected{/if}>Día {d}</option>
-{/for}
-</select>
-<button type="submit">Guardar</button>
-</form>
-<form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline" class="needs-confirm">
-<button type="submit">Eliminar</button>
-</form>
-</td>
-</tr>
-{/for}
-<tr>
-<form method="post" action="/private/admin/events/{event.id}/talk">
-<td>Nuevo</td>
-<td><input name="name"></td>
-<td>
-<input name="description" placeholder="Descripcion">
-<select name="location">
-{#for sc in event.scenarios}
-<option value="{sc.id}">{sc.name}</option>
-{/for}
-</select>
-<input name="startTime" type="time">
-<input name="duration" type="number" min="1">
-<select name="day">
-{#for d in event.dayList}
-<option value="{d}">Día {d}</option>
-{/for}
-</select>
-<button type="submit">Agregar</button>
-</td>
-</form>
-</tr>
-</tbody>
-</table>
-<h2>Agenda</h2>
-{#for d in event.dayList}
-<h3>Día {d}</h3>
-<ul>
-{#for t in event.getAgendaForDay(d)}
-<li>{t.startTimeStr} - {t.endTimeStr} | {t.name} | {event.getScenarioName(t.location)}</li>
-{/for}
-</ul>
-{/for}
+<section id="scenarios">
+  <h2><span class="icon">🏟️</span>Escenarios</h2>
+  <div class="card">
+  <table>
+    <thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
+    <tbody>
+    {#for sc in event.scenarios}
+    <tr>
+      <form method="post" action="/private/admin/events/{event.id}/scenario">
+      <td>{sc.id}<input type="hidden" name="scenarioId" value="{sc.id}"></td>
+      <td><input name="name" value="{sc.name}"></td>
+      <td>
+        <input name="features" value="{sc.features}" placeholder="Caracteristicas">
+        <input name="location" value="{sc.location}" placeholder="Ubicacion">
+        <button type="submit">Guardar</button>
+      </form>
+      <form method="post" action="/private/admin/events/{event.id}/scenario/{sc.id}/delete" style="display:inline" class="needs-confirm">
+        <button type="submit">Eliminar</button>
+      </form>
+      </td>
+    </tr>
+    {/for}
+    <tr>
+      <form method="post" action="/private/admin/events/{event.id}/scenario">
+      <td>Nuevo</td>
+      <td><input name="name"></td>
+      <td>
+        <input name="features" placeholder="Caracteristicas">
+        <input name="location" placeholder="Ubicacion">
+        <button type="submit">Agregar</button>
+      </td>
+      </form>
+    </tr>
+    </tbody>
+  </table>
+  </div>
+</section>
+<section id="talks">
+  <h2><span class="icon">🗣️</span>Charlas</h2>
+  <div class="card">
+  <table>
+  <thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
+  <tbody>
+  {#for t in event.agenda}
+  <tr>
+  <form method="post" action="/private/admin/events/{event.id}/talk">
+  <td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
+  <td><input name="name" value="{t.name}"></td>
+  <td>
+  <input name="description" value="{t.description}" placeholder="Descripcion">
+  <select name="location">
+  {#for sc in event.scenarios}
+  <option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
+  {/for}
+  </select>
+  <input name="startTime" type="time" value="{t.startTimeStr}">
+  <input name="duration" type="number" min="1" value="{t.durationMinutes}">
+  <select name="day">
+  {#for d in event.dayList}
+  <option value="{d}"{#if t.day == d} selected{/if}>Día {d}</option>
+  {/for}
+  </select>
+  <button type="submit">Guardar</button>
+  </form>
+  <form method="post" action="/private/admin/events/{event.id}/talk/{t.id}/delete" style="display:inline" class="needs-confirm">
+  <button type="submit">Eliminar</button>
+  </form>
+  </td>
+  </tr>
+  {/for}
+  <tr>
+  <form method="post" action="/private/admin/events/{event.id}/talk">
+  <td>Nuevo</td>
+  <td><input name="name"></td>
+  <td>
+  <input name="description" placeholder="Descripcion">
+  <select name="location">
+  {#for sc in event.scenarios}
+  <option value="{sc.id}">{sc.name}</option>
+  {/for}
+  </select>
+  <input name="startTime" type="time">
+  <input name="duration" type="number" min="1">
+  <select name="day">
+  {#for d in event.dayList}
+  <option value="{d}">Día {d}</option>
+  {/for}
+  </select>
+  <button type="submit">Agregar</button>
+  </td>
+  </form>
+  </tr>
+  </tbody>
+  </table>
+  </div>
+</section>
+<section id="agenda">
+  <h2><span class="icon">🗓️</span>Agenda</h2>
+  {#for d in event.dayList}
+  <h3>Día {d}</h3>
+  <ul>
+  {#for t in event.getAgendaForDay(d)}
+  <li>{t.startTimeStr} - {t.endTimeStr} | {t.name} | {event.getScenarioName(t.location)}</li>
+  {/for}
+  </ul>
+  {/for}
+</section>
 {/if}
 <p><a href="/private/admin/events">Volver a la administración de Eventos</a></p>
 {/main}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -1,8 +1,9 @@
 {#include layout/base}
 {#title}Eventos{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Eventos</span>{/breadcrumbs}
 {#main}
 <section class="event-list-admin">
-  <h1 class="page-title">Eventos</h1>
+    <h1 class="page-title"><span class="icon">🗓️</span>Eventos</h1>
   {#if message}
   <p class="section-subtitle">{message}</p>
   {/if}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -1,5 +1,6 @@
 {#include layout/base}
 {#title}Panel de administraci\u00f3n{/title}
+{#breadcrumbs}<a href="/private/profile">Perfil</a><span class="sep">/</span><span>Admin</span>{/breadcrumbs}
 {#main}
 <section class="admin-overview">
     <h1 class="page-title">Admin Panel</h1>

--- a/quarkus-app/src/main/resources/templates/EventResource/agenda.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/agenda.html
@@ -2,6 +2,11 @@
 {#title}
 {#if event}{event.title} - Agenda{#else}Agenda{/if}
 {/title}
+{#if event}
+{#breadcrumbs}
+<a href="/">Eventos</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><span>Agenda</span>
+{/breadcrumbs}
+{/if}
 {#main}
 {#if event}
 <section class="event-agenda">
@@ -10,10 +15,10 @@
   <div class="card agenda-day">
     <h2 class="card-title">Día {d}</h2>
     <ul class="agenda-list">
-    {#for t in event.getAgendaForDay(d)}
-      <li class="agenda-item">{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
-    {/for}
-    </ul>
+      {#for t in event.getAgendaForDay(d)}
+        <li class="agenda-item"><span class="icon">🗣️</span>{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+      {/for}
+      </ul>
   </div>
   {/for}
   <a href="/event/{event.id}" class="btn">Volver al evento</a>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -6,6 +6,11 @@
 Evento
 {/if}
 {/title}
+{#if event}
+{#breadcrumbs}
+<a href="/">Eventos</a><span class="sep">/</span><span>{event.title}</span>
+{/breadcrumbs}
+{/if}
 {#main}
 {#if event}
 <section class="event-detail">
@@ -13,29 +18,30 @@ Evento
   <div class="card">
     <p>{event.description}</p>
   </div>
-  {#if !event.scenarios.isEmpty()}
-  <div class="card">
-    <h2 class="card-title">Escenarios</h2>
-    <ul class="agenda-list">
-    {#for s in event.scenarios}
-      <li class="agenda-item"><a href="/scenario/{s.id}">{s.name}</a></li>
-    {/for}
-    </ul>
-  </div>
-  {/if}
-  {#if !event.agenda.isEmpty()}
-  <div class="card">
-    <h2 class="card-title">Agenda</h2>
-    {#for d in event.dayList}
-      <h3>Día {d}</h3>
+    {#if !event.scenarios.isEmpty()}
+    <div class="card">
+      <h2 class="card-title"><span class="icon">🏟️</span>Escenarios</h2>
       <ul class="agenda-list">
-      {#for t in event.getAgendaForDay(d)}
-        <li class="agenda-item">{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+      {#for s in event.scenarios}
+        <li class="agenda-item"><span class="icon">📍</span><a href="/scenario/{s.id}">{s.name}</a></li>
       {/for}
       </ul>
-    {/for}
-  </div>
-  {/if}
+    </div>
+    {/if}
+    {#if !event.agenda.isEmpty()}
+    <div class="card">
+      <h2 class="card-title"><span class="icon">🗓️</span>Agenda</h2>
+      <p><a href="/event/{event.id}/agenda" class="btn btn-secondary">Ver agenda completa</a></p>
+      {#for d in event.dayList}
+        <h3>Día {d}</h3>
+        <ul class="agenda-list">
+        {#for t in event.getAgendaForDay(d)}
+          <li class="agenda-item"><span class="icon">🗣️</span>{t.startTimeStr} - {t.endTimeStr} | <a href="/talk/{t.id}">{t.name}</a> | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+        {/for}
+        </ul>
+      {/for}
+    </div>
+    {/if}
   <a href="/" class="btn">Volver al inicio</a>
 </section>
 {#else}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -1,5 +1,6 @@
 {#include layout/base}
 {#title}Inicio{/title}
+{#breadcrumbs}<span>Eventos</span>{/breadcrumbs}
 {#main}
 <section class="home-section">
     <h1 class="page-title">Eventos disponibles</h1>

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -6,16 +6,21 @@
 Escenario
 {/if}
 {/title}
+{#if scenario}
+{#breadcrumbs}
+<a href="/">Eventos</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><span>Escenario: {scenario.name}</span>
+{/breadcrumbs}
+{/if}
 {#main}
 {#if scenario}
-<h1>{scenario.name}</h1>
+<h1><span class="icon">🏟️</span>{scenario.name}</h1>
 {#if scenario.location}<p>Ubicacion: {scenario.location}</p>{/if}
 {#if scenario.features}<p>{scenario.features}</p>{/if}
 {#if !talks.isEmpty()}
-<h2>Charlas</h2>
+<h2><span class="icon">🗣️</span>Charlas</h2>
 <ul>
 {#for t in talks}
-    <li>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) :
+    <li><span class="icon">🗣️</span>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) :
         <a href="/talk/{t.id}">{t.name}</a>
     </li>
 {/for}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -6,24 +6,29 @@
 Charla
 {/if}
 {/title}
+{#if talk}
+{#breadcrumbs}
+<a href="/">Eventos</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><span>Charla: {talk.name}</span>
+{/breadcrumbs}
+{/if}
 {#main}
 {#if talk}
-<h1>{talk.name}</h1>
+<h1><span class="icon">🗣️</span>{talk.name}</h1>
 {#if talk.description}<p>{talk.description}</p>{/if}
 {#if app:isAuthenticated()}
 <p><a href="/private/profile/add/{talk.id}">Agregar a mis charlas</a></p>
 {/if}
-{#if !occurrences.isEmpty()}
-<h2>Horarios</h2>
-<ul>
-{#for t in occurrences}
-    <li>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) -
-        <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
-    </li>
-{/for}
-</ul>
-{/if}
-{#if event}<p><a href="/event/{event.id}">Volver al evento</a></p>{/if}
+  {#if !occurrences.isEmpty()}
+  <h2><span class="icon">⏰</span>Horarios</h2>
+  <ul>
+  {#for t in occurrences}
+      <li><span class="icon">⏰</span>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) -
+          <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
+      </li>
+  {/for}
+  </ul>
+  {/if}
+  {#if event}<p><a href="/event/{event.id}">Volver al evento</a></p>{/if}
 {#else}
 <p>Charla no encontrada.</p>
 {/if}

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -33,6 +33,7 @@
         {/if}
     </div>
 </nav>
+<nav class="breadcrumbs" aria-label="Ruta de navegación">{#insert breadcrumbs}{/}</nav>
 <div id="notification" class="notification hidden" role="alert"></div>
 <div id="loading" class="loading hidden"><div class="spinner"></div></div>
 <main id="main-content" class="container">


### PR DESCRIPTION
## Summary
- add global breadcrumb slot and supporting styles
- show breadcrumbs and icons on public event pages
- enhance admin pages with breadcrumbs and sub-navigation

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891843f515883339e850b7db8bde1f1