### PR TITLE
Supply chain: SBOM generation, image scan & (optional) Cosign attach

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### Checklist
+
+- [ ] Closes #<issue> / Refs INC-<id>
+- [ ] CI green (build + tests + linters)
+- [ ] SBOM generado (Maven)
+- [ ] Imagen escaneada (Grype)
+- [ ] Screenshots si UI
+- [ ] Notas de rollout/flags

--- a/.github/workflows/sbom-and-scan.yml
+++ b/.github/workflows/sbom-and-scan.yml
@@ -1,0 +1,76 @@
+name: SBOM and scan
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  id-token: write
+
+concurrency:
+  group: sbom-and-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ${{ vars.REGISTRY }}
+      IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v3
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Build and generate SBOM
+        working-directory: quarkus-app
+        run: ./mvnw -B -DskipTests verify
+
+      - name: Build container image
+        run: |
+          docker build -f quarkus-app/src/main/docker/Dockerfile.jvm -t ${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA} quarkus-app
+
+      - name: Setup Syft
+        uses: anchore/setup-syft@v1
+
+      - name: Setup Grype
+        uses: anchore/setup-grype@v1
+
+      - name: Generate image SBOM
+        run: syft packages ${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA} -o cyclonedx-json > sbom-image.cdx.json
+
+      - name: Scan image for vulnerabilities
+        env:
+          FAIL_ON: ${{ github.event_name == 'pull_request' && 'high' || 'critical' }}
+        run: grype sbom:sbom-image.cdx.json --fail-on ${FAIL_ON}
+
+      - name: Upload dependency SBOM
+        uses: actions/upload-artifact@v3
+        with:
+          name: bom
+          path: quarkus-app/target/bom.json
+
+      - name: Upload image SBOM
+        uses: actions/upload-artifact@v3
+        with:
+          name: sbom-image
+          path: sbom-image.cdx.json
+
+      - name: Cosign attach SBOM
+        if: ${{ env.REGISTRY != '' && env.IMAGE_NAME != '' && (secrets.COSIGN_PRIVATE_KEY != '' || secrets.COSIGN_EXPERIMENTAL != '') }}
+        env:
+          COSIGN_EXPERIMENTAL: ${{ secrets.COSIGN_EXPERIMENTAL }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+        run: cosign attach sbom --sbom sbom-image.cdx.json --type cyclonedx ${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}

--- a/README.md
+++ b/README.md
@@ -68,3 +68,32 @@ redirects back to the event list displaying a confirmation banner.
   This indicates that the OAuth client credentials are incorrect. Verify that `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` (or the values in `google-oauth-secret.yaml`) match the client configuration in the Google Cloud console and that the redirect URI is registered correctly.
 - **The application supports RP-Initiated Logout but the OpenID Provider does not advertise the end_session_endpoint**
   Google does not publish an RP logout endpoint. Ensure Quarkus' built-in logout is disabled by leaving `quarkus.oidc.logout.path` empty and using the provided `/logout` endpoint instead.
+
+## Supply chain: SBOM & Vulnerabilities
+
+The build generates Software Bill of Materials (SBOM) for dependencies and container images and scans them for known vulnerabilities.
+
+### Local commands
+
+```bash
+# Generate dependency SBOM
+./mvnw -f quarkus-app/pom.xml -DskipTests org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom
+# Generate image SBOM
+syft oci:${REGISTRY}/${IMAGE_NAME}:<tag> -o cyclonedx-json > sbom-image.cdx.json
+# Scan image
+grype oci:${REGISTRY}/${IMAGE_NAME}:<tag> --fail-on High
+```
+
+### CI
+
+- `target/bom.json` and `sbom-image.cdx.json` are uploaded as workflow artifacts.
+- Pull requests fail on **High** or **Critical** findings; pushes to `main` fail on **Critical**.
+- If `COSIGN_*` secrets are available, the image SBOM is attached and signed with [Cosign](https://github.com/sigstore/cosign).
+
+Required variables and secrets:
+
+- `REGISTRY` – container registry (e.g. `ghcr.io`)
+- `IMAGE_NAME` – image repository (e.g. `owner/repo`)
+- `COSIGN_EXPERIMENTAL`, or `COSIGN_PRIVATE_KEY`/`COSIGN_PASSWORD` for Cosign attachment
+
+For coordinated vulnerability disclosure, see [SECURITY.md](SECURITY.md).

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -107,6 +108,27 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>json</outputFormat>
+                    <schemaVersion>1.5</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeTestScope>false</includeTestScope>
+                    <includeProvidedScope>false</includeProvidedScope>
+                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- add CycloneDX Maven plugin to produce aggregate SBOM
- add SBOM + Grype scanning workflow with optional Cosign attach
- document supply chain steps and provide PR checklist

## Testing
- `MAVEN_OPTS='-Djava.net.preferIPv4Stack=true -Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080' ./mvnw -B -DskipTests verify` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_6897b8b226248333b7dbfd1502f25e01