### PR TITLE
feat: link talks to speakers for reuse

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
@@ -3,6 +3,9 @@ package com.scanales.eventflow.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @RegisterForReflection
 
@@ -19,6 +22,9 @@ public class Speaker {
     private String twitter;
     private String linkedin;
     private String instagram;
+
+    /** Talks owned by this speaker and reusable across events. */
+    private List<Talk> talks = new ArrayList<>();
 
     public Speaker() {
     }
@@ -90,5 +96,13 @@ public class Speaker {
 
     public void setInstagram(String instagram) {
         this.instagram = instagram;
+    }
+
+    public List<Talk> getTalks() {
+        return talks;
+    }
+
+    public void setTalks(List<Talk> talks) {
+        this.talks = talks;
     }
 }

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -102,27 +102,20 @@ Nuevo Evento
   <h2><span class="icon">🗣️</span>Charlas</h2>
   <div class="card">
   <table>
-  <thead><tr><th>ID</th><th>Nombre</th><th>Acciones</th></tr></thead>
+  <thead><tr><th>ID</th><th>Charla</th><th>Acciones</th></tr></thead>
   <tbody>
   {#for t in event.agenda}
   <tr>
   <form method="post" action="/private/admin/events/{event.id}/talk">
   <td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
-  <td><input name="name" value="{t.name}"></td>
+  <td>{t.name}<br><small>{t.getSpeakerNames()}</small></td>
   <td>
-  <input name="description" value="{t.description}" placeholder="Descripcion">
-  <select name="speakers" multiple>
-  {#for sp in speakers}
-  <option value="{sp.id}"{#if t.speakers.contains(sp)} selected{/if}>{sp.name}</option>
-  {/for}
-  </select>
   <select name="location">
   {#for sc in event.scenarios}
   <option value="{sc.id}"{#if sc.id == t.location} selected{/if}>{sc.name}</option>
   {/for}
   </select>
   <input name="startTime" type="time" value="{t.startTimeStr}">
-  <input name="duration" type="number" min="1" value="{t.durationMinutes}">
   <select name="day">
   {#for d in event.dayList}
   <option value="{d}"{#if t.day == d} selected{/if}>Día {d}</option>
@@ -139,21 +132,29 @@ Nuevo Evento
   <tr>
   <form method="post" action="/private/admin/events/{event.id}/talk">
   <td>Nuevo</td>
-  <td><input name="name"></td>
   <td>
-  <input name="description" placeholder="Descripcion">
-  <select name="speakers" multiple>
-  {#for sp in speakers}
-  <option value="{sp.id}">{sp.name}</option>
-  {/for}
-  </select>
+    <select id="speakerSelect" name="speakerId">
+      <option value="">Seleccione orador</option>
+      {#for sp in speakers}
+      <option value="{sp.id}">{sp.name}</option>
+      {/for}
+    </select>
+    <select id="talkSelect" name="talkId">
+      <option value="">Seleccione charla</option>
+      {#for sp in speakers}
+        {#for t in sp.talks}
+        <option value="{t.id}" data-speaker="{sp.id}">{t.name}</option>
+        {/for}
+      {/for}
+    </select>
+  </td>
+  <td>
   <select name="location">
   {#for sc in event.scenarios}
   <option value="{sc.id}">{sc.name}</option>
   {/for}
   </select>
   <input name="startTime" type="time">
-  <input name="duration" type="number" min="1">
   <select name="day">
   {#for d in event.dayList}
   <option value="{d}">Día {d}</option>
@@ -165,6 +166,22 @@ Nuevo Evento
   </tr>
   </tbody>
   </table>
+  <script>
+    (function(){
+      const speakerSelect = document.getElementById('speakerSelect');
+      const talkSelect = document.getElementById('talkSelect');
+      function filterTalks(){
+        const sid = speakerSelect.value;
+        Array.from(talkSelect.options).forEach(opt => {
+          if(!opt.value){return;}
+          opt.hidden = sid && opt.dataset.speaker !== sid;
+        });
+        talkSelect.value = '';
+      }
+      speakerSelect.addEventListener('change', filterTalks);
+      filterTalks();
+    })();
+  </script>
   </div>
 </section>
 <section id="agenda">

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -173,7 +173,7 @@ Nuevo Evento
       function filterTalks(){
         const sid = speakerSelect.value;
         Array.from(talkSelect.options).forEach(opt => {
-          if(!opt.value){return;}
+          if(!opt.value) return;
           opt.hidden = sid && opt.dataset.speaker !== sid;
         });
         talkSelect.value = '';

--- a/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
@@ -27,6 +27,39 @@
   </form>
   </td>
 </tr>
+<tr>
+  <td colspan="3">
+    <table class="sub-table">
+      <thead><tr><th>ID</th><th>Título</th><th>Duración</th><th>Acciones</th></tr></thead>
+      <tbody>
+        {#for t in s.talks}
+        <tr>
+          <form method="post" action="/private/admin/speakers/{s.id}/talk">
+            <td>{t.id}<input type="hidden" name="talkId" value="{t.id}"></td>
+            <td><input name="name" value="{t.name}"></td>
+            <td><input name="duration" type="number" min="1" value="{t.durationMinutes}"></td>
+            <td>
+              <input name="description" value="{t.description}" placeholder="Descripcion">
+              <button type="submit">Guardar</button>
+          </form>
+          <form method="post" action="/private/admin/speakers/{s.id}/talk/{t.id}/delete" style="display:inline" class="needs-confirm">
+              <button type="submit">Eliminar</button>
+          </form>
+            </td>
+        </tr>
+        {/for}
+        <tr>
+          <form method="post" action="/private/admin/speakers/{s.id}/talk">
+            <td>Nuevo</td>
+            <td><input name="name"></td>
+            <td><input name="duration" type="number" min="1"></td>
+            <td><input name="description" placeholder="Descripcion"><button type="submit">Agregar</button></td>
+          </form>
+        </tr>
+      </tbody>
+    </table>
+  </td>
+</tr>
 {/for}
 <tr>
   <form method="post" action="/private/admin/speakers">


### PR DESCRIPTION
## Summary
- allow speakers to manage their own talks
- reuse speaker talks when scheduling events
- update admin UIs to select speakers and their talks

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68966deb7ae88333a6e5df4e62505f89