### PR TITLE
feat: add project header to homepage

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -341,50 +341,33 @@ button:focus-visible {
 }
 
 /* --- Home page --- */
-.home-hero {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 2rem;
-    padding: 2rem 0;
+.project-header {
+    text-align: center;
+    padding: 1rem 0.5rem;
+    background-color: var(--color-light);
+    border-bottom: 1px solid #eee;
 }
 
-.home-hero .hero-text {
-    flex: 1;
-}
-
-.home-hero .hero-title {
-    font-size: 2rem;
+.project-header .project-description {
     margin: 0 0 0.5rem;
-    color: var(--color-dark);
 }
 
-.home-hero .hero-description {
-    font-size: 1rem;
-    color: #555;
+.project-header .project-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem 1rem;
+    font-size: 0.9rem;
 }
 
-.home-hero .hero-image {
-    flex: 1;
-    text-align: right;
+.project-header .project-links a {
+    color: var(--color-primary);
+    text-decoration: none;
 }
 
-.home-hero .hero-image img {
-    max-width: 300px;
-    width: 100%;
-    height: auto;
+.project-header .project-links a:hover {
+    text-decoration: underline;
 }
-
-@media (max-width: 768px) {
-    .home-hero {
-        flex-direction: column;
-        text-align: center;
-    }
-    .home-hero .hero-image {
-        text-align: center;
-    }
-}
-
 .home-section {
     padding: 2rem 0;
     text-align: center;

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -2,13 +2,12 @@
 {#title}Inicio{/title}
 {#breadcrumbs}<span>Inicio</span>{/breadcrumbs}
 {#main}
-<section class="home-hero">
-    <div class="hero-text">
-        <h1 class="hero-title">Eventos tech en un solo lugar</h1>
-        <p class="hero-description">Descubre, comparte y participa en las actividades que la comunidad prepara para vos.</p>
-    </div>
-    <div class="hero-image">
-        <img src="/img/eventflow-logo.png" alt="Logo de EventFlow">
+<section class="project-header">
+    <p class="project-description"><strong>EventFlow</strong> es una plataforma para gestionar eventos, actividades, espacios y charlas. Esto es OpenSource, gratuito y con dedicación y pasión por la tecnología!</p>
+    <div class="project-links">
+        <span class="project-version">Versión actual: <strong>Beta 2.0.0</strong> – <a href="https://github.com/scanalesespinoza/eventflow/releases" target="_blank" rel="noopener">Releases</a></span>
+        <a href="https://github.com/scanalesespinoza/eventflow/issues" target="_blank" rel="noopener">Si encuentras algo para mejorar, ayúdanos creando un issue!</a>
+        <a href="https://ko-fi.com/sergiocanales" target="_blank" rel="noopener">Apóyanos en Ko-fi ☕</a>
     </div>
 </section>
 <section class="home-section">


### PR DESCRIPTION
## Summary
- highlight project status and contribution links on homepage
- style new project header section
- remove home hero block and its styling

## Testing
- `cd quarkus-app && ./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68977de136ec833386aa4c7d3d2da168