### PR TITLE
feat: add async persistence and metrics dashboard

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -1,0 +1,36 @@
+package com.scanales.eventflow.private_;
+
+import com.scanales.eventflow.service.MetricsService;
+import com.scanales.eventflow.service.MetricsService.Metrics;
+import com.scanales.eventflow.util.AdminUtils;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/** Exposes system metrics for the admin dashboard. */
+@Path("/private/admin/metrics")
+public class AdminMetricsResource {
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    MetricsService metricsService;
+
+    @GET
+    @Authenticated
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response metrics() {
+        if (!AdminUtils.isAdmin(identity)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        Metrics metrics = metricsService.getMetrics();
+        return Response.ok(metrics).build();
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -5,7 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Scenario;
@@ -25,6 +27,14 @@ public class EventService {
      */
     private static final Map<String, Event> events = new ConcurrentHashMap<>();
 
+    @Inject
+    PersistenceService persistence;
+
+    @PostConstruct
+    void init() {
+        events.putAll(persistence.loadEvents());
+    }
+
     public List<Event> listEvents() {
         return new ArrayList<>(events.values());
     }
@@ -35,10 +45,12 @@ public class EventService {
 
     public void saveEvent(Event event) {
         events.put(event.getId(), event);
+        persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
 
     public void deleteEvent(String id) {
         events.remove(id);
+        persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
 
     public void saveScenario(String eventId, Scenario scenario) {
@@ -48,12 +60,14 @@ public class EventService {
         }
         event.getScenarios().removeIf(s -> s.getId().equals(scenario.getId()));
         event.getScenarios().add(scenario);
+        persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
 
     public void deleteScenario(String eventId, String scenarioId) {
         Event event = events.get(eventId);
         if (event != null) {
             event.getScenarios().removeIf(s -> s.getId().equals(scenarioId));
+            persistence.saveEvents(new ConcurrentHashMap<>(events));
         }
     }
 
@@ -64,12 +78,14 @@ public class EventService {
         }
         event.getAgenda().removeIf(t -> t.getId().equals(talk.getId()));
         event.getAgenda().add(talk);
+        persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
 
     public void deleteTalk(String eventId, String talkId) {
         Event event = events.get(eventId);
         if (event != null) {
             event.getAgenda().removeIf(t -> t.getId().equals(talkId));
+            persistence.saveEvents(new ConcurrentHashMap<>(events));
         }
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/MetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/MetricsService.java
@@ -1,0 +1,31 @@
+package com.scanales.eventflow.service;
+
+import java.lang.management.ManagementFactory;
+
+import com.sun.management.OperatingSystemMXBean;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/** Provides simple system metrics for the admin dashboard. */
+@ApplicationScoped
+public class MetricsService {
+
+    public record Metrics(double cpu, double memory, double disk, boolean lowDisk) {}
+
+    @Inject
+    PersistenceService persistenceService;
+
+    public Metrics getMetrics() {
+        double cpu = 0d;
+        var os = ManagementFactory.getOperatingSystemMXBean();
+        if (os instanceof OperatingSystemMXBean bean) {
+            cpu = bean.getSystemCpuLoad();
+            if (cpu < 0) cpu = 0d; // can be -1 when undefined
+        }
+        Runtime rt = Runtime.getRuntime();
+        double mem = 1d - ((double) rt.freeMemory() / (double) rt.totalMemory());
+        double disk = persistenceService.getDiskUsage();
+        return new Metrics(cpu * 100d, mem * 100d, disk * 100d, persistenceService.isLowDiskSpace());
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
@@ -1,0 +1,133 @@
+package com.scanales.eventflow.service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.jboss.logging.Logger;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Speaker;
+
+/**
+ * Persists application data to JSON files using an asynchronous writer. All
+ * write operations are queued on a single thread to avoid blocking user
+ * interactions.
+ */
+@ApplicationScoped
+public class PersistenceService {
+
+    private static final Logger LOG = Logger.getLogger(PersistenceService.class);
+
+    private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    private final Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
+    private final Path eventsFile = dataDir.resolve("events.json");
+    private final Path speakersFile = dataDir.resolve("speakers.json");
+
+    private volatile boolean lowDiskSpace;
+    private static final long MIN_FREE_BYTES = 50L * 1024 * 1024; // 50 MB
+
+    @PostConstruct
+    void init() {
+        try {
+            Files.createDirectories(dataDir);
+        } catch (IOException e) {
+            LOG.error("Unable to create data directory", e);
+        }
+    }
+
+    /** Returns whether the storage has critically low free space. */
+    public boolean isLowDiskSpace() {
+        return lowDiskSpace;
+    }
+
+    /** Persists all events asynchronously. */
+    public void saveEvents(Map<String, Event> events) {
+        scheduleWrite(eventsFile, events);
+    }
+
+    /** Persists all speakers asynchronously. */
+    public void saveSpeakers(Map<String, Speaker> speakers) {
+        scheduleWrite(speakersFile, speakers);
+    }
+
+    /** Loads events from disk or returns an empty map if none. */
+    public Map<String, Event> loadEvents() {
+        return read(eventsFile, new TypeReference<Map<String, Event>>() {});
+    }
+
+    /** Loads speakers from disk or returns an empty map if none. */
+    public Map<String, Speaker> loadSpeakers() {
+        return read(speakersFile, new TypeReference<Map<String, Speaker>>() {});
+    }
+
+    /** Percentage of disk usage for the data directory (0-100). */
+    public double getDiskUsage() {
+        File f = dataDir.toFile();
+        long total = f.getTotalSpace();
+        long free = f.getUsableSpace();
+        if (total == 0) {
+            return 0d;
+        }
+        return ((double) (total - free) / (double) total);
+    }
+
+    private void scheduleWrite(Path file, Object data) {
+        executor.submit(() -> {
+            checkDiskSpace();
+            if (lowDiskSpace) {
+                LOG.warn("Low disk space - skipping persistence");
+                return;
+            }
+            try {
+                mapper.writeValue(file.toFile(), data);
+            } catch (IOException e) {
+                LOG.error("Failed to persist data to " + file, e);
+            }
+        });
+    }
+
+    private <T> Map<String, T> read(Path file, TypeReference<Map<String, T>> type) {
+        if (!Files.exists(file)) {
+            return new ConcurrentHashMap<>();
+        }
+        try {
+            return mapper.readValue(file.toFile(), type);
+        } catch (IOException e) {
+            LOG.error("Failed to read " + file, e);
+            return new ConcurrentHashMap<>();
+        }
+    }
+
+    private void checkDiskSpace() {
+        File f = dataDir.toFile();
+        long free = f.getUsableSpace();
+        lowDiskSpace = free < MIN_FREE_BYTES;
+    }
+
+    /** Blocks until all queued persistence tasks are finished. */
+    public void flush() {
+        try {
+            Future<?> f = executor.submit(() -> {});
+            f.get();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -22,6 +23,14 @@ public class SpeakerService {
 
     @Inject
     EventService eventService;
+
+    @Inject
+    PersistenceService persistence;
+
+    @PostConstruct
+    void init() {
+        speakers.putAll(persistence.loadSpeakers());
+    }
 
     public List<Speaker> listSpeakers() {
         return new ArrayList<>(speakers.values());
@@ -51,6 +60,7 @@ public class SpeakerService {
             }
             return existing;
         });
+        persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
     }
 
     public void deleteSpeaker(String id) {
@@ -63,6 +73,7 @@ public class SpeakerService {
                 }
             }
         }
+        persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
     }
 
     public void saveTalk(String speakerId, Talk talk) {
@@ -83,6 +94,7 @@ public class SpeakerService {
             t.setDurationMinutes(talk.getDurationMinutes());
             t.setSpeakers(talk.getSpeakers());
         }
+        persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
     }
 
     public Talk getTalk(String speakerId, String talkId) {
@@ -115,5 +127,6 @@ public class SpeakerService {
         for (Event e : eventService.listEvents()) {
             e.getAgenda().removeIf(t -> t.getId().equals(talkId));
         }
+        persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
     }
 }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/MetricsServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/MetricsServiceTest.java
@@ -1,0 +1,23 @@
+package com.scanales.eventflow.service;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class MetricsServiceTest {
+
+    @Inject
+    MetricsService metricsService;
+
+    @Test
+    public void metricsWithinBounds() {
+        MetricsService.Metrics m = metricsService.getMetrics();
+        Assertions.assertTrue(m.cpu() >= 0 && m.cpu() <= 100);
+        Assertions.assertTrue(m.memory() >= 0 && m.memory() <= 100);
+        Assertions.assertTrue(m.disk() >= 0 && m.disk() <= 100);
+    }
+}


### PR DESCRIPTION
## Summary
- add `PersistenceService` to asynchronously store events and speakers to JSON with disk space checks
- expose basic CPU, memory and disk metrics through `MetricsService` and new `/private/admin/metrics` endpoint
- integrate persistence into existing event and speaker services

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68967d77b1448333930cc35b7aafdea4