### PR TITLE
feat: log persistence operations

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -9,6 +9,8 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Scenario;
 import com.scanales.eventflow.model.Talk;
@@ -30,9 +32,12 @@ public class EventService {
     @Inject
     PersistenceService persistence;
 
+    private static final Logger LOG = Logger.getLogger(EventService.class);
+
     @PostConstruct
     void init() {
         events.putAll(persistence.loadEvents());
+        LOG.infof("Loaded %d events into memory", events.size());
     }
 
     public List<Event> listEvents() {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
@@ -47,6 +47,7 @@ public class PersistenceService {
     void init() {
         try {
             Files.createDirectories(dataDir);
+            LOG.infov("Using data directory {0}", dataDir.toAbsolutePath());
         } catch (IOException e) {
             LOG.error("Unable to create data directory", e);
         }
@@ -97,6 +98,7 @@ public class PersistenceService {
             }
             try {
                 mapper.writeValue(file.toFile(), data);
+                LOG.infof("Persisted %s at %s", file.getFileName(), java.time.Instant.now());
             } catch (IOException e) {
                 LOG.error("Failed to persist data to " + file, e);
             }
@@ -105,10 +107,13 @@ public class PersistenceService {
 
     private <T> Map<String, T> read(Path file, TypeReference<Map<String, T>> type) {
         if (!Files.exists(file)) {
+            LOG.infof("No persistence file %s found - starting empty", file.getFileName());
             return new ConcurrentHashMap<>();
         }
         try {
-            return mapper.readValue(file.toFile(), type);
+            Map<String, T> data = mapper.readValue(file.toFile(), type);
+            LOG.infof("Loaded %d entries from %s", data.size(), file.getFileName());
+            return new ConcurrentHashMap<>(data);
         } catch (IOException e) {
             LOG.error("Failed to read " + file, e);
             return new ConcurrentHashMap<>();

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -9,6 +9,8 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+
 import com.scanales.eventflow.model.Speaker;
 import com.scanales.eventflow.model.Talk;
 import com.scanales.eventflow.model.Event;
@@ -27,9 +29,12 @@ public class SpeakerService {
     @Inject
     PersistenceService persistence;
 
+    private static final Logger LOG = Logger.getLogger(SpeakerService.class);
+
     @PostConstruct
     void init() {
         speakers.putAll(persistence.loadSpeakers());
+        LOG.infof("Loaded %d speakers into memory", speakers.size());
     }
 
     public List<Speaker> listSpeakers() {


### PR DESCRIPTION
## Summary
- log data directory and record every persistence read/write
- report persisted entities at startup for events and speakers

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896a23a0640833387acd77c65c25b4f