### PR TITLE
fix: ensure custom object id resolver used during data load

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
@@ -3,12 +3,14 @@ package com.scanales.eventflow.model;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdResolver;
 import com.fasterxml.jackson.annotation.SimpleObjectIdResolver;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * An {@link ObjectIdResolver} that ignores attempts to bind the same id to
  * multiple objects. This is useful when deserializing graphs where references
  * to the same object are repeated, avoiding "Already had POJO for id" errors.
  */
+@RegisterForReflection
 public class PermissiveObjectIdResolver extends SimpleObjectIdResolver {
     @Override
     public void bindItem(ObjectIdGenerator.IdKey id, Object pojo) {


### PR DESCRIPTION
## Summary
- register `PermissiveObjectIdResolver` for reflection so Jackson uses it when reading data

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689742a24fc08333b289edd7054209b1