### PR TITLE
Refine sidebar and note styles

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -400,7 +400,8 @@ button:focus-visible {
     justify-content: space-between;
     gap: 1rem;
     padding-bottom: .5rem;
-    border-bottom: 1px solid rgba(0,0,0,.06);
+    padding-top: .5rem;
+    border-bottom: 1px solid rgba(0, 0, 0, .06);
 }
 
 .box-header .title {
@@ -425,17 +426,26 @@ button:focus-visible {
 }
 
 .note {
-    background: rgba(0,120,255,.06);
-    border: 1px solid rgba(0,120,255,.12);
+    background: rgba(0, 120, 255, .06);
+    border: 1px solid rgba(0, 120, 255, .12);
     border-radius: .75rem;
-    padding: .9rem 1rem;
+    padding: .1rem .5rem;
     line-height: 1.5;
+}
+
+p.note {
+    margin-top: .5rem;
 }
 
 .sidebar-actions {
     display: flex;
+    gap: 0.2rem;
     flex-direction: column;
-    gap: .75rem;
+}
+
+.release-box {
+    display: flex;
+    flex-direction: column;
     justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- Adjust sidebar actions layout with tighter gap
- Tweak note and box-header styles for improved spacing
- Add release box and paragraph note styling helpers

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6897b5dd2a2083339e1547a01c6d9b0c