### PR TITLE
feat: allow configuring event map link

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -95,6 +95,7 @@ public class AdminEventResource {
                               @FormParam("date") String date,
                               @FormParam("days") int days,
                               @FormParam("logoUrl") String logoUrl,
+                              @FormParam("mapUrl") String mapUrl,
                               @FormParam("contactEmail") String contactEmail,
                               @FormParam("website") String website,
                               @FormParam("twitter") String twitter,
@@ -109,6 +110,7 @@ public class AdminEventResource {
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
         event.setDateStr(date);
         event.setLogoUrl(sanitizeUrl(logoUrl));
+        event.setMapUrl(sanitizeUrl(mapUrl));
         event.setContactEmail(sanitizeEmail(contactEmail));
         event.setWebsite(sanitizeUrl(website));
         event.setTwitter(sanitizeUrl(twitter));
@@ -130,6 +132,7 @@ public class AdminEventResource {
                                 @FormParam("date") String date,
                                 @FormParam("days") int days,
                                 @FormParam("logoUrl") String logoUrl,
+                                @FormParam("mapUrl") String mapUrl,
                                 @FormParam("contactEmail") String contactEmail,
                                 @FormParam("website") String website,
                                 @FormParam("twitter") String twitter,
@@ -148,6 +151,7 @@ public class AdminEventResource {
         event.setDateStr(date);
         event.setDays(days);
         event.setLogoUrl(sanitizeUrl(logoUrl));
+        event.setMapUrl(sanitizeUrl(mapUrl));
         event.setContactEmail(sanitizeEmail(contactEmail));
         event.setWebsite(sanitizeUrl(website));
         event.setTwitter(sanitizeUrl(twitter));

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -40,6 +40,8 @@ Nuevo Evento
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <label for="logoUrl">Logo URL</label>
     <input id="logoUrl" name="logoUrl" type="url" value="{event.logoUrl}">
+    <label for="mapUrl">Mapa URL</label>
+    <input id="mapUrl" name="mapUrl" type="url" value="{event.mapUrl}">
     <label for="website">Sitio Web</label>
     <input id="website" name="website" type="url" value="{event.website}">
     <label for="contactEmail">Correo de contacto</label>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventResourceMapLinkTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventResourceMapLinkTest.java
@@ -1,0 +1,57 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.service.EventService;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class EventResourceMapLinkTest {
+
+    @Inject
+    EventService eventService;
+
+    private static final String EVENT_WITH_MAP = "map1";
+    private static final String EVENT_WITHOUT_MAP = "map2";
+
+    @AfterEach
+    public void cleanup() {
+        eventService.deleteEvent(EVENT_WITH_MAP);
+        eventService.deleteEvent(EVENT_WITHOUT_MAP);
+    }
+
+    @Test
+    public void showsMapLinkWhenConfigured() {
+        Event event = new Event(EVENT_WITH_MAP, "Evento con mapa", "desc");
+        event.setMapUrl("https://example.com/map");
+        eventService.saveEvent(event);
+
+        given()
+            .when().get("/event/" + EVENT_WITH_MAP)
+            .then()
+            .statusCode(200)
+            .body(containsString("Ver mapa"))
+            .body(containsString("https://example.com/map"));
+    }
+
+    @Test
+    public void hidesMapLinkWhenMissing() {
+        Event event = new Event(EVENT_WITHOUT_MAP, "Evento sin mapa", "desc");
+        eventService.saveEvent(event);
+
+        given()
+            .when().get("/event/" + EVENT_WITHOUT_MAP)
+            .then()
+            .statusCode(200)
+            .body(not(containsString("Ver mapa")));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add mapUrl field to admin event form and resource
- display map link only when provided and test for behavior

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896402ed65483339a992acdb19c3b46