### PR TITLE
Handle recursive JSON references for events and speakers

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
@@ -1,12 +1,15 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 @RegisterForReflection
 
 /**

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -1,6 +1,8 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.LocalTime;
@@ -8,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
 @RegisterForReflection
 
 /**


### PR DESCRIPTION
## Summary
- Prevent infinite recursion when serializing talks and speakers by assigning JSON identity based on each object's `id`.

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896ac9d8b988333bfc836e077295e45