### PR TITLE
feat: improve user talk scheduling UX

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -10,8 +10,10 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.UserScheduleService;
 import com.scanales.eventflow.model.Talk;
 import jakarta.inject.Inject;
+import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/talk")
 public class TalkResource {
@@ -20,11 +22,18 @@ public class TalkResource {
     static class Templates {
         static native TemplateInstance detail(Talk talk,
                                              com.scanales.eventflow.model.Event event,
-                                             java.util.List<Talk> occurrences);
+                                             java.util.List<Talk> occurrences,
+                                             boolean inSchedule);
     }
 
     @Inject
     EventService eventService;
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    UserScheduleService userSchedule;
 
     @GET
     @Path("{id}")
@@ -37,6 +46,14 @@ public class TalkResource {
         }
         var event = eventService.findEventByTalk(id);
         var occurrences = eventService.findTalkOccurrences(id);
-        return Templates.detail(talk, event, occurrences);
+        boolean inSchedule = false;
+        if (identity != null && !identity.isAnonymous()) {
+            String email = identity.getAttribute("email");
+            if (email == null) {
+                email = identity.getPrincipal().getName();
+            }
+            inSchedule = userSchedule.getTalksForUser(email).contains(id);
+        }
+        return Templates.detail(talk, event, occurrences, inSchedule);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -42,7 +42,7 @@ public class TalkResource {
     public TemplateInstance detail(@PathParam("id") String id) {
         Talk talk = eventService.findTalk(id);
         if (talk == null) {
-            return Templates.detail(null, null, java.util.List.of());
+            return Templates.detail(null, null, java.util.List.<Talk>of(), false);
         }
         var event = eventService.findEventByTalk(id);
         var occurrences = eventService.findTalkOccurrences(id);

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -12,9 +12,13 @@ public class UserScheduleService {
 
     private final Map<String, Set<String>> schedules = new ConcurrentHashMap<>();
 
-    /** Adds the talk id to the schedule for the given user email. */
-    public void addTalkForUser(String email, String talkId) {
-        schedules.computeIfAbsent(email, k -> ConcurrentHashMap.newKeySet())
+    /**
+     * Adds the talk id to the schedule for the given user email.
+     * 
+     * @return {@code true} if the talk was newly added, {@code false} if it was already present
+     */
+    public boolean addTalkForUser(String email, String talkId) {
+        return schedules.computeIfAbsent(email, k -> ConcurrentHashMap.newKeySet())
                 .add(talkId);
     }
 
@@ -23,14 +27,20 @@ public class UserScheduleService {
         return schedules.getOrDefault(email, java.util.Set.of());
     }
 
-    /** Removes the talk id from the user schedule. */
-    public void removeTalkForUser(String email, String talkId) {
+    /**
+     * Removes the talk id from the user schedule.
+     *
+     * @return {@code true} if the talk was removed, {@code false} if it was not registered
+     */
+    public boolean removeTalkForUser(String email, String talkId) {
         Set<String> talks = schedules.get(email);
         if (talks != null) {
-            talks.remove(talkId);
+            boolean removed = talks.remove(talkId);
             if (talks.isEmpty()) {
                 schedules.remove(email);
             }
+            return removed;
         }
+        return false;
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -1,6 +1,8 @@
 package com.scanales.eventflow.util;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Duration;
 import java.util.List;
 
 import io.quarkus.arc.Arc;
@@ -10,6 +12,7 @@ import io.quarkus.qute.TemplateExtension;
 import io.quarkus.security.identity.SecurityIdentity;
 
 import com.scanales.eventflow.util.AdminUtils;
+import com.scanales.eventflow.model.Talk;
 
 @TemplateExtension(namespace = "app")
 public class AppTemplateExtensions {
@@ -35,5 +38,36 @@ public class AppTemplateExtensions {
     public static boolean isAdmin() {
         SecurityIdentity identity = Arc.container().instance(SecurityIdentity.class).get();
         return AdminUtils.isAdmin(identity);
+    }
+
+    /** Returns a human-readable state for the given talk based on current time. */
+    public static String talkState(Talk t) {
+        if (t == null || t.getStartTime() == null) {
+            return "A tiempo";
+        }
+        LocalTime now = LocalTime.now();
+        LocalTime start = t.getStartTime();
+        LocalTime end = t.getEndTime();
+        if (now.isAfter(end)) {
+            return "Finalizada";
+        }
+        if (!now.isBefore(start)) {
+            return "En curso";
+        }
+        long minutes = Duration.between(now, start).toMinutes();
+        if (minutes <= 15) {
+            return "Pronto";
+        }
+        return "A tiempo";
+    }
+
+    /** CSS class for the talk state badge. */
+    public static String talkStateClass(Talk t) {
+        return switch (talkState(t)) {
+            case "Pronto" -> "warning";
+            case "En curso" -> "info";
+            case "Finalizada" -> "past";
+            default -> "success";
+        };
     }
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -50,14 +50,14 @@ function hideLoading() {
 function showNotification(type, message) {
     const note = document.getElementById('notification');
     if (!note) return;
-    note.textContent = message;
+    note.innerHTML = message;
     note.className = 'notification ' + type;
     note.classList.add('show');
     setTimeout(() => {
         note.classList.remove('show');
         setTimeout(() => {
             note.className = 'notification hidden';
-            note.textContent = '';
+            note.innerHTML = '';
         }, 300);
     }, 3000);
 }

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -458,6 +458,22 @@ footer {
     to { opacity: 1; transform: translateY(0); }
 }
 
+/* Profile talk cards */
+.event-group { margin-bottom: 2rem; }
+.day-title { margin: 1rem 0 0.5rem; color: var(--color-dark); }
+.talks-day { display: grid; gap: 1rem; }
+@media (min-width: 600px) {
+    .talks-day { grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); }
+}
+.talk-card h5 { margin: 0 0 0.5rem; color: var(--color-dark); }
+.talk-card .talk-time,
+.talk-card .talk-scenario { margin: 0 0 0.5rem; font-size: 0.9rem; color: #555; }
+.badge { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.8rem; margin-bottom: 0.5rem; }
+.badge.success { background: #4caf50; color: #fff; }
+.badge.warning { background: #ff9800; color: #fff; }
+.badge.info { background: #2196f3; color: #fff; }
+.badge.past { background: #9e9e9e; color: #fff; }
+
 @keyframes spin {
     from { transform: rotate(0deg); }
     to { transform: rotate(360deg); }

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -3,27 +3,61 @@
 {#main}
 <h1>Perfil de usuario</h1>
 <p><strong>Nombre completo:</strong> {name}</p>
-<p><strong>Nombre:</strong> {givenName}</p>
-<p><strong>Apellido:</strong> {familyName}</p>
 <p><strong>Email:</strong> {email}</p>
-<p><strong>Sub:</strong> {sub}</p>
-<h2>Mis charlas:</h2>
-{#if talks.isEmpty()}
+
+<h2 class="page-title">Tus Charlas Registradas</h2>
+{#if groups.isEmpty()}
 <p>Aún no hay charlas.</p>
 {#else}
-<ul>
-{#for e in talks}
-    <li>Día {e.talk.day} - {e.talk.startTimeStr} ({e.talk.durationMinutes} min) -
-        <a href="/talk/{e.talk.id}">{e.talk.name}</a>
-        {#if e.event}
-            - <a href="/scenario/{e.talk.location}">{e.event.getScenarioName(e.talk.location)}</a>
-        {/if}
-        - <a href="/private/profile/remove/{e.talk.id}">Eliminar de mis charlas</a>
-    </li>
+{#for g in groups}
+  <div class="event-group">
+    <h3 class="event-title">{g.event.title}</h3>
+    {#for d in g.days}
+      <h4 class="day-title">Día {d.day}</h4>
+      <div class="talks-day">
+        {#for t in d.talks}
+        <div class="card talk-card" data-talk-id="{t.id}">
+          <h5><a href="/talk/{t.id}">{t.name}</a></h5>
+          <p class="talk-time">{t.startTimeStr} ({t.durationMinutes} min)</p>
+          <p class="talk-scenario">{g.event.getScenarioName(t.location)}</p>
+          <span class="badge {app:talkStateClass(t)}">{app:talkState(t)}</span>
+          <button class="btn btn-secondary remove-talk" data-talk-id="{t.id}">Eliminar</button>
+        </div>
+        {/for}
+      </div>
+    {/for}
+  </div>
 {/for}
-</ul>
 {/if}
 <p><a href="/private/admin">Admin Panel</a></p>
 <p><a href="/logout">Salir</a></p>
+<script>
+(function() {
+  document.querySelectorAll('.remove-talk').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      if (!confirm('¿Estás seguro?')) return;
+      const id = btn.dataset.talkId;
+      try {
+        const res = await fetch('/private/profile/remove/' + id, { method: 'POST', headers: { 'Accept': 'application/json' } });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.status === 'removed') {
+            showNotification('success', 'Charla eliminada');
+            const card = btn.closest('.talk-card');
+            if (card) card.remove();
+          } else {
+            showNotification('error', 'Charla no encontrada');
+          }
+        } else {
+          showNotification('error', 'Ocurrió un error al eliminar la charla');
+        }
+      } catch (e) {
+        showNotification('error', 'Ocurrió un error al eliminar la charla');
+      }
+    });
+  });
+})();
+</script>
 {/main}
 {/include}
+

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -21,7 +21,45 @@ Charla
   {/if}
   <p><strong>Duración:</strong> {talk.durationMinutes} min</p>
   {#if app:isAuthenticated()}
-  <p><a href="/private/profile/add/{talk.id}">Agregar a mis charlas</a></p>
+  <p>
+    <button id="addTalkBtn" class="btn">
+      {#if inSchedule}<span class="icon">✔</span> Agregada{#else}<span class="icon">➕</span> Agregar a mis charlas{/if}
+    </button>
+  </p>
+  <script>
+  (function() {
+    const btn = document.getElementById('addTalkBtn');
+    if (!btn) return;
+    if ({inSchedule}) {
+      btn.disabled = true;
+      btn.classList.add('btn-secondary');
+    }
+    btn.addEventListener('click', async () => {
+      if (btn.disabled) return;
+      try {
+        const res = await fetch('/private/profile/add/{talk.id}', {
+          method: 'POST',
+          headers: { 'Accept': 'application/json' }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          if (data.status === 'added') {
+            showNotification('success', 'Charla agregada. <a href="/private/profile">Ver en Mis Charlas</a>');
+          } else if (data.status === 'exists') {
+            showNotification('info', 'La charla ya estaba registrada. <a href="/private/profile">Ver en Mis Charlas</a>');
+          }
+          btn.disabled = true;
+          btn.classList.add('btn-secondary');
+          btn.innerHTML = '<span class="icon">✔</span> Agregada';
+        } else {
+          showNotification('error', 'Ocurrió un error al registrar la charla');
+        }
+      } catch (e) {
+        showNotification('error', 'Ocurrió un error al registrar la charla');
+      }
+    });
+  })();
+  </script>
   {/if}
   {#if !occurrences.isEmpty()}
   <div class="card">


### PR DESCRIPTION
## Summary
- add asynchronous talk registration with toast feedback
- redesign profile page with grouped talk cards and remove actions
- show talk timing status badges

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689203a6b4348333b59a6e39a6fda6b3