### PR TITLE
feat: redesign home events timeline

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
+import java.time.LocalDate;
 import java.util.Comparator;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.service.EventService;
@@ -23,7 +24,8 @@ public class HomeResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance home(java.util.List<com.scanales.eventflow.model.Event> events);
+        static native TemplateInstance home(java.util.List<com.scanales.eventflow.model.Event> events,
+                LocalDate today);
     }
 
     @GET
@@ -34,7 +36,7 @@ public class HomeResource {
                 .sorted(Comparator.comparing(Event::getDate,
                         Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
-        return Templates.home(events);
+        return Templates.home(events, LocalDate.now());
     }
 
     @GET

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -408,6 +408,7 @@ button:focus-visible {
     flex-wrap: wrap;
     gap: 1rem;
     align-items: center;
+    justify-content: space-between;
 }
 
 .event-logo {
@@ -434,14 +435,35 @@ button:focus-visible {
     padding: 0.5rem;
 }
 
-.event-info {
+.event-main {
     flex: 1;
     min-width: 200px;
+}
+
+.event-description {
+    margin: 0.5rem 0;
+}
+
+.event-countdown {
+    text-align: right;
+    min-width: 120px;
 }
 
 .days-left {
     font-weight: bold;
     margin-top: 0.5rem;
+}
+
+@media (max-width: 600px) {
+    .event-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .event-countdown {
+        text-align: left;
+        align-self: flex-start;
+    }
 }
 
 /* Grid of event cards on the home page */

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -8,7 +8,7 @@
         <p class="section-subtitle no-events">No hay eventos disponibles.</p>
     {#else}
         <div class="timeline">
-            <div class="timeline-label">HOY</div>
+            <div class="timeline-label">Hoy: {today.format('dd/MM/yyyy')}</div>
             {#for e in events}
             <div class="timeline-item">
                 <div class="timeline-marker"></div>
@@ -20,10 +20,10 @@
                         <div class="no-logo">Sin logo disponible</div>
                         {/if}
                     </div>
-                    <div class="event-info">
+                    <div class="event-main">
                         <h2 class="event-name"><a href="/event/{e.id}">{e.title}</a></h2>
-                        {#if e.formattedDate}
-                        <p class="event-date">{e.formattedDate}</p>
+                        {#if e.descriptionSummary}
+                        <p class="event-description">{e.descriptionSummary}</p>
                         {/if}
                         {#if app:validUrl(e.website) || app:validUrl(e.twitter) || app:validUrl(e.linkedin) || app:validUrl(e.instagram) || app:validUrl(e.ticketsUrl)}
                         <div class="event-links">
@@ -34,9 +34,12 @@
                             {#if app:validUrl(e.ticketsUrl)}<a href="{e.ticketsUrl}" target="_blank" rel="noopener" class="btn">🎟️ Entradas</a>{/if}
                         </div>
                         {/if}
+                    </div>
+                    <div class="event-countdown">
                         {#if e.formattedDate}
-                        <p class="days-left">Faltan {e.daysUntil} días</p>
+                        <p class="event-date">{e.formattedDate}</p>
                         {/if}
+                        <p class="days-left">Faltan {e.daysUntil} días</p>
                     </div>
                 </article>
             </div>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -49,7 +50,8 @@ public class HomeTimelineTest {
 
         Assertions.assertTrue(html.indexOf("Evento Cercano") < html.indexOf("Evento Lejano"),
                 "El evento más próximo debe aparecer primero");
-        Assertions.assertTrue(html.contains("HOY"));
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        Assertions.assertTrue(html.contains("Hoy: " + today));
     }
 }
 


### PR DESCRIPTION
## Summary
- display current date atop event timeline
- restructure event list to full-width rows with logos, descriptions, links and countdown
- style event timeline for clearer layout and mobile responsiveness
- adjust tests for timeline date label

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68962f57fc188333b05a706bfd95c9f7