### PR TITLE
fix duplicate object id deserialization

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
@@ -1,0 +1,21 @@
+package com.scanales.eventflow.model;
+
+import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdResolver;
+import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
+
+/**
+ * An {@link ObjectIdResolver} that ignores attempts to bind the same id to
+ * multiple objects. This is useful when deserializing graphs where references
+ * to the same object are repeated, avoiding "Already had POJO for id" errors.
+ */
+public class PermissiveObjectIdResolver extends SimpleObjectIdResolver {
+    @Override
+    public void bindItem(ObjectIdGenerator.IdKey id, Object pojo) {
+        // Only bind if this id has not been seen before. If it's already
+        // associated with an object, ignore the new binding to keep the first.
+        if (resolveId(id) == null) {
+            super.bindItem(id, pojo);
+        }
+    }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Speaker.java
@@ -9,7 +9,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id",
+        resolver = PermissiveObjectIdResolver.class)
 @RegisterForReflection
 
 /**

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -10,7 +10,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+@JsonIdentityInfo(
+        generator = ObjectIdGenerators.PropertyGenerator.class,
+        property = "id",
+        resolver = PermissiveObjectIdResolver.class)
 @RegisterForReflection
 
 /**


### PR DESCRIPTION
## Summary
- add permissive object id resolver to tolerate repeated ids in JSON graphs
- use the custom resolver for Talk and Speaker entities

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896bf3defc083338b74f7dae01569d6