### PR TITLE
Prevent failure when user email missing in talk registration

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -22,6 +22,9 @@ public class UserScheduleService {
 
     /** Adds the talk id to the schedule for the given user email. */
     public boolean addTalkForUser(String email, String talkId) {
+        if (email == null || talkId == null) {
+            return false;
+        }
         return schedules.computeIfAbsent(email, k -> new ConcurrentHashMap<>())
                 .putIfAbsent(talkId, new TalkDetails()) == null;
     }
@@ -37,11 +40,15 @@ public class UserScheduleService {
 
     /** Returns the map of talk details for the user. */
     public Map<String, TalkDetails> getTalkDetailsForUser(String email) {
+        if (email == null) {
+            return java.util.Map.of();
+        }
         return schedules.getOrDefault(email, java.util.Map.of());
     }
 
     /** Updates the stored details for a given talk. */
     public boolean updateTalk(String email, String talkId, Boolean attended, Integer rating, Set<String> motivations) {
+        if (email == null || talkId == null) return false;
         Map<String, TalkDetails> talks = schedules.get(email);
         if (talks == null) return false;
         TalkDetails details = talks.get(talkId);
@@ -61,6 +68,7 @@ public class UserScheduleService {
 
     /** Removes the talk id from the user schedule. */
     public boolean removeTalkForUser(String email, String talkId) {
+        if (email == null || talkId == null) return false;
         Map<String, TalkDetails> talks = schedules.get(email);
         if (talks != null) {
             boolean removed = talks.remove(talkId) != null;
@@ -76,6 +84,9 @@ public class UserScheduleService {
     public record Summary(int total, long attended, long rated) {}
 
     public Summary getSummaryForUser(String email) {
+        if (email == null) {
+            return new Summary(0, 0, 0);
+        }
         Map<String, TalkDetails> talks = schedules.get(email);
         if (talks == null) {
             return new Summary(0, 0, 0);

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleServiceTest.java
@@ -45,5 +45,15 @@ public class UserScheduleServiceTest {
         assertEquals(0, summary.attended());
         assertEquals(0, summary.rated());
     }
+
+    @Test
+    public void ignoreNullUser() {
+        UserScheduleService svc = new UserScheduleService();
+
+        assertFalse(svc.addTalkForUser(null, "t1"));
+        assertTrue(svc.getTalksForUser(null).isEmpty());
+        assertTrue(svc.getTalkDetailsForUser(null).isEmpty());
+        assertEquals(0, svc.getSummaryForUser(null).total());
+    }
 }
 


### PR DESCRIPTION
## Summary
- Avoid NullPointerExceptions in `UserScheduleService` by validating email and talk id across schedule operations
- Add unit test ensuring null users are ignored instead of causing errors

## Testing
- `mvn -q test` *(fails: could not resolve io.quarkus.platform:quarkus-bom:pom:3.24.3 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894dd05a0a0833380474efc0ed9fe65