### PR TITLE
Improve navigation between events, scenarios and talks

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -374,6 +374,71 @@ button:focus-visible {
     margin: 0 0 1rem;
 }
 
+/* Grid of scenario cards on event detail */
+.scenario-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+    padding: 0;
+}
+
+.scenario-card {
+    background-color: var(--color-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    animation: fadeInUp 0.3s ease;
+}
+
+.scenario-card h3 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    color: var(--color-dark);
+}
+
+.scenario-card .btn {
+    margin-top: auto;
+    align-self: flex-start;
+}
+
+/* Talk list on scenario detail */
+.talk-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.talk-item {
+    background-color: var(--color-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    margin-bottom: 1rem;
+    display: flex;
+    flex-direction: column;
+    animation: fadeInUp 0.3s ease;
+}
+
+.talk-item h3 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    color: var(--color-dark);
+}
+
+.talk-item .talk-time {
+    font-size: 0.9rem;
+    color: #555;
+    margin: 0 0 0.5rem;
+}
+
+.talk-item .btn {
+    margin-top: auto;
+    align-self: flex-start;
+}
+
 footer {
     background-color: var(--color-dark);
     color: var(--color-light);

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -17,15 +17,23 @@ Evento
   <h1 class="page-title">{event.title}</h1>
   <div class="card">
     <p>{event.description}</p>
+    {#if event.mapUrl}
+      <p><strong>Lugar:</strong> <a href="{event.mapUrl}" target="_blank">Ver mapa</a></p>
+    {/if}
+    <p><strong>Duración:</strong> {event.days} día{#if event.days > 1}s{/if}</p>
   </div>
     {#if !event.scenarios.isEmpty()}
     <div class="card">
       <h2 class="card-title"><span class="icon">🏟️</span>Escenarios</h2>
-      <ul class="agenda-list">
+      <div class="scenario-grid">
       {#for s in event.scenarios}
-        <li class="agenda-item"><span class="icon">📍</span><a href="/scenario/{s.id}">{s.name}</a></li>
+        <article class="scenario-card">
+          <h3>{s.name}</h3>
+          {#if s.location}<p class="scenario-location">{s.location}</p>{/if}
+          <a href="/scenario/{s.id}" class="btn">Ver charlas</a>
+        </article>
       {/for}
-      </ul>
+      </div>
     </div>
     {/if}
     {#if !event.agenda.isEmpty()}

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -13,22 +13,32 @@ Escenario
 {/breadcrumbs}
 {#main}
 {#if scenario}
-<h1><span class="icon">🏟️</span>{scenario.name}</h1>
-{#if scenario.location}<p>Ubicacion: {scenario.location}</p>{/if}
-{#if scenario.features}<p>{scenario.features}</p>{/if}
-{#if !talks.isEmpty()}
-<h2><span class="icon">🗣️</span>Charlas</h2>
-<ul>
-{#for t in talks}
-    <li><span class="icon">🗣️</span>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) :
-        <a href="/talk/{t.id}">{t.name}</a>
+<section class="scenario-detail">
+  <h1 class="page-title">{scenario.name}</h1>
+  {#if scenario.location}<p class="scenario-location"><strong>Ubicación:</strong> {scenario.location}</p>{/if}
+  {#if scenario.features}<p>{scenario.features}</p>{/if}
+  {#if !talks.isEmpty()}
+  <ul class="talk-list">
+  {#for t in talks}
+    <li class="talk-item">
+      <h3>{t.name}</h3>
+      <p class="talk-time">Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min)</p>
+      {#if t.speaker}
+      <p class="talk-speakers">Orador: {t.speaker.name}{#if t.coSpeaker} & {t.coSpeaker.name}{/if}</p>
+      {/if}
+      <a href="/talk/{t.id}" class="btn btn-secondary">Ver charla</a>
     </li>
-{/for}
-</ul>
-{/if}
-{#if event}
-<p><a href="/event/{event.id}">Volver al evento</a></p>
-{/if}
+  {/for}
+  </ul>
+  {#else}
+  <p>No hay charlas para este escenario.</p>
+  {/if}
+  {#if event}
+  <div class="action-group">
+    <a href="/event/{event.id}" class="btn">Volver al evento</a>
+  </div>
+  {/if}
+</section>
 {#else}
 <p>Escenario no encontrado.</p>
 {/if}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -8,27 +8,36 @@ Charla
 {/title}
 {#breadcrumbs}
 {#if talk}
-<a href="/">Eventos</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><span>Charla: {talk.name}</span>
+<a href="/">Eventos</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><a href="/scenario/{talk.location}">{event.getScenarioName(talk.location)}</a><span class="sep">/</span><span>Charla: {talk.name}</span>
 {/if}
 {/breadcrumbs}
 {#main}
 {#if talk}
-<h1><span class="icon">🗣️</span>{talk.name}</h1>
-{#if talk.description}<p>{talk.description}</p>{/if}
-{#if app:isAuthenticated()}
-<p><a href="/private/profile/add/{talk.id}">Agregar a mis charlas</a></p>
-{/if}
-  {#if !occurrences.isEmpty()}
-  <h2><span class="icon">⏰</span>Horarios</h2>
-  <ul>
-  {#for t in occurrences}
-      <li><span class="icon">⏰</span>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) -
-          <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
-      </li>
-  {/for}
-  </ul>
+<section class="talk-detail">
+  <h1 class="page-title">{talk.name}</h1>
+  {#if talk.description}<p>{talk.description}</p>{/if}
+  {#if talk.speaker}
+    <p><strong>Orador:</strong> {talk.speaker.name}{#if talk.coSpeaker} & {talk.coSpeaker.name}{/if}</p>
   {/if}
-  {#if event}<p><a href="/event/{event.id}">Volver al evento</a></p>{/if}
+  <p><strong>Duración:</strong> {talk.durationMinutes} min</p>
+  {#if app:isAuthenticated()}
+  <p><a href="/private/profile/add/{talk.id}">Agregar a mis charlas</a></p>
+  {/if}
+  {#if !occurrences.isEmpty()}
+  <div class="card">
+    <h2 class="card-title"><span class="icon">⏰</span>Horarios</h2>
+    <ul class="agenda-list">
+    {#for t in occurrences}
+        <li class="agenda-item"><span class="icon">⏰</span>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) - <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+    {/for}
+    </ul>
+  </div>
+  {/if}
+  <div class="action-group">
+    <a href="/scenario/{talk.location}" class="btn btn-secondary">Volver al escenario</a>
+    {#if event}<a href="/event/{event.id}" class="btn">Volver al evento</a>{/if}
+  </div>
+</section>
 {#else}
 <p>Charla no encontrada.</p>
 {/if}


### PR DESCRIPTION
## Summary
- show event location/duration and scenario cards on event detail
- display talk cards with speakers within scenario detail
- enrich talk detail with speaker info, schedule and back links; add responsive styles

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe5642008333bf6eeb1314a43bf6