### PR TITLE
Improve feedback when adding talks

### DIFF
--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -49,9 +49,11 @@
       try {
         const res = await fetch('/private/profile/add/{talk.id}', {
           method: 'POST',
-          headers: { 'Accept': 'application/json' }
+          headers: { 'Accept': 'application/json' },
+          credentials: 'same-origin'
         });
-        if (res.ok) {
+        const contentType = res.headers.get('content-type') || '';
+        if (res.ok && contentType.includes('application/json')) {
           const data = await res.json();
           if (data.status === 'added') {
             showNotification('success', 'Charla agregada. <a href="/private/profile">Ver en Mis Charlas</a>');
@@ -61,6 +63,8 @@
           btn.disabled = true;
           btn.classList.add('btn-secondary');
           btn.innerHTML = '<span class="icon">✔</span> Agregada';
+        } else if (res.status === 401) {
+          showNotification('info', 'Debe iniciar sesión para agregar la charla');
         } else {
           showNotification('error', 'Ocurrió un error al registrar la charla');
         }


### PR DESCRIPTION
## Summary
- handle non-JSON and unauthorized responses when adding a talk

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68950ed8e1f48333a820b7efcb28c0a7