### PR TITLE
feat: unify talk representation across features

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/TalkInfo.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/TalkInfo.java
@@ -1,0 +1,7 @@
+package com.scanales.eventflow.model;
+
+/**
+ * Combines a talk with its parent event for reuse across the application.
+ */
+public record TalkInfo(Talk talk, Event event) {}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/MyEventsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/MyEventsResource.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.model.TalkInfo;
 import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.UserScheduleService;
 
@@ -55,12 +56,7 @@ public class MyEventsResource {
 
         var talkIds = userSchedule.getTalksForUser(email);
         List<TalkInfo> talks = talkIds.stream()
-                .map(tid -> {
-                    Talk t = eventService.findTalk(tid);
-                    if (t == null) return null;
-                    Event e = eventService.findEventByTalk(tid);
-                    return new TalkInfo(t, e);
-                })
+                .map(eventService::findTalkInfo)
                 .filter(java.util.Objects::nonNull)
                 .toList();
 
@@ -73,8 +69,6 @@ public class MyEventsResource {
 
         return Templates.myEvents(grouped.values(), name, email);
     }
-
-    public static record TalkInfo(Talk talk, Event event) {}
 
     public static record EventGroup(Event event, List<Talk> talks) {}
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Scenario;
 import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.model.TalkInfo;
 
 /** Simple in-memory store for events. */
 @ApplicationScoped
@@ -132,6 +133,16 @@ public class EventService {
                         .anyMatch(t -> t.getId().equals(talkId)))
                 .findFirst()
                 .orElse(null);
+    }
+
+    /** Returns a {@link TalkInfo} containing the talk and its parent event or {@code null}. */
+    public TalkInfo findTalkInfo(String talkId) {
+        Talk talk = findTalk(talkId);
+        if (talk == null) {
+            return null;
+        }
+        Event event = findEventByTalk(talkId);
+        return new TalkInfo(talk, event);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add TalkInfo record to represent a talk with its event
- expose EventService.findTalkInfo and refactor profile and my-events resources to use it

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894f8a0c08c8333918ffb7b7b42b604