### PR TITLE
Add responsive intro hero on home page

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -341,6 +341,50 @@ button:focus-visible {
 }
 
 /* --- Home page --- */
+.home-hero {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    padding: 2rem 0;
+}
+
+.home-hero .hero-text {
+    flex: 1;
+}
+
+.home-hero .hero-title {
+    font-size: 2rem;
+    margin: 0 0 0.5rem;
+    color: var(--color-dark);
+}
+
+.home-hero .hero-description {
+    font-size: 1rem;
+    color: #555;
+}
+
+.home-hero .hero-image {
+    flex: 1;
+    text-align: right;
+}
+
+.home-hero .hero-image img {
+    max-width: 300px;
+    width: 100%;
+    height: auto;
+}
+
+@media (max-width: 768px) {
+    .home-hero {
+        flex-direction: column;
+        text-align: center;
+    }
+    .home-hero .hero-image {
+        text-align: center;
+    }
+}
+
 .home-section {
     padding: 2rem 0;
     text-align: center;

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -2,6 +2,15 @@
 {#title}Inicio{/title}
 {#breadcrumbs}<span>Inicio</span>{/breadcrumbs}
 {#main}
+<section class="home-hero">
+    <div class="hero-text">
+        <h1 class="hero-title">Eventos tech en un solo lugar</h1>
+        <p class="hero-description">Descubre, comparte y participa en las actividades que la comunidad prepara para vos.</p>
+    </div>
+    <div class="hero-image">
+        <img src="/img/eventflow-logo.png" alt="Logo de EventFlow">
+    </div>
+</section>
 <section class="home-section">
     <h1 class="page-title">Eventos disponibles</h1>
     {#if events.isEmpty()}


### PR DESCRIPTION
## Summary
- Highlight site purpose with a new hero block on the home page
- Style the hero section for responsiveness and keep event list prominent

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68976e8e7d8883339774b39bc7be3509