### PR TITLE
feat: add manual backup and restore

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminBackupResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminBackupResource.java
@@ -1,0 +1,189 @@
+package com.scanales.eventflow.private_;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import org.jboss.logging.Logger;
+import org.jboss.resteasy.reactive.multipart.FileUpload;
+
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.SpeakerService;
+import com.scanales.eventflow.service.PersistenceService;
+import com.scanales.eventflow.util.AdminUtils;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@Path("/private/admin/backup")
+public class AdminBackupResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance index(String message);
+    }
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    EventService eventService;
+
+    @Inject
+    SpeakerService speakerService;
+
+    @Inject
+    PersistenceService persistence;
+
+    @ConfigProperty(name = "quarkus.application.version")
+    String appVersion;
+
+    private static final Logger LOG = Logger.getLogger(AdminBackupResource.class);
+
+    private boolean isAdmin() {
+        return AdminUtils.isAdmin(identity);
+    }
+
+    @GET
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public Response index(@QueryParam("msg") String message) {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return Response.ok(Templates.index(message)).build();
+    }
+
+    @GET
+    @Path("/download")
+    @Authenticated
+    @Produces("application/zip")
+    public Response download() {
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        try {
+            persistence.flush();
+            Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
+            if (!Files.exists(dataDir)) {
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("\u274c Error: No hay datos para respaldar.")
+                        .type(MediaType.TEXT_PLAIN + ";charset=UTF-8")
+                        .build();
+            }
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+                try (var stream = Files.list(dataDir)) {
+                    stream.filter(Files::isRegularFile).forEach(p -> {
+                        try (InputStream in = Files.newInputStream(p)) {
+                            zos.putNextEntry(new ZipEntry(p.getFileName().toString()));
+                            in.transferTo(zos);
+                            zos.closeEntry();
+                        } catch (Exception e) {
+                            LOG.error("Failed to add file to backup", e);
+                        }
+                    });
+                }
+            }
+            byte[] data = baos.toByteArray();
+            String ts = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss").format(LocalDateTime.now());
+            String filename = String.format("backup_%s_v%s.zip", ts, appVersion);
+            LOG.infov("Generated backup {0}", filename);
+            return Response.ok(data)
+                    .header("Content-Disposition", "attachment; filename=" + filename)
+                    .build();
+        } catch (Exception e) {
+            LOG.error("Failed to generate backup", e);
+            return Response.serverError()
+                    .entity("\u274c Error al generar el backup.")
+                    .type(MediaType.TEXT_PLAIN + ";charset=UTF-8")
+                    .build();
+        }
+    }
+
+    @POST
+    @Path("/upload")
+    @Authenticated
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response upload(@FormParam("file") FileUpload file) {
+        String redirect = "/private/admin/backup";
+        if (!isAdmin()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        if (file == null || file.size() == 0) {
+            LOG.warn("No file uploaded for restore");
+            return Response.seeOther(UriBuilder.fromPath(redirect)
+                    .queryParam("msg", "\u274c Archivo inv\u00e1lido.")
+                    .build()).build();
+        }
+        String fileName = file.fileName();
+        if (fileName == null || !fileName.endsWith(".zip")) {
+            LOG.warnf("Invalid backup type: %s", fileName);
+            return Response.seeOther(UriBuilder.fromPath(redirect)
+                    .queryParam("msg", "\u274c Archivo no es ZIP.")
+                    .build()).build();
+        }
+        if (!fileName.matches("backup_.*_v" + java.util.regex.Pattern.quote(appVersion) + "\\.zip")) {
+            LOG.warnf("Incompatible backup version: %s", fileName);
+            return Response.seeOther(UriBuilder.fromPath(redirect)
+                    .queryParam("msg", "\u274c Versi\u00f3n incompatible.")
+                    .build()).build();
+        }
+        Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
+        try {
+            Files.createDirectories(dataDir);
+            long free = dataDir.toFile().getUsableSpace();
+            long size = file.size();
+            if (free < size) {
+                LOG.warn("Not enough disk space for restore");
+                return Response.seeOther(UriBuilder.fromPath(redirect)
+                        .queryParam("msg", "\u274c Espacio insuficiente.")
+                        .build()).build();
+            }
+            try (InputStream in = Files.newInputStream(file.filePath());
+                 ZipInputStream zis = new ZipInputStream(in)) {
+                ZipEntry entry;
+                while ((entry = zis.getNextEntry()) != null) {
+                    Path target = dataDir.resolve(entry.getName());
+                    Files.copy(zis, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    zis.closeEntry();
+                }
+            }
+            persistence.flush();
+            eventService.reload();
+            speakerService.reload();
+            LOG.infof("Backup restored from %s", fileName);
+            return Response.seeOther(UriBuilder.fromPath(redirect)
+                    .queryParam("msg", "\u2705 Backup restaurado.")
+                    .build()).build();
+        } catch (Exception e) {
+            LOG.error("Failed to restore backup", e);
+            return Response.seeOther(UriBuilder.fromPath(redirect)
+                    .queryParam("msg", "\u274c Error al restaurar.")
+                    .build()).build();
+        }
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminBackupResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminBackupResource.java
@@ -3,7 +3,6 @@ package com.scanales.eventflow.private_;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -87,7 +86,7 @@ public class AdminBackupResource {
         }
         try {
             persistence.flush();
-            Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
+            java.nio.file.Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
             if (!Files.exists(dataDir)) {
                 return Response.status(Response.Status.BAD_REQUEST)
                         .entity("\u274c Error: No hay datos para respaldar.")
@@ -152,7 +151,7 @@ public class AdminBackupResource {
                     .queryParam("msg", "\u274c Versi\u00f3n incompatible.")
                     .build()).build();
         }
-        Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
+        java.nio.file.Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));
         try {
             Files.createDirectories(dataDir);
             long free = dataDir.toFile().getUsableSpace();
@@ -167,7 +166,7 @@ public class AdminBackupResource {
                  ZipInputStream zis = new ZipInputStream(in)) {
                 ZipEntry entry;
                 while ((entry = zis.getNextEntry()) != null) {
-                    Path target = dataDir.resolve(entry.getName());
+                    java.nio.file.Path target = dataDir.resolve(entry.getName());
                     Files.copy(zis, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                     zis.closeEntry();
                 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -185,4 +185,10 @@ public class EventService {
                         .thenComparing(Talk::getStartTime))
                 .toList();
     }
+
+    /** Reloads events from persistence replacing the current cache. */
+    public void reload() {
+        events.clear();
+        events.putAll(persistence.loadEvents());
+    }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -129,4 +129,10 @@ public class SpeakerService {
         }
         persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
     }
+
+    /** Reloads speakers from persistence replacing the current cache. */
+    public void reload() {
+        speakers.clear();
+        speakers.putAll(persistence.loadSpeakers());
+    }
 }

--- a/quarkus-app/src/main/resources/templates/AdminBackupResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminBackupResource/index.html
@@ -1,0 +1,20 @@
+{#include layout/base}
+{#title}Backup{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Backup</span>{/breadcrumbs}
+{#main}
+<section class="backup-admin">
+  <h1 class="page-title">Respaldo de datos</h1>
+  {#if message}
+  <p class="section-subtitle">{message}</p>
+  {/if}
+  <div class="card action-group">
+    <a href="/private/admin/backup/download" class="btn">Manual BackUp</a>
+    <form method="post" action="/private/admin/backup/upload" enctype="multipart/form-data">
+      <input type="file" name="file" accept=".zip">
+      <button type="submit" class="btn btn-secondary">Upload BackUp</button>
+    </form>
+  </div>
+  <a href="/private/admin" class="btn btn-secondary">Volver</a>
+</section>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -30,7 +30,6 @@
             <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline" class="needs-confirm">
               <button type="submit" class="btn btn-secondary">Eliminar</button>
             </form>
-            <a href="/private/admin/events/{ev.id}/export" class="btn btn-secondary">Exportar</a>
           </td>
         </tr>
       {/for}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -8,6 +8,7 @@
     <div class="card action-group">
         <a href="/private/admin/events" class="btn">Administrar eventos</a>
         <a href="/private/admin/speakers" class="btn">Administrar oradores</a>
+        <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
         <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- remove per-event export option
- add admin backup/restore endpoints with UI
- reload caches after restoring backup

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689692311fc883339c68f053b2ca375a