### PR TITLE
Enable Java time module for persistence serialization

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
@@ -34,7 +34,9 @@ public class PersistenceService {
 
     private static final Logger LOG = Logger.getLogger(PersistenceService.class);
 
-    private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+    private final ObjectMapper mapper = new ObjectMapper()
+            .findAndRegisterModules()
+            .enable(SerializationFeature.INDENT_OUTPUT);
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private final Path dataDir = Paths.get(System.getProperty("eventflow.data.dir", "data"));


### PR DESCRIPTION
## Summary
- Register Jackson modules on the PersistenceService's ObjectMapper to support Java time types

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896c39cf1b0833381a5d20a8273873f