### PR TITLE
fix: prevent infinite loading overlay

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -25,15 +25,26 @@ function bannerParallax() {
     }
 }
 
-function showLoading() {
+let loadingTimeout;
+let loadingTarget = 'el contenido';
+
+function showLoading(target = 'el contenido') {
+    loadingTarget = target;
     document.body.classList.remove('loaded');
     const loader = document.getElementById('loading');
     if (loader) loader.classList.remove('hidden');
+    clearTimeout(loadingTimeout);
+    loadingTimeout = setTimeout(() => {
+        hideLoading();
+        showNotification('error', `No se pudo cargar ${loadingTarget}`);
+    }, 5000);
 }
 
 function hideLoading() {
     const loader = document.getElementById('loading');
     if (loader) loader.classList.add('hidden');
+    document.body.classList.add('loaded');
+    clearTimeout(loadingTimeout);
 }
 
 function showNotification(type, message) {
@@ -58,7 +69,7 @@ function handleForms() {
                 e.preventDefault();
                 return;
             }
-            showLoading();
+            showLoading('los datos');
             const btn = form.querySelector('button[type="submit"]');
             if (btn) btn.disabled = true;
         });
@@ -91,8 +102,12 @@ window.addEventListener('DOMContentLoaded', () => {
     handleForms();
     highlightNav();
     handleNotificationsFromUrl();
-    document.body.classList.add('loaded');
+    hideLoading();
+    if (document.querySelector('.no-events')) {
+        hideLoading();
+        showNotification('info', 'No hay eventos disponibles');
+    }
 });
 window.addEventListener('resize', adjustLayout);
 window.addEventListener('scroll', bannerParallax);
-window.addEventListener('beforeunload', showLoading);
+window.addEventListener('beforeunload', () => showLoading('la página'));

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -416,6 +416,10 @@ footer {
     border-left: 4px solid #4caf50;
 }
 
+.notification.info {
+    border-left: 4px solid #2196f3;
+}
+
 .notification.error {
     border-left: 4px solid #f44336;
 }
@@ -436,6 +440,10 @@ footer {
     align-items: center;
     justify-content: center;
     z-index: 1000;
+}
+
+.loading.hidden {
+    display: none;
 }
 
 .spinner {


### PR DESCRIPTION
## Summary
- stop showing the loading spinner after 5 seconds and notify the user
- hide loading indicator on page load and warn when no events are available
- display an informational notification and remove the overlay when the event list is empty
- ensure `.hidden` overrides `.loading` so the spinner is removed correctly

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891d9b97d7483338a598e434e15074b