### PR TITLE
style: redesign project header with dashboard layout

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -341,32 +341,60 @@ button:focus-visible {
 }
 
 /* --- Home page --- */
-.project-header {
-    text-align: center;
-    padding: 1rem 0.5rem;
+.box {
     background-color: var(--color-light);
-    border-bottom: 1px solid #eee;
+    border-radius: 8px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.project-header {
+    margin: 1rem 0 2rem;
+}
+
+.project-header .box-header {
+    background-color: var(--color-dark);
+    color: var(--color-light);
+    padding: 0.75rem 1rem;
+    border-radius: 8px 8px 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.project-header .project-title {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.project-header .project-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-size: 0.9rem;
+}
+
+.project-header .box-body {
+    padding: 1rem;
 }
 
 .project-header .project-description {
-    margin: 0 0 0.5rem;
+    margin-top: 0;
+    margin-bottom: 1rem;
 }
 
 .project-header .project-links {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
-    gap: 0.5rem 1rem;
-    font-size: 0.9rem;
+    gap: 0.5rem;
 }
 
-.project-header .project-links a {
-    color: var(--color-primary);
-    text-decoration: none;
-}
-
-.project-header .project-links a:hover {
-    text-decoration: underline;
+@media (max-width: 600px) {
+    .project-header .box-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 }
 .home-section {
     padding: 2rem 0;

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -2,12 +2,22 @@
 {#title}Inicio{/title}
 {#breadcrumbs}<span>Inicio</span>{/breadcrumbs}
 {#main}
-<section class="project-header">
-    <p class="project-description"><strong>EventFlow</strong> es una plataforma para gestionar eventos, actividades, espacios y charlas. Esto es OpenSource, gratuito y con dedicación y pasión por la tecnología!</p>
-    <div class="project-links">
-        <span class="project-version">Versión actual: <strong>Beta 2.0.0</strong> – <a href="https://github.com/scanalesespinoza/eventflow/releases" target="_blank" rel="noopener">Releases</a></span>
-        <a href="https://github.com/scanalesespinoza/eventflow/issues" target="_blank" rel="noopener">Si encuentras algo para mejorar, ayúdanos creando un issue!</a>
-        <a href="https://ko-fi.com/sergiocanales" target="_blank" rel="noopener">Apóyanos en Ko-fi ☕</a>
+<section class="project-header box">
+    <div class="box-header">
+        <h1 class="project-title">EventFlow</h1>
+        <div class="project-meta">
+            <span class="project-status">Estado: <strong>En desarrollo</strong></span>
+            <span class="project-version">Versión: <strong>Beta 2.0.0</strong></span>
+            <span class="project-update">Última actualización: {today.format('dd/MM/yyyy')}</span>
+        </div>
+    </div>
+    <div class="box-body">
+        <p class="project-description">EventFlow es una plataforma para gestionar eventos, actividades, espacios y charlas. Esto es OpenSource, gratuito y con dedicación y pasión por la tecnología!</p>
+        <div class="project-links">
+            <a href="https://github.com/scanalesespinoza/eventflow/releases" target="_blank" rel="noopener" class="btn">Releases</a>
+            <a href="https://github.com/scanalesespinoza/eventflow/issues" target="_blank" rel="noopener" class="btn">Reportar issue</a>
+            <a href="https://ko-fi.com/sergiocanales" target="_blank" rel="noopener" class="btn">Ko-fi ☕</a>
+        </div>
     </div>
 </section>
 <section class="home-section">


### PR DESCRIPTION
## Summary
- restyle `project-header` into a dashboard-like box with status, version, last update and quick links
- introduce reusable `.box` styles and responsive header rules for a cleaner look

## Testing
- `mvn -q test` *(fails: The goal you specified requires a project to execute but there is no POM in this directory)*

------
https://chatgpt.com/codex/tasks/task_e_689784dd98a08333aa91a82f0baa2bb6