### PR TITLE
feat: improve event previews on home page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -212,6 +212,25 @@ public class Event {
     }
 
     /**
+     * Returns a short summary of the description limited to the first paragraph
+     * and a maximum of 150 characters.
+     */
+    public String getDescriptionSummary() {
+        if (description == null || description.isBlank()) {
+            return "";
+        }
+        String summary = description.strip();
+        int newline = summary.indexOf('\n');
+        if (newline >= 0) {
+            summary = summary.substring(0, newline);
+        }
+        if (summary.length() > 150) {
+            summary = summary.substring(0, 150).trim() + "...";
+        }
+        return summary;
+    }
+
+    /**
      * Returns a list with values from 1 to {@code days} to easily iterate in templates.
      */
     public java.util.List<Integer> getDayList() {

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -328,6 +328,8 @@ button:focus-visible {
     flex-direction: column;
     transition: transform 0.2s ease;
     animation: fadeInUp 0.3s ease;
+    text-decoration: none;
+    color: var(--color-dark);
 }
 
 .event-card:hover {
@@ -335,31 +337,31 @@ button:focus-visible {
 }
 
 .event-image {
-    width: 100%;
-    height: 150px;
     background-color: var(--color-accent);
     display: flex;
     align-items: center;
     justify-content: center;
+    height: 120px;
+    padding: 1rem;
 }
 
 .event-image img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+    max-width: 120px;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.no-logo {
+    color: var(--color-light);
+    font-size: 0.9rem;
+    text-align: center;
 }
 
 .event-content {
     padding: 1rem;
-    text-align: left;
     flex-grow: 1;
     display: flex;
     flex-direction: column;
-}
-
-.event-content .btn {
-    margin-top: auto;
-    align-self: flex-start;
 }
 
 .event-name {
@@ -368,10 +370,31 @@ button:focus-visible {
     color: var(--color-dark);
 }
 
-.event-date {
+
+.event-excerpt {
     font-size: 0.9rem;
     color: #555;
     margin: 0 0 1rem;
+}
+
+.event-more {
+    margin-top: auto;
+    font-weight: bold;
+    color: var(--color-primary);
+}
+
+@media (min-width: 600px) {
+    .event-card {
+        flex-direction: row;
+        align-items: center;
+    }
+    .event-image {
+        width: 120px;
+        height: 120px;
+    }
+    .event-content {
+        text-align: left;
+    }
 }
 
 /* Event detail header */

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -9,16 +9,22 @@
     {#else}
         <div class="event-grid">
         {#for e in events}
-            <article class="event-card">
+            <a href="/event/{e.id}" class="event-card">
                 <div class="event-image">
-                    <img src="/img/eventflow-logo.png" alt="Imagen de {e.title}">
+                    {#if app:validUrl(e.logoUrl)}
+                        <img src="{e.logoUrl}" alt="Logo de {e.title}">
+                    {#else}
+                        <div class="no-logo">Sin logo disponible</div>
+                    {/if}
                 </div>
                 <div class="event-content">
                     <h2 class="event-name">{e.title}</h2>
-                    <p class="event-date">{e.formattedCreatedAt}</p>
-                    <a href="/event/{e.id}" class="btn">Ver detalles</a>
+                    {#if e.description}
+                        <p class="event-excerpt">{e.descriptionSummary}</p>
+                    {/if}
+                    <span class="event-more">Ver más</span>
                 </div>
-            </article>
+            </a>
         {/for}
         </div>
     {/if}


### PR DESCRIPTION
## Summary
- show event logo or placeholder in the home event list
- display short description with "Ver más" link and make the entire card clickable
- add helper for description summaries

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892a18060588333965a6700cca16ffc