### PR TITLE
Fix persistence deserialization issues for talks

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/PermissiveObjectIdResolver.java
@@ -13,6 +13,11 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 @RegisterForReflection
 public class PermissiveObjectIdResolver extends SimpleObjectIdResolver {
     @Override
+    public ObjectIdResolver newForDeserialization(Object context) {
+        return new PermissiveObjectIdResolver();
+    }
+
+    @Override
     public void bindItem(ObjectIdGenerator.IdKey id, Object pojo) {
         // Only bind if this id has not been seen before. If it's already
         // associated with an object, ignore the new binding to keep the first.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.model;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.validation.constraints.NotBlank;
@@ -74,6 +75,7 @@ public class Talk {
         this.speakers = speakers;
     }
 
+    @JsonIgnore
     public String getSpeakerNames() {
         return speakers.stream()
                 .map(Speaker::getName)


### PR DESCRIPTION
## Summary
- Handle repeated object ids during Jackson deserialization to avoid "Already had POJO for id" failures
- Exclude derived speaker name list from JSON to prevent unrecognized field errors

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68974a32847883338fb152dc28430f0a