### PR TITLE
fix: handle anonymous talk view

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -67,9 +67,12 @@ public class TalkResource {
             if (identity != null && !identity.isAnonymous()) {
                 String email = identity.getAttribute("email");
                 if (email == null) {
-                    email = identity.getPrincipal().getName();
+                    var principal = identity.getPrincipal();
+                    email = principal != null ? principal.getName() : null;
                 }
-                inSchedule = userSchedule.getTalksForUser(email).contains(id);
+                if (email != null) {
+                    inSchedule = userSchedule.getTalksForUser(email).contains(id);
+                }
             }
             return Response.ok(Templates.detail(talk, event, occurrences, inSchedule)).build();
         } catch (Exception e) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -28,6 +28,9 @@ public class UserScheduleService {
 
     /** Returns the set of talk ids registered by the user. */
     public Set<String> getTalksForUser(String email) {
+        if (email == null) {
+            return java.util.Set.of();
+        }
         Map<String, TalkDetails> talks = schedules.get(email);
         return talks == null ? java.util.Set.of() : talks.keySet();
     }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -1,0 +1,53 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.model.Speaker;
+import com.scanales.eventflow.service.EventService;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class TalkResourceTest {
+
+    @Inject
+    EventService eventService;
+
+    private static final String EVENT_ID = "e1";
+    private static final String TALK_ID = "t1";
+
+    @BeforeEach
+    public void setup() {
+        Event event = new Event(EVENT_ID, "Evento", "desc");
+        Talk talk = new Talk(TALK_ID, "Charla de prueba");
+        talk.setSpeaker(new Speaker("s1", "Speaker"));
+        talk.setStartTime(LocalTime.of(10, 0));
+        talk.setDurationMinutes(60);
+        event.getAgenda().add(talk);
+        eventService.saveEvent(event);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        eventService.deleteEvent(EVENT_ID);
+    }
+
+    @Test
+    public void anonymousUserCanViewTalk() {
+        given()
+            .when().get("/talk/" + TALK_ID)
+            .then()
+            .statusCode(200)
+            .body(containsString("Charla de prueba"));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid NPE when loading talk detail without authentication
- guard UserScheduleService against null emails
- cover anonymous talk access with test

## Testing
- `mvn test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68948700142483339dcb84663636a37f