### PR TITLE
Align persistent data directory with application path

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               protocol: TCP
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:+UseContainerSupport -Deventflow.data.dir=/data"
+              value: "-XX:+UseContainerSupport -Deventflow.data.dir=/work/data"
             - name: OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:
@@ -76,7 +76,7 @@ spec:
               memory: 52Mi
           volumeMounts:
             - name: data
-              mountPath: /data
+              mountPath: /work/data
           securityContext:
             capabilities:
               drop:

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
@@ -48,8 +48,15 @@ public class PersistenceService {
         try {
             Files.createDirectories(dataDir);
             LOG.infov("Using data directory {0}", dataDir.toAbsolutePath());
+            try (var stream = Files.list(dataDir)) {
+                if (stream.findAny().isPresent()) {
+                    LOG.info("Persistence data found");
+                } else {
+                    LOG.info("Data directory is empty");
+                }
+            }
         } catch (IOException e) {
-            LOG.error("Unable to create data directory", e);
+            LOG.error("Unable to initialize data directory", e);
         }
     }
 
@@ -107,15 +114,15 @@ public class PersistenceService {
 
     private <T> Map<String, T> read(Path file, TypeReference<Map<String, T>> type) {
         if (!Files.exists(file)) {
-            LOG.infof("No persistence file %s found - starting empty", file.getFileName());
+            LOG.infof("No persistence file %s found - starting empty", file.toAbsolutePath());
             return new ConcurrentHashMap<>();
         }
         try {
             Map<String, T> data = mapper.readValue(file.toFile(), type);
-            LOG.infof("Loaded %d entries from %s", data.size(), file.getFileName());
+            LOG.infof("Loaded %d entries from %s", data.size(), file.toAbsolutePath());
             return new ConcurrentHashMap<>(data);
         } catch (IOException e) {
-            LOG.error("Failed to read " + file, e);
+            LOG.error("Failed to read " + file.toAbsolutePath(), e);
             return new ConcurrentHashMap<>();
         }
     }


### PR DESCRIPTION
## Summary
- mount PVC at `/work/data` and pass this path via `JAVA_TOOL_OPTIONS` so the application reads persisted data on startup
- log whether the data directory contains files and show absolute paths when loading persistence files

## Testing
- `./mvnw -q -Djava.net.preferIPv4Stack=true test` *(fails: java.net.SocketException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896a81977e48333a18ff9d64bfd6283