### PR TITLE
feat: adjust branding for navigation and header

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -69,7 +69,18 @@ button:focus-visible {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.nav-logo img {
+.nav-logo {
+    color: var(--color-light);
+    text-decoration: none;
+}
+
+.nav-logo .title {
+    margin: 0;
+    font-size: 1.5rem;
+    line-height: 1;
+}
+
+.logo-main {
     height: 40px;
     width: auto;
     border-radius: 50%;
@@ -400,8 +411,7 @@ button:focus-visible {
 
 .meta {
     display: flex;
-    gap: 1.25rem;
-    flex-wrap: wrap;
+    gap: 0.25rem;
     color: var(--muted-foreground, #555);
     font-size: .95rem;
 }

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -10,7 +10,7 @@
 <body>
 <a href="#main-content" class="skip-link">Ir al contenido principal</a>
 <header class="nav-menu" id="nav-menu" aria-label="Principal">
-    <a href="/" class="nav-logo"><img src="/img/eventflow-logo.png" alt="EventFlow" class="logo-main" /></a>
+    <a href="/" class="nav-logo"><h2 class="title">EventFlow</h2></a>
     <button id="menuToggle" class="menu-toggle" aria-label="Menú" aria-controls="primary-navigation" aria-expanded="false">&#9776;</button>
     <div class="nav-links" id="primary-navigation">
         <a href="/">Inicio</a>

--- a/quarkus-app/src/main/resources/templates/partials/project-header.html
+++ b/quarkus-app/src/main/resources/templates/partials/project-header.html
@@ -1,7 +1,7 @@
 <section class="box project-header">
     <div>
         <div class="box-header">
-            <h2 class="title">EventFlow</h2>
+            <img src="/img/eventflow-logo.png" alt="EventFlow" class="logo-main" />
             <div class="meta">
                 <span>Estado: <strong>{#if stats?? && stats.status??}{stats.status}{#else}—{/if}</strong></span>
                 <span>Versión: <strong>{#if version??}Persistente con soporte de Eventos, Oradores y Charlas – v{version}{#else}—{/if}</strong></span>


### PR DESCRIPTION
## Summary
- replace navbar logo image with compact text heading
- move logo image to project header and create shared logo style
- tighten meta info spacing

## Testing
- `mvn -q test` *(fails: could not resolve dependencies, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897aaa7f3f88333aae6c5da751d37c6