### PR TITLE
Improve clarity of registered talks view

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -596,15 +596,24 @@ footer {
 @media (min-width: 600px) {
     .talks-day { grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); }
 }
-.talk-card h5 { margin: 0 0 0.5rem; color: var(--color-dark); }
+.talk-card { display: flex; flex-direction: column; gap: 0.5rem; }
+.talk-card h5 { margin: 0 0 0.25rem; color: var(--color-dark); }
+.talk-card .talk-event { margin: 0; font-size: 0.95rem; color: #555; }
 .talk-card .talk-time,
-.talk-card .talk-scenario { margin: 0 0 0.5rem; font-size: 0.9rem; color: #555; }
+.talk-card .talk-scenario { margin: 0; font-size: 0.9rem; color: #555; }
 .talk-card .attendance-icon { margin-right: 0.25rem; }
 .talk-card .state-icon { margin-left: 0.25rem; }
 .talk-card .motivation-list { display: flex; flex-wrap: wrap; gap: 0.25rem; margin-bottom: 0.5rem; }
 .talk-card .motivation-badge { background: #e0e0e0; color: #333; cursor: pointer; }
-.talk-card .motivation-select,
-.talk-card .rating-select { width: 100%; margin-top: 0.5rem; }
+.talk-card .motivation-select { width: 100%; }
+.talk-card .talk-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem; margin-top: 0.5rem; }
+.talk-card .talk-actions .rating-label { margin-right: 0.25rem; }
+.talk-card .talk-actions .rating-select { min-width: 120px; }
+.talk-card .rating-select { width: 100%; }
+@media (min-width: 600px) {
+    .talk-card .motivation-select,
+    .talk-card .rating-select { width: auto; }
+}
 .filter { display: flex; gap: 0.5rem; margin: 1rem 0; }
 .filter .btn { flex: 1; }
 .badge { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 4px; font-size: 0.8rem; margin-bottom: 0.5rem; }

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -31,8 +31,9 @@
               {#if app:talkState(t) == 'Finalizada'}🕓{/if}
             </span>
           </h5>
-          <p class="talk-speaker">{#if t.speaker}{t.speaker.name}{/if}</p>
+          <p class="talk-event">{g.event.title}</p>
           <p class="talk-time">{t.startTimeStr} ({t.durationMinutes} min)</p>
+          <p class="talk-speaker">{#if t.speaker}{t.speaker.name}{/if}</p>
           <p class="talk-scenario">{g.event.getScenarioName(t.location)}</p>
           <div class="motivation-list">
             {#for m in info.get(t.id).motivations}
@@ -49,17 +50,20 @@
           <div class="attendance">
             <label><input type="checkbox" class="attended-checkbox" data-talk-id="{t.id}" {#if info.get(t.id).attended}checked{/if}> Asistí</label>
           </div>
-          <div class="rating">
-            <select class="rating-select" data-talk-id="{t.id}">
-              <option value="">Calificación</option>
-              <option value="1" {#if info.get(t.id).rating == 1}selected{/if}>1</option>
-              <option value="2" {#if info.get(t.id).rating == 2}selected{/if}>2</option>
-              <option value="3" {#if info.get(t.id).rating == 3}selected{/if}>3</option>
-              <option value="4" {#if info.get(t.id).rating == 4}selected{/if}>4</option>
-              <option value="5" {#if info.get(t.id).rating == 5}selected{/if}>5</option>
-            </select>
+          <div class="talk-actions">
+            <div class="rating">
+              <label for="rating-{t.id}" class="rating-label">⭐ Valorar</label>
+              <select id="rating-{t.id}" class="rating-select" data-talk-id="{t.id}">
+                <option value="">Calificación</option>
+                <option value="1" {#if info.get(t.id).rating == 1}selected{/if}>1</option>
+                <option value="2" {#if info.get(t.id).rating == 2}selected{/if}>2</option>
+                <option value="3" {#if info.get(t.id).rating == 3}selected{/if}>3</option>
+                <option value="4" {#if info.get(t.id).rating == 4}selected{/if}>4</option>
+                <option value="5" {#if info.get(t.id).rating == 5}selected{/if}>5</option>
+              </select>
+            </div>
+            <button class="btn btn-secondary remove-talk" data-talk-id="{t.id}">🗑️ Eliminar</button>
           </div>
-          <button class="btn btn-secondary remove-talk" data-talk-id="{t.id}">Eliminar</button>
         </div>
         {/for}
       </div>


### PR DESCRIPTION
## Summary
- Highlight event and time for each talk with clearer actions to rate or delete
- Adjust layout and spacing of talk cards for better readability
- Keep dropdowns compact on desktop and responsive on mobile

## Testing
- `mvn test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689618c74d7c8333985f92ae07a43f16