### PR TITLE
Remove Add Event button from navigation

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -19,7 +19,6 @@
             <a href="/private/profile">Mis Charlas</a>
             {#if app:isAdmin()}
                 <a href="/private/admin">Admin</a>
-                <a href="/private/admin/events/new" class="btn add-event">Agregar Evento</a>
             {/if}
             <div class="user-menu">
                 <button id="userMenuBtn" class="user-menu-btn" aria-label="Usuario" aria-expanded="false">


### PR DESCRIPTION
## Summary
- remove global "Agregar Evento" navigation button

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: io.quarkus.platform:quarkus-bom:pom:3.24.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897666f1ff48333878a4a29cee10e1e