### PR TITLE
Simplify navigation by removing Events menu item

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -8,6 +8,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
 import com.scanales.eventflow.service.EventService;
 import jakarta.inject.Inject;
 
@@ -28,5 +30,14 @@ public class HomeResource {
     public TemplateInstance home() {
         var events = eventService.listEvents();
         return Templates.home(events);
+    }
+
+    @GET
+    @Path("/events")
+    @PermitAll
+    public Response legacyEvents() {
+        return Response.status(Response.Status.MOVED_PERMANENTLY)
+                .location(URI.create("/"))
+                .build();
     }
 }

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -8,7 +8,7 @@ Evento
 {/title}
 {#breadcrumbs}
   {#if event}
-  <a href="/">Eventos</a><span class="sep">/</span><span>{event.title}</span>
+  <a href="/">Inicio</a><span class="sep">/</span><span>{event.title}</span>
   {/if}
 {/breadcrumbs}
 {#main}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -1,6 +1,6 @@
 {#include layout/base}
 {#title}Inicio{/title}
-{#breadcrumbs}<span>Eventos</span>{/breadcrumbs}
+{#breadcrumbs}<span>Inicio</span>{/breadcrumbs}
 {#main}
 <section class="home-section">
     <h1 class="page-title">Eventos disponibles</h1>

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -8,7 +8,7 @@ Escenario
 {/title}
 {#breadcrumbs}
   {#if scenario}
-  <a href="/">Eventos</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><span>Escenario: {scenario.name}</span>
+  <a href="/">Inicio</a><span class="sep">/</span><a href="/event/{event.id}">{event.title}</a><span class="sep">/</span><span>Escenario: {scenario.name}</span>
   {/if}
 {/breadcrumbs}
 {#main}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -4,7 +4,7 @@
 {/title}
 {#breadcrumbs}
 {#if talk}
-<a href="/">Eventos</a>
+<a href="/">Inicio</a>
 {#if event}<span class="sep">/</span><a href="/event/{event.id}">{event.title}</a>{/if}
 {#if talk.location && event}<span class="sep">/</span><a href="/scenario/{talk.location}">{event.getScenarioName(talk.location)}</a>{/if}
 <span class="sep">/</span><span>Charla: {talk.name ?: talk.id}</span>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -14,7 +14,6 @@
     <button id="menuToggle" class="menu-toggle" aria-label="Menú" aria-controls="primary-navigation" aria-expanded="false">&#9776;</button>
     <div class="nav-links" id="primary-navigation">
         <a href="/">Inicio</a>
-        <a href="/">Eventos</a>
         {#if app:isAuthenticated()}
             <a href="/my-events">Mis Eventos</a>
             <a href="/private/profile">Mis Charlas</a>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeResourceRedirectTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeResourceRedirectTest.java
@@ -1,0 +1,21 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class HomeResourceRedirectTest {
+
+    @Test
+    public void eventsPathRedirectsToHome() {
+        given()
+            .when().get("/events")
+            .then()
+            .statusCode(301)
+            .header("Location", equalTo("/"));
+    }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeResourceRedirectTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeResourceRedirectTest.java
@@ -13,6 +13,7 @@ public class HomeResourceRedirectTest {
     @Test
     public void eventsPathRedirectsToHome() {
         given()
+            .redirects().follow(false)
             .when().get("/events")
             .then()
             .statusCode(301)

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeResourceRedirectTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeResourceRedirectTest.java
@@ -1,7 +1,7 @@
 package com.scanales.eventflow.public_;
 
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.endsWith;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,6 +17,6 @@ public class HomeResourceRedirectTest {
             .when().get("/events")
             .then()
             .statusCode(301)
-            .header("Location", equalTo("/"));
+            .header("Location", endsWith("/"));
     }
 }


### PR DESCRIPTION
## Summary
- remove duplicated "Eventos" option from the main navigation
- update breadcrumbs to use only "Inicio" across event views
- redirect legacy `/events` route to home and test the redirect

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689552281628833383d3ae953c951331