### PR TITLE
feat: add reusable project header

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -11,7 +11,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
+import java.util.Map;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.service.EventService;
 import jakarta.inject.Inject;
@@ -25,7 +27,7 @@ public class HomeResource {
     @CheckedTemplate
     static class Templates {
         static native TemplateInstance home(java.util.List<com.scanales.eventflow.model.Event> events,
-                LocalDate today);
+                LocalDate today, String version, Map<String, String> stats, Map<String, String> links);
     }
 
     @GET
@@ -36,7 +38,15 @@ public class HomeResource {
                 .sorted(Comparator.comparing(Event::getDate,
                         Comparator.nullsLast(Comparator.naturalOrder())))
                 .toList();
-        return Templates.home(events, LocalDate.now());
+        var today = LocalDate.now();
+        var stats = Map.of(
+                "status", "En desarrollo",
+                "lastUpdated", today.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
+        var links = Map.of(
+                "releasesUrl", "https://github.com/scanalesespinoza/eventflow/releases",
+                "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
+                "donateUrl", "https://ko-fi.com/sergiocanales");
+        return Templates.home(events, today, "2.0.0", stats, links);
     }
 
     @GET

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -342,59 +342,106 @@ button:focus-visible {
 
 /* --- Home page --- */
 .box {
-    background-color: var(--color-light);
-    border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    background: var(--surface, #fff);
+    border: 1px solid rgba(0,0,0,.06);
+    border-radius: 1rem;
+    box-shadow: 0 6px 16px rgba(0,0,0,.06);
+    padding: 1rem 1.25rem;
 }
 
 .project-header {
-    margin: 1rem 0 2rem;
+    display: grid;
+    grid-template-columns: 1fr 220px;
+    gap: 1rem;
 }
 
-.project-header .box-header {
-    background-color: var(--color-dark);
-    color: var(--color-light);
-    padding: 0.75rem 1rem;
-    border-radius: 8px 8px 0 0;
+@media (max-width: 900px) {
+    .project-header {
+        grid-template-columns: 1fr;
+    }
+    .sidebar-actions {
+        flex-direction: row;
+        gap: .5rem;
+    }
+}
+
+.box-header {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 0.5rem;
+    gap: 1rem;
+    padding-bottom: .5rem;
+    border-bottom: 1px solid rgba(0,0,0,.06);
 }
 
-.project-header .project-title {
-    margin: 0;
-    font-size: 1.5rem;
+.box-header .title {
+    font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+    font-weight: 700;
+    letter-spacing: .2px;
 }
 
-.project-header .project-meta {
+.meta {
     display: flex;
+    gap: 1.25rem;
     flex-wrap: wrap;
-    gap: 0.5rem 1rem;
-    font-size: 0.9rem;
+    color: var(--muted-foreground, #555);
+    font-size: .95rem;
 }
 
-.project-header .box-body {
-    padding: 1rem;
+.meta strong {
+    color: var(--brand-text, #0b5cab);
 }
 
-.project-header .project-description {
-    margin-top: 0;
-    margin-bottom: 1rem;
+.box-body {
+    margin-top: .75rem;
 }
 
-.project-header .project-links {
+.note {
+    background: rgba(0,120,255,.06);
+    border: 1px solid rgba(0,120,255,.12);
+    border-radius: .75rem;
+    padding: .9rem 1rem;
+    line-height: 1.5;
+}
+
+.sidebar-actions {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+    flex-direction: column;
+    gap: .75rem;
 }
 
-@media (max-width: 600px) {
-    .project-header .box-header {
-        flex-direction: column;
-        align-items: flex-start;
-    }
+.side-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: .6rem .9rem;
+    border-radius: .75rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid transparent;
+    box-shadow: 0 3px 10px rgba(0,0,0,.06);
+    transition: all .2s ease;
+}
+
+.side-btn.primary {
+    background: var(--brand, #0ea5e9);
+    color: #fff;
+}
+
+.side-btn.secondary {
+    background: #fff;
+    color: var(--brand-text, #0b5cab);
+    border-color: rgba(0,0,0,.1);
+}
+
+.side-btn:hover {
+    box-shadow: 0 6px 16px rgba(0,0,0,.1);
+    filter: brightness(1.03);
+}
+
+.side-btn:focus-visible {
+    outline: 2px solid var(--brand, #0ea5e9);
+    outline-offset: 2px;
 }
 .home-section {
     padding: 2rem 0;

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -1,25 +1,7 @@
-{#include layout/base}
+{#include layout/base version=version stats=stats links=links}
 {#title}Inicio{/title}
 {#breadcrumbs}<span>Inicio</span>{/breadcrumbs}
 {#main}
-<section class="project-header box">
-    <div class="box-header">
-        <h1 class="project-title">EventFlow</h1>
-        <div class="project-meta">
-            <span class="project-status">Estado: <strong>En desarrollo</strong></span>
-            <span class="project-version">Versión: <strong>Beta 2.0.0</strong></span>
-            <span class="project-update">Última actualización: {today.format('dd/MM/yyyy')}</span>
-        </div>
-    </div>
-    <div class="box-body">
-        <p class="project-description">EventFlow es una plataforma para gestionar eventos, actividades, espacios y charlas. Esto es OpenSource, gratuito y con dedicación y pasión por la tecnología!</p>
-        <div class="project-links">
-            <a href="https://github.com/scanalesespinoza/eventflow/releases" target="_blank" rel="noopener" class="btn">Releases</a>
-            <a href="https://github.com/scanalesespinoza/eventflow/issues" target="_blank" rel="noopener" class="btn">Reportar issue</a>
-            <a href="https://ko-fi.com/sergiocanales" target="_blank" rel="noopener" class="btn">Ko-fi ☕</a>
-        </div>
-    </div>
-</section>
 <section class="home-section">
     <h1 class="page-title">Eventos disponibles</h1>
     {#if events.isEmpty()}

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -43,6 +43,9 @@
 <div id="notification" class="notification hidden" role="alert"></div>
 <div id="loading" class="loading hidden"><div class="spinner"></div></div>
 <main id="main-content" class="container">
+    {#if version || links}
+        {#include partials/project-header version=version stats=stats links=links /}
+    {/if}
     {#insert main}{/}
 </main>
 <footer>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -43,7 +43,7 @@
 <div id="notification" class="notification hidden" role="alert"></div>
 <div id="loading" class="loading hidden"><div class="spinner"></div></div>
 <main id="main-content" class="container">
-    {#if version || links}
+    {#if version?? || links??}
         {#include partials/project-header version=version stats=stats links=links /}
     {/if}
     {#insert main}{/}

--- a/quarkus-app/src/main/resources/templates/partials/project-header.html
+++ b/quarkus-app/src/main/resources/templates/partials/project-header.html
@@ -1,0 +1,20 @@
+<section class="box project-header">
+    <div>
+        <div class="box-header">
+            <h2 class="title">EventFlow</h2>
+            <div class="meta">
+                <span>Estado: <strong>{stats.status ?: '—'}</strong></span>
+                <span>Versión: <strong>{#if version}Beta {version}{#else}—{/if}</strong></span>
+                <span>Última actualización: {stats.lastUpdated ?: '—'}</span>
+            </div>
+        </div>
+        <div class="box-body">
+            <p class="note">EventFlow es una plataforma para gestionar eventos, actividades, espacios y charlas. Esto es OpenSource, gratuito y con dedicación y pasión por la tecnología.</p>
+        </div>
+    </div>
+    <div class="sidebar-actions">
+        <a href="{links.releasesUrl ?: '#'}" target="_blank" rel="noopener" class="side-btn secondary" aria-label="Ver releases">Releases</a>
+        <a href="{links.issuesUrl ?: '#'}" target="_blank" rel="noopener" class="side-btn secondary" aria-label="Reportar issue">Reportar issue</a>
+        <a href="{links.donateUrl ?: '#'}" target="_blank" rel="noopener" class="side-btn primary" aria-label="Apoyar en Ko-fi">Ko-fi ☕</a>
+    </div>
+</section>

--- a/quarkus-app/src/main/resources/templates/partials/project-header.html
+++ b/quarkus-app/src/main/resources/templates/partials/project-header.html
@@ -3,9 +3,9 @@
         <div class="box-header">
             <h2 class="title">EventFlow</h2>
             <div class="meta">
-                <span>Estado: <strong>{stats.status ?: '—'}</strong></span>
-                <span>Versión: <strong>{#if version}Beta {version}{#else}—{/if}</strong></span>
-                <span>Última actualización: {stats.lastUpdated ?: '—'}</span>
+                <span>Estado: <strong>{#if stats?? && stats.status??}{stats.status}{#else}—{/if}</strong></span>
+                <span>Versión: <strong>{#if version??}Beta {version}{#else}—{/if}</strong></span>
+                <span>Última actualización: {#if stats?? && stats.lastUpdated??}{stats.lastUpdated}{#else}—{/if}</span>
             </div>
         </div>
         <div class="box-body">
@@ -13,8 +13,8 @@
         </div>
     </div>
     <div class="sidebar-actions">
-        <a href="{links.releasesUrl ?: '#'}" target="_blank" rel="noopener" class="side-btn secondary" aria-label="Ver releases">Releases</a>
-        <a href="{links.issuesUrl ?: '#'}" target="_blank" rel="noopener" class="side-btn secondary" aria-label="Reportar issue">Reportar issue</a>
-        <a href="{links.donateUrl ?: '#'}" target="_blank" rel="noopener" class="side-btn primary" aria-label="Apoyar en Ko-fi">Ko-fi ☕</a>
+        <a href="{#if links?? && links.releasesUrl??}{links.releasesUrl}{#else}#{/if}" target="_blank" rel="noopener" class="side-btn secondary" aria-label="Ver releases">Releases</a>
+        <a href="{#if links?? && links.issuesUrl??}{links.issuesUrl}{#else}#{/if}" target="_blank" rel="noopener" class="side-btn secondary" aria-label="Reportar issue">Reportar issue</a>
+        <a href="{#if links?? && links.donateUrl??}{links.donateUrl}{#else}#{/if}" target="_blank" rel="noopener" class="side-btn primary" aria-label="Apoyar en Ko-fi">Ko-fi ☕</a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add reusable project header partial with status, version and action links
- include dashboard header in base layout and pass project data from home resource
- style project header and sidebar actions for desktop and mobile

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68978c4d1eb48333b2f89c6c4101b5dc