### PR TITLE
Fix persistence deserialization issues for talks

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
@@ -13,6 +13,11 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @RegisterForReflection
 public class PermissiveObjectIdResolver extends SimpleObjectIdResolver {
     @Override
+    public ObjectIdResolver newForDeserialization(Object context) {
+        return new PermissiveObjectIdResolver();
+    }
+
+    @Override
     public void bindItem(ObjectIdGenerator.IdKey id, Object pojo) {
         // Only bind if this id has not been seen before. If it's already
         // associated with an object, ignore the new binding to keep the first.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.NotBlank;
@@ -13,6 +14,7 @@ import java.util.List;
         generator = ObjectIdGenerators.PropertyGenerator.class,
         property = "id",
         resolver = PermissiveObjectIdResolver.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 @RegisterForReflection
 
 /**


### PR DESCRIPTION
## Summary
- Handle duplicate object ids when deserializing JSON graphs
- Ignore unknown fields in `Talk` models (e.g., `speakerNames`)

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68974a32847883338fb152dc28430f0a