### PR TITLE
Fix API contract for schedule add/remove endpoints

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-qute</artifactId>
         </dependency>
         <dependency>
@@ -54,14 +58,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jsonb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-qute</artifactId>
         </dependency>
         <dependency>

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -158,7 +158,7 @@ public class ProfileResource {
             if (info != null) {
                 body.put("eventId", info.event().getId());
             }
-            return Response.ok(body).build();
+            return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
         }
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/talk/" + id)
@@ -185,7 +185,9 @@ public class ProfileResource {
         boolean removed = userSchedule.removeTalkForUser(email, id);
         String status = removed ? "removed" : "missing";
         if (acceptsJson(headers)) {
-            return Response.ok(java.util.Map.of("status", status, "talkId", id)).build();
+            return Response.ok(java.util.Map.of("status", status, "talkId", id))
+                    .type(MediaType.APPLICATION_JSON)
+                    .build();
         }
         return Response.status(Response.Status.SEE_OTHER)
                 .header("Location", "/private/profile")
@@ -193,8 +195,8 @@ public class ProfileResource {
     }
 
     private boolean acceptsJson(HttpHeaders headers) {
-        return headers.getAcceptableMediaTypes().stream()
-                .anyMatch(mt -> mt.isCompatible(MediaType.APPLICATION_JSON_TYPE));
+        String accept = headers.getHeaderString(HttpHeaders.ACCEPT);
+        return accept != null && accept.toLowerCase().contains(MediaType.APPLICATION_JSON);
     }
 
     private String getClaim(String claimName) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -156,7 +156,7 @@ public class ProfileResource {
             body.put("status", status);
             body.put("talkId", id);
             if (info != null) {
-                body.put("eventId", info.event().id());
+                body.put("eventId", info.event().getId());
             }
             return Response.ok(body).build();
         }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -22,6 +22,8 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -143,12 +145,24 @@ public class ProfileResource {
     @POST
     @Path("add/{id}")
     @Authenticated
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response addTalk(@PathParam("id") String id) {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_HTML })
+    public Response addTalk(@PathParam("id") String id, @Context HttpHeaders headers) {
         String email = getEmail();
         boolean added = userSchedule.addTalkForUser(email, id);
         String status = added ? "added" : "exists";
-        return Response.ok(java.util.Map.of("status", status)).build();
+        if (acceptsJson(headers)) {
+            var info = eventService.findTalkInfo(id);
+            java.util.Map<String, Object> body = new java.util.HashMap<>();
+            body.put("status", status);
+            body.put("talkId", id);
+            if (info != null) {
+                body.put("eventId", info.event().id());
+            }
+            return Response.ok(body).build();
+        }
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/talk/" + id)
+                .build();
     }
 
     @GET
@@ -165,12 +179,22 @@ public class ProfileResource {
     @POST
     @Path("remove/{id}")
     @Authenticated
-    @Produces(MediaType.APPLICATION_JSON)
-    public Response removeTalk(@PathParam("id") String id) {
+    @Produces({ MediaType.APPLICATION_JSON, MediaType.TEXT_HTML })
+    public Response removeTalk(@PathParam("id") String id, @Context HttpHeaders headers) {
         String email = getEmail();
         boolean removed = userSchedule.removeTalkForUser(email, id);
         String status = removed ? "removed" : "missing";
-        return Response.ok(java.util.Map.of("status", status)).build();
+        if (acceptsJson(headers)) {
+            return Response.ok(java.util.Map.of("status", status, "talkId", id)).build();
+        }
+        return Response.status(Response.Status.SEE_OTHER)
+                .header("Location", "/private/profile")
+                .build();
+    }
+
+    private boolean acceptsJson(HttpHeaders headers) {
+        return headers.getAcceptableMediaTypes().stream()
+                .anyMatch(mt -> mt.isCompatible(MediaType.APPLICATION_JSON_TYPE));
     }
 
     private String getClaim(String claimName) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -6,9 +6,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jboss.logging.Logger;
+
 /** In-memory store for user schedules and talk details. */
 @ApplicationScoped
 public class UserScheduleService {
+
+    private static final Logger LOG = Logger.getLogger(UserScheduleService.class);
 
     /** Stores user email -> (talkId -> details). */
     private final Map<String, Map<String, TalkDetails>> schedules = new ConcurrentHashMap<>();
@@ -25,8 +29,11 @@ public class UserScheduleService {
         if (email == null || talkId == null) {
             return false;
         }
-        return schedules.computeIfAbsent(email, k -> new ConcurrentHashMap<>())
+        boolean added = schedules.computeIfAbsent(email, k -> new ConcurrentHashMap<>())
                 .putIfAbsent(talkId, new TalkDetails()) == null;
+        LOG.infov("addTalk(user={0}, talk={1}, result={2})", email, talkId,
+                added ? "added" : "exists");
+        return added;
     }
 
     /** Returns the set of talk ids registered by the user. */
@@ -75,8 +82,11 @@ public class UserScheduleService {
             if (talks.isEmpty()) {
                 schedules.remove(email);
             }
+            LOG.infov("removeTalk(user={0}, talk={1}, result={2})", email, talkId,
+                    removed ? "removed" : "not-found");
             return removed;
         }
+        LOG.infov("removeTalk(user={0}, talk={1}, result=not-found)", email, talkId);
         return false;
     }
 

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -100,23 +100,36 @@
       btn.addEventListener('click', async () => {
         if (!confirm('¿Estás seguro?')) return;
         const id = btn.dataset.talkId;
+        btn.disabled = true;
         try {
-          const res = await fetch('/private/profile/remove/' + id, { method: 'POST', headers: { 'Accept': 'application/json' } });
-          if (res.ok) {
+          const res = await fetch('/private/profile/remove/' + id, {
+            method: 'POST',
+            headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+            body: '{}'
+          });
+          const contentType = res.headers.get('content-type') || '';
+          if (res.ok && contentType.includes('application/json')) {
             const data = await res.json();
             if (data.status === 'removed') {
               const card = btn.closest('.talk-card');
               if (card) card.remove();
               updateSummary();
-              showNotification('success', 'Charla eliminada');
+              showNotification('success', 'Charla eliminada de tu agenda');
+              return;
+            } else if (data.status === 'error') {
+              showNotification('error', data.message || 'Ocurrió un error');
             } else {
               showNotification('error', 'Charla no encontrada');
             }
+          } else if (res.status === 401) {
+            showNotification('info', 'Debe iniciar sesión');
           } else {
             showNotification('error', 'Ocurrió un error al eliminar la charla');
           }
         } catch (e) {
           showNotification('error', 'Ocurrió un error al eliminar la charla');
+        } finally {
+          btn.disabled = false;
         }
       });
     });

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -46,30 +46,43 @@
     }
     btn.addEventListener('click', async () => {
       if (btn.disabled) return;
+      btn.disabled = true;
       try {
         const res = await fetch('/private/profile/add/{talk.id}', {
           method: 'POST',
-          headers: { 'Accept': 'application/json' },
-          credentials: 'same-origin'
+          headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+          credentials: 'same-origin',
+          body: '{}'
         });
         const contentType = res.headers.get('content-type') || '';
         if (res.ok && contentType.includes('application/json')) {
           const data = await res.json();
           if (data.status === 'added') {
-            showNotification('success', 'Charla agregada. <a href="/private/profile">Ver en Mis Charlas</a>');
+            showNotification('success', 'Charla agregada a tu agenda');
+            btn.classList.add('btn-secondary');
+            btn.innerHTML = '<span class="icon">✔</span> Agregada';
           } else if (data.status === 'exists') {
             showNotification('info', 'La charla ya estaba registrada. <a href="/private/profile">Ver en Mis Charlas</a>');
+            btn.classList.add('btn-secondary');
+            btn.innerHTML = '<span class="icon">✔</span> Agregada';
+          } else if (data.status === 'error') {
+            showNotification('error', data.message || 'Ocurrió un error');
+            btn.disabled = false;
+            return;
           }
-          btn.disabled = true;
-          btn.classList.add('btn-secondary');
-          btn.innerHTML = '<span class="icon">✔</span> Agregada';
         } else if (res.status === 401) {
           showNotification('info', 'Debe iniciar sesión para agregar la charla');
+          btn.disabled = false;
+          return;
         } else {
           showNotification('error', 'Ocurrió un error al registrar la charla');
+          btn.disabled = false;
+          return;
         }
       } catch (e) {
         showNotification('error', 'Ocurrió un error al registrar la charla');
+        btn.disabled = false;
+        return;
       }
     });
   })();

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -1,0 +1,79 @@
+package com.scanales.eventflow.private_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+
+@QuarkusTest
+public class ProfileResourceTest {
+
+    @Test
+    @TestSecurity(user = "user@example.com")
+    public void addTalkJson() {
+        given()
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .body("{}")
+        .when()
+            .post("/private/profile/add/t1")
+        .then()
+            .statusCode(200)
+            .body("status", is("added"))
+            .body("talkId", is("t1"));
+    }
+
+    @Test
+    @TestSecurity(user = "user@example.com")
+    public void removeTalkJson() {
+        // ensure talk exists
+        given().header("Accept", "application/json").header("Content-Type", "application/json").body("{}")
+            .post("/private/profile/add/t2").then().statusCode(200);
+
+        given()
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .body("{}")
+        .when()
+            .post("/private/profile/remove/t2")
+        .then()
+            .statusCode(200)
+            .body("status", is("removed"))
+            .body("talkId", is("t2"));
+    }
+
+    @Test
+    @TestSecurity(user = "user@example.com")
+    public void addTalkHtmlRedirect() {
+        given()
+            .header("Accept", "text/html")
+            .header("Content-Type", "application/json")
+            .body("{}")
+        .when()
+            .post("/private/profile/add/t3")
+        .then()
+            .statusCode(303)
+            .header("Location", endsWith("/talk/t3"));
+    }
+
+    @Test
+    @TestSecurity(user = "user@example.com")
+    public void removeTalkHtmlRedirect() {
+        // ensure talk exists
+        given().header("Accept", "application/json").header("Content-Type", "application/json").body("{}")
+            .post("/private/profile/add/t4").then().statusCode(200);
+
+        given()
+            .header("Accept", "text/html")
+            .header("Content-Type", "application/json")
+            .body("{}")
+        .when()
+            .post("/private/profile/remove/t4")
+        .then()
+            .statusCode(303)
+            .header("Location", endsWith("/private/profile"));
+    }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -49,6 +49,7 @@ public class ProfileResourceTest {
     @TestSecurity(user = "user@example.com")
     public void addTalkHtmlRedirect() {
         given()
+            .redirects().follow(false)
             .header("Accept", "text/html")
             .header("Content-Type", "application/json")
             .body("{}")
@@ -67,6 +68,7 @@ public class ProfileResourceTest {
             .post("/private/profile/add/t4").then().statusCode(200);
 
         given()
+            .redirects().follow(false)
             .header("Accept", "text/html")
             .header("Content-Type", "application/json")
             .body("{}")


### PR DESCRIPTION
## Summary
- Return JSON or HTML redirects for profile add/remove based on Accept header
- Improve client-side handling of add/remove responses and messages
- Log add/remove operations in UserScheduleService and add tests for content negotiation

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: io.quarkus.platform:quarkus-bom:pom:3.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_689533f0b9608333bda090f865d86ac5