### PR TITLE
feat: improve home event timeline layout

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -261,6 +261,19 @@ public class Event {
     }
 
     /**
+     * Returns the number of days remaining from today until the event date.
+     * If the event date is in the past or not defined, zero is returned.
+     */
+    public long getDaysUntil() {
+        if (date == null) {
+            return 0;
+        }
+        long diff = java.time.temporal.ChronoUnit.DAYS
+                .between(java.time.LocalDate.now(), date);
+        return diff < 0 ? 0 : diff;
+    }
+
+    /**
      * Returns the creation date formatted for display in the UI.
      * If the date is not available, an empty string is returned.
      */

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -10,6 +10,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.util.Comparator;
+import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.service.EventService;
 import jakarta.inject.Inject;
 
@@ -28,7 +30,10 @@ public class HomeResource {
     @PermitAll
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance home() {
-        var events = eventService.listEvents();
+        var events = eventService.listEvents().stream()
+                .sorted(Comparator.comparing(Event::getDate,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
         return Templates.home(events);
     }
 

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -361,6 +361,89 @@ button:focus-visible {
     margin-top: 2rem;
 }
 
+/* Timeline of upcoming events on the home page */
+.timeline {
+    position: relative;
+    padding-left: 2rem;
+    margin-top: 2rem;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    left: 0.75rem;
+    top: 1.5rem;
+    bottom: 0;
+    width: 2px;
+    background-color: var(--color-primary);
+}
+
+.timeline-label {
+    font-weight: bold;
+    margin-left: 0;
+}
+
+.timeline-item {
+    position: relative;
+    margin-top: 2rem;
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -0.6rem;
+    top: 1rem;
+    width: 12px;
+    height: 12px;
+    background-color: var(--color-primary);
+    border-radius: 50%;
+}
+
+.event-row {
+    background-color: var(--color-light);
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    padding: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+}
+
+.event-logo {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--color-accent);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.event-logo img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.no-logo {
+    color: var(--color-light);
+    font-size: 0.8rem;
+    text-align: center;
+    padding: 0.5rem;
+}
+
+.event-info {
+    flex: 1;
+    min-width: 200px;
+}
+
+.days-left {
+    font-weight: bold;
+    margin-top: 0.5rem;
+}
+
 /* Grid of event cards on the home page */
 .event-grid {
     display: grid;

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -7,33 +7,43 @@
     {#if events.isEmpty()}
         <p class="section-subtitle no-events">No hay eventos disponibles.</p>
     {#else}
-        <div class="event-grid">
-        {#for e in events}
-            <a href="/event/{e.id}" class="event-card">
-                <div class="event-image">
-                    {#if app:validUrl(e.logoUrl)}
+        <div class="timeline">
+            <div class="timeline-label">HOY</div>
+            {#for e in events}
+            <div class="timeline-item">
+                <div class="timeline-marker"></div>
+                <article class="event-row">
+                    <div class="event-logo">
+                        {#if app:validUrl(e.logoUrl)}
                         <img src="{e.logoUrl}" alt="Logo de {e.title}">
-                    {#else}
+                        {#else}
                         <div class="no-logo">Sin logo disponible</div>
-                    {/if}
-                </div>
-                <div class="event-content">
-                    <h2 class="event-name">{e.title}</h2>
-                    {#if e.formattedDate}
-                        <p class="event-date">{e.formattedDate}</p>
-                        {#if e.startTimeStr}
-                        <p class="event-time">{e.startTimeStr} - {e.endTimeStr}</p>
                         {/if}
-                    {/if}
-                    {#if e.description}
-                        <p class="event-excerpt">{e.descriptionSummary}</p>
-                    {/if}
-                    <span class="event-more">Ver más</span>
-                </div>
-            </a>
-        {/for}
+                    </div>
+                    <div class="event-info">
+                        <h2 class="event-name"><a href="/event/{e.id}">{e.title}</a></h2>
+                        {#if e.formattedDate}
+                        <p class="event-date">{e.formattedDate}</p>
+                        {/if}
+                        {#if app:validUrl(e.website) || app:validUrl(e.twitter) || app:validUrl(e.linkedin) || app:validUrl(e.instagram) || app:validUrl(e.ticketsUrl)}
+                        <div class="event-links">
+                            {#if app:validUrl(e.website)}<a href="{e.website}" target="_blank" rel="noopener" class="btn">🌐 Sitio Web</a>{/if}
+                            {#if app:validUrl(e.twitter)}<a href="{e.twitter}" target="_blank" rel="noopener" class="btn">🐦 Twitter</a>{/if}
+                            {#if app:validUrl(e.linkedin)}<a href="{e.linkedin}" target="_blank" rel="noopener" class="btn">💼 LinkedIn</a>{/if}
+                            {#if app:validUrl(e.instagram)}<a href="{e.instagram}" target="_blank" rel="noopener" class="btn">📸 Instagram</a>{/if}
+                            {#if app:validUrl(e.ticketsUrl)}<a href="{e.ticketsUrl}" target="_blank" rel="noopener" class="btn">🎟️ Entradas</a>{/if}
+                        </div>
+                        {/if}
+                        {#if e.formattedDate}
+                        <p class="days-left">Faltan {e.daysUntil} días</p>
+                        {/if}
+                    </div>
+                </article>
+            </div>
+            {/for}
         </div>
     {/if}
 </section>
 {/main}
 {/include}
+

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
@@ -1,0 +1,55 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.service.EventService;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class HomeTimelineTest {
+
+    @Inject
+    EventService eventService;
+
+    @BeforeEach
+    public void setup() {
+        Event first = new Event("home1", "Evento Cercano", "desc");
+        first.setDate(LocalDate.now().plusDays(3));
+        Event second = new Event("home2", "Evento Lejano", "desc");
+        second.setDate(LocalDate.now().plusDays(10));
+        eventService.saveEvent(first);
+        eventService.saveEvent(second);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        eventService.listEvents().forEach(e -> eventService.deleteEvent(e.getId()));
+    }
+
+    @Test
+    public void homeShowsEventsOrderedWithCountdown() {
+        String html = given()
+                .when().get("/")
+                .then()
+                .statusCode(200)
+                .body(containsString("Faltan 3 días"))
+                .body(containsString("Faltan 10 días"))
+                .extract().asString();
+
+        Assertions.assertTrue(html.indexOf("Evento Cercano") < html.indexOf("Evento Lejano"),
+                "El evento más próximo debe aparecer primero");
+        Assertions.assertTrue(html.contains("HOY"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add countdown calculation for events and sort upcoming events
- Redesign home page into single-column timeline with links and days remaining
- Style new timeline layout and add test for ordering and countdown

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from/to central - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689623b6e5b08333bb3cc4a889c82830