### PR TITLE
Mostrar fecha y horario de eventos

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -5,7 +5,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @RegisterForReflection
@@ -43,6 +45,8 @@ public class Event {
     private LocalDateTime createdAt;
     /** Email of the user who created the event. */
     private String creator;
+    /** Day when the event takes place. */
+    private LocalDate date;
 
     public Event() {
     }
@@ -197,6 +201,63 @@ public class Event {
 
     public void setCreator(String creator) {
         this.creator = creator;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public String getDateStr() {
+        return date == null ? "" : date.toString();
+    }
+
+    public void setDateStr(String value) {
+        if (value != null && !value.isBlank()) {
+            this.date = LocalDate.parse(value);
+        } else {
+            this.date = null;
+        }
+    }
+
+    /** Returns the event date formatted for display, e.g. "5 de septiembre de 2025". */
+    public String getFormattedDate() {
+        if (date == null) {
+            return "";
+        }
+        var formatter = java.time.format.DateTimeFormatter.ofPattern("d 'de' MMMM 'de' yyyy", new java.util.Locale("es"));
+        return date.format(formatter);
+    }
+
+    /** Returns the starting time of the event based on the earliest talk. */
+    public LocalTime getStartTime() {
+        return agenda.stream()
+                .map(Talk::getStartTime)
+                .filter(t -> t != null)
+                .min(LocalTime::compareTo)
+                .orElse(null);
+    }
+
+    /** Returns the ending time of the event based on the last scheduled talk. */
+    public LocalTime getEndTime() {
+        return agenda.stream()
+                .map(Talk::getEndTime)
+                .filter(t -> t != null)
+                .max(LocalTime::compareTo)
+                .orElse(null);
+    }
+
+    public String getStartTimeStr() {
+        LocalTime t = getStartTime();
+        return t == null ? "" : t.toString();
+    }
+
+    public String getEndTimeStr() {
+        LocalTime t = getEndTime();
+        return t == null ? "" : t.toString();
     }
 
     /**

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -92,6 +92,7 @@ public class AdminEventResource {
     @Authenticated
     public Response saveEvent(@FormParam("title") String title,
                               @FormParam("description") String description,
+                              @FormParam("date") String date,
                               @FormParam("days") int days,
                               @FormParam("logoUrl") String logoUrl,
                               @FormParam("contactEmail") String contactEmail,
@@ -106,6 +107,7 @@ public class AdminEventResource {
         var now = java.time.LocalDateTime.now();
         String id = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(now);
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
+        event.setDateStr(date);
         event.setLogoUrl(sanitizeUrl(logoUrl));
         event.setContactEmail(sanitizeEmail(contactEmail));
         event.setWebsite(sanitizeUrl(website));
@@ -125,6 +127,7 @@ public class AdminEventResource {
     public Response updateEvent(@PathParam("id") String id,
                                 @FormParam("title") String title,
                                 @FormParam("description") String description,
+                                @FormParam("date") String date,
                                 @FormParam("days") int days,
                                 @FormParam("logoUrl") String logoUrl,
                                 @FormParam("contactEmail") String contactEmail,
@@ -142,6 +145,7 @@ public class AdminEventResource {
         }
         event.setTitle(title);
         event.setDescription(description);
+        event.setDateStr(date);
         event.setDays(days);
         event.setLogoUrl(sanitizeUrl(logoUrl));
         event.setContactEmail(sanitizeEmail(contactEmail));

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -421,6 +421,24 @@ button:focus-visible {
     color: var(--color-dark);
 }
 
+.event-date {
+    font-size: 0.9rem;
+    color: #333;
+    margin: 0 0 0.25rem;
+}
+
+.event-time {
+    font-size: 0.85rem;
+    color: #555;
+    margin: 0 0 0.5rem;
+}
+
+.event-time-info {
+    font-size: 0.85rem;
+    color: #555;
+    margin: 0.5rem 0;
+}
+
 
 .event-excerpt {
     font-size: 0.9rem;
@@ -463,6 +481,11 @@ button:focus-visible {
 
 .event-summary .event-info {
     flex: 1;
+}
+
+.event-datetime {
+    font-weight: bold;
+    margin: 0.5rem 0;
 }
 
 .event-links {

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -33,6 +33,9 @@ Nuevo Evento
     <input id="title" name="title" type="text" value="{event.title}">
     <label for="description">Descripcion</label>
     <textarea id="description" name="description">{event.description}</textarea>
+    <label for="date">Fecha de realización</label>
+    <input id="date" name="date" type="date" value="{event.dateStr}">
+    <p class="event-time-info">Horario calculado: {#if event.startTimeStr}{event.startTimeStr} - {event.endTimeStr}{#else}Sin charlas{/if}</p>
     <label for="days">Días del evento</label>
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <label for="logoUrl">Logo URL</label>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -21,6 +21,9 @@ Evento
       {/if}
       <div class="event-info">
         <h1 class="page-title">{event.title}</h1>
+        {#if event.formattedDate}
+        <p class="event-datetime">{event.formattedDate} | {event.startTimeStr} – {event.endTimeStr} hrs.</p>
+        {/if}
         {#if event.description}
         <p class="event-description">{event.description}</p>
         {/if}

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -19,6 +19,12 @@
                 </div>
                 <div class="event-content">
                     <h2 class="event-name">{e.title}</h2>
+                    {#if e.formattedDate}
+                        <p class="event-date">{e.formattedDate}</p>
+                        {#if e.startTimeStr}
+                        <p class="event-time">{e.startTimeStr} - {e.endTimeStr}</p>
+                        {/if}
+                    {/if}
                     {#if e.description}
                         <p class="event-excerpt">{e.descriptionSummary}</p>
                     {/if}

--- a/quarkus-app/src/main/resources/templates/MyEventsResource/myEvents.html
+++ b/quarkus-app/src/main/resources/templates/MyEventsResource/myEvents.html
@@ -10,6 +10,9 @@
   {#for group in groups}
     <div class="event-summary">
       <h2>{group.event.title}</h2>
+      {#if group.event.formattedDate}
+      <p class="event-date">{group.event.formattedDate} | {group.event.startTimeStr} - {group.event.endTimeStr}</p>
+      {/if}
       <p>{group.event.description}</p>
       <a href="/event/{group.event.id}" class="btn btn-outline">Ver evento</a>
       <ul class="talk-list">


### PR DESCRIPTION
## Summary
- Permitir definir la fecha del evento y calcular automáticamente horarios de inicio y fin
- Mostrar fecha y horario en la administración, inicio y detalle de eventos
- Estilos para destacar la nueva información temporal

## Testing
- `mvn -q test` *(failed: Could not resolve io.quarkus.platform:quarkus-bom due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6895da9731548333b1257ba67938bee9