### PR TITLE
chore: update version references to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Smart event management platform: spaces, activities, speakers, attendees, and personalized planning.
 
-## v2.0.0 – Gitless & Stable
+## v2.1.0 – Persistente con soporte de Eventos, Oradores y Charlas
 
 Esta versión elimina completamente la sincronización con repositorios Git introducida en versiones experimentales posteriores a v1.0.0.
 

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: eventflow
-          image: quay.io/sergio_canales_e/eventflow:v2.0.0
+          image: quay.io/sergio_canales_e/eventflow:v2.1.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -71,7 +71,7 @@ native executable:
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 
-> ./target/eventflow-2.0.0-runner
+> ./target/eventflow-2.1.0-runner
 
 
 ## Google Login Demo

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.scanales</groupId>
     <artifactId>eventflow</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/quarkus-app/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:v2.0.0 .
+# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:v2.1.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
+# docker run -i --rm -p 8080:8080 eventflow:v2.1.0
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
+# docker run -i --rm -p 8080:8080 eventflow:v2.1.0
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.legacy-jar
+++ b/quarkus-app/src/main/docker/Dockerfile.legacy-jar
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:v2.0.0 .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:v2.1.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
+# docker run -i --rm -p 8080:8080 eventflow:v2.1.0
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:v2.0.0
+# docker run -i --rm -p 8080:8080 eventflow:v2.1.0
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:v2.0.0 .
+# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:v2.1.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:v2.0.0
+# docker run -i --rm -p 8080:8080 eventflow-native:v2.1.0
 #
 # The `registry.access.redhat.com/ubi9/ubi-minimal:9.5` base image provides
 # GLIBC 2.34+ and is compatible with binaries built on newer systems. If you

--- a/quarkus-app/src/main/docker/Dockerfile.native-micro
+++ b/quarkus-app/src/main/docker/Dockerfile.native-micro
@@ -10,11 +10,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:v2.0.0 .
+# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:v2.1.0 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:v2.0.0
+# docker run -i --rm -p 8080:8080 eventflow-native:v2.1.0
 #
 # The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -46,7 +46,7 @@ public class HomeResource {
                 "releasesUrl", "https://github.com/scanalesespinoza/eventflow/releases",
                 "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
                 "donateUrl", "https://ko-fi.com/sergiocanales");
-        return Templates.home(events, today, "2.0.0", stats, links);
+        return Templates.home(events, today, "2.1.0", stats, links);
     }
 
     @GET

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -13,7 +13,7 @@ quarkus.oidc.authentication.user-info-required=false
 quarkus.oidc.authentication.id-token-required=true
 quarkus.oidc.token.principal-claim=id_token
 # Application version
-quarkus.application.version=2.0.0
+quarkus.application.version=2.1.0
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings
 quarkus.log.category."io.quarkus.oidc".level=INFO

--- a/quarkus-app/src/main/resources/templates/partials/project-header.html
+++ b/quarkus-app/src/main/resources/templates/partials/project-header.html
@@ -4,7 +4,7 @@
             <h2 class="title">EventFlow</h2>
             <div class="meta">
                 <span>Estado: <strong>{#if stats?? && stats.status??}{stats.status}{#else}—{/if}</strong></span>
-                <span>Versión: <strong>{#if version??}Beta {version}{#else}—{/if}</strong></span>
+                <span>Versión: <strong>{#if version??}Persistente con soporte de Eventos, Oradores y Charlas – v{version}{#else}—{/if}</strong></span>
                 <span>Última actualización: {#if stats?? && stats.lastUpdated??}{stats.lastUpdated}{#else}—{/if}</span>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- bump documented version to v2.1.0
- update deployment manifest, config, and source to report v2.1.0
- refresh Docker instructions to use v2.1.0 image tags
- describe v2.1.0 as persistente with support for eventos, oradores y charlas

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689796412b388333b492680831acacba