### PR TITLE
feat: enrich event detail view with contact and social links

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -24,6 +24,20 @@ public class Event {
     private int days = 1;
     /** URL or identifier for the venue map. */
     private String mapUrl;
+    /** URL of the event logo. */
+    private String logoUrl;
+    /** Contact email for the event organizers. */
+    private String contactEmail;
+    /** Official website of the event. */
+    private String website;
+    /** Link to the event's Twitter/X profile. */
+    private String twitter;
+    /** Link to the event's LinkedIn profile. */
+    private String linkedin;
+    /** Link to the event's Instagram profile. */
+    private String instagram;
+    /** URL to obtain tickets for the event. */
+    private String ticketsUrl;
     private List<Talk> agenda = new ArrayList<>();
     /** Time when the event was created. */
     private LocalDateTime createdAt;
@@ -103,6 +117,62 @@ public class Event {
 
     public void setMapUrl(String mapUrl) {
         this.mapUrl = mapUrl;
+    }
+
+    public String getLogoUrl() {
+        return logoUrl;
+    }
+
+    public void setLogoUrl(String logoUrl) {
+        this.logoUrl = logoUrl;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public void setContactEmail(String contactEmail) {
+        this.contactEmail = contactEmail;
+    }
+
+    public String getWebsite() {
+        return website;
+    }
+
+    public void setWebsite(String website) {
+        this.website = website;
+    }
+
+    public String getTwitter() {
+        return twitter;
+    }
+
+    public void setTwitter(String twitter) {
+        this.twitter = twitter;
+    }
+
+    public String getLinkedin() {
+        return linkedin;
+    }
+
+    public void setLinkedin(String linkedin) {
+        this.linkedin = linkedin;
+    }
+
+    public String getInstagram() {
+        return instagram;
+    }
+
+    public void setInstagram(String instagram) {
+        this.instagram = instagram;
+    }
+
+    public String getTicketsUrl() {
+        return ticketsUrl;
+    }
+
+    public void setTicketsUrl(String ticketsUrl) {
+        this.ticketsUrl = ticketsUrl;
     }
 
     public List<Talk> getAgenda() {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -92,13 +92,27 @@ public class AdminEventResource {
     @Authenticated
     public Response saveEvent(@FormParam("title") String title,
                               @FormParam("description") String description,
-                              @FormParam("days") int days) {
+                              @FormParam("days") int days,
+                              @FormParam("logoUrl") String logoUrl,
+                              @FormParam("contactEmail") String contactEmail,
+                              @FormParam("website") String website,
+                              @FormParam("twitter") String twitter,
+                              @FormParam("linkedin") String linkedin,
+                              @FormParam("instagram") String instagram,
+                              @FormParam("ticketsUrl") String ticketsUrl) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
         var now = java.time.LocalDateTime.now();
         String id = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(now);
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
+        event.setLogoUrl(sanitizeUrl(logoUrl));
+        event.setContactEmail(sanitizeEmail(contactEmail));
+        event.setWebsite(sanitizeUrl(website));
+        event.setTwitter(sanitizeUrl(twitter));
+        event.setLinkedin(sanitizeUrl(linkedin));
+        event.setInstagram(sanitizeUrl(instagram));
+        event.setTicketsUrl(sanitizeUrl(ticketsUrl));
         eventService.saveEvent(event);
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/private/admin/events")
@@ -111,7 +125,14 @@ public class AdminEventResource {
     public Response updateEvent(@PathParam("id") String id,
                                 @FormParam("title") String title,
                                 @FormParam("description") String description,
-                                @FormParam("days") int days) {
+                                @FormParam("days") int days,
+                                @FormParam("logoUrl") String logoUrl,
+                                @FormParam("contactEmail") String contactEmail,
+                                @FormParam("website") String website,
+                                @FormParam("twitter") String twitter,
+                                @FormParam("linkedin") String linkedin,
+                                @FormParam("instagram") String instagram,
+                                @FormParam("ticketsUrl") String ticketsUrl) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
@@ -122,6 +143,13 @@ public class AdminEventResource {
         event.setTitle(title);
         event.setDescription(description);
         event.setDays(days);
+        event.setLogoUrl(sanitizeUrl(logoUrl));
+        event.setContactEmail(sanitizeEmail(contactEmail));
+        event.setWebsite(sanitizeUrl(website));
+        event.setTwitter(sanitizeUrl(twitter));
+        event.setLinkedin(sanitizeUrl(linkedin));
+        event.setInstagram(sanitizeUrl(instagram));
+        event.setTicketsUrl(sanitizeUrl(ticketsUrl));
         eventService.saveEvent(event);
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/event/" + id)
@@ -349,10 +377,37 @@ public class AdminEventResource {
         return event.getId() != null && !event.getId().isBlank() && hasLists;
     }
 
+    private String sanitizeUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        try {
+            var u = new java.net.URL(url);
+            u.toURI();
+            return url;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String sanitizeEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return null;
+        }
+        return email.contains("@") ? email : null;
+    }
+
     private void fillDefaults(Event event) {
         if (event.getTitle() == null) event.setTitle("VACIO");
         if (event.getDescription() == null) event.setDescription("VACIO");
         if (event.getMapUrl() == null) event.setMapUrl("VACIO");
+        if (event.getLogoUrl() == null) event.setLogoUrl("VACIO");
+        if (event.getContactEmail() == null) event.setContactEmail("VACIO");
+        if (event.getWebsite() == null) event.setWebsite("VACIO");
+        if (event.getTwitter() == null) event.setTwitter("VACIO");
+        if (event.getLinkedin() == null) event.setLinkedin("VACIO");
+        if (event.getInstagram() == null) event.setInstagram("VACIO");
+        if (event.getTicketsUrl() == null) event.setTicketsUrl("VACIO");
         if (event.getCreator() == null) event.setCreator("VACIO");
         if (event.getCreatedAt() == null) event.setCreatedAt(java.time.LocalDateTime.now());
 

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -374,6 +374,40 @@ button:focus-visible {
     margin: 0 0 1rem;
 }
 
+/* Event detail header */
+.event-summary .event-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.event-summary .event-logo {
+    max-width: 150px;
+    height: auto;
+}
+
+.event-summary .event-info {
+    flex: 1;
+}
+
+.event-links {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+@media (max-width: 600px) {
+    .event-summary .event-header {
+        flex-direction: column;
+        text-align: center;
+    }
+    .event-links {
+        justify-content: center;
+    }
+}
+
 /* Grid of scenario cards on event detail */
 .scenario-grid {
     display: grid;

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -34,6 +34,23 @@ Nuevo Evento
     <textarea id="description" name="description">{event.description}</textarea>
     <label for="days">Días del evento</label>
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
+    <label for="logoUrl">Logo URL</label>
+    <input id="logoUrl" name="logoUrl" type="url" value="{event.logoUrl}">
+    <label for="website">Sitio Web</label>
+    <input id="website" name="website" type="url" value="{event.website}">
+    <label for="contactEmail">Correo de contacto</label>
+    <input id="contactEmail" name="contactEmail" type="email" value="{event.contactEmail}">
+    <label for="ticketsUrl">Link de entradas</label>
+    <input id="ticketsUrl" name="ticketsUrl" type="url" value="{event.ticketsUrl}">
+    <fieldset>
+      <legend>Redes Sociales</legend>
+      <label for="twitter">Twitter/X</label>
+      <input id="twitter" name="twitter" type="url" value="{event.twitter}">
+      <label for="linkedin">LinkedIn</label>
+      <input id="linkedin" name="linkedin" type="url" value="{event.linkedin}">
+      <label for="instagram">Instagram</label>
+      <input id="instagram" name="instagram" type="url" value="{event.instagram}">
+    </fieldset>
     <button type="submit">Guardar</button>
 </form>
 </section>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -14,11 +14,28 @@ Evento
 {#main}
 {#if event}
 <section class="event-detail">
-  <h1 class="page-title">{event.title}</h1>
-  <div class="card">
-    <p>{event.description}</p>
+  <div class="card event-summary">
+    <div class="event-header">
+      {#if event.logoUrl}
+      <img src="{event.logoUrl}" alt="Logo de {event.title}" class="event-logo">
+      {/if}
+      <div class="event-info">
+        <h1 class="page-title">{event.title}</h1>
+        {#if event.description}
+        <p class="event-description">{event.description}</p>
+        {/if}
+        <div class="event-links">
+          {#if event.website}<a href="{event.website}" target="_blank" rel="noopener" class="btn">🌐 Sitio Web</a>{/if}
+          {#if event.twitter}<a href="{event.twitter}" target="_blank" rel="noopener" class="btn">🐦 Twitter</a>{/if}
+          {#if event.linkedin}<a href="{event.linkedin}" target="_blank" rel="noopener" class="btn">💼 LinkedIn</a>{/if}
+          {#if event.instagram}<a href="{event.instagram}" target="_blank" rel="noopener" class="btn">📸 Instagram</a>{/if}
+          {#if event.contactEmail}<a href="mailto:{event.contactEmail}" target="_blank" rel="noopener" class="btn">📧 Email</a>{/if}
+          {#if event.ticketsUrl}<a href="{event.ticketsUrl}" target="_blank" rel="noopener" class="btn">🎟️ Entradas</a>{/if}
+        </div>
+      </div>
+    </div>
     {#if event.mapUrl}
-      <p><strong>Lugar:</strong> <a href="{event.mapUrl}" target="_blank">Ver mapa</a></p>
+      <p><strong>Lugar:</strong> <a href="{event.mapUrl}" target="_blank" rel="noopener">Ver mapa</a></p>
     {/if}
     <p><strong>Duración:</strong> {event.days} día{#if event.days > 1}s{/if}</p>
   </div>


### PR DESCRIPTION
## Summary
- extend event model with logo, website, socials, contact and ticket URLs
- show logo, description and quick access links on event detail page
- allow editing new fields in admin UI with basic URL/email validation and responsive styling

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68921e47b6c08333ac388468e6bf390c