### PR TITLE
Supply chain: SBOM generation, image scan & (optional) Cosign attach

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Summary
+Problem → Solution
+
+### Checks
+- [ ] Closes #<issue> / Refs INC-<id>
+- [ ] CI green (build + tests + linters)
+- [ ] SBOM generated (Maven) & image SBOM (Syft)
+- [ ] Image scanned (Grype) — thresholds respected
+- [ ] Rollout/feature flags notes if applicable
+- [ ] Docs updated (README/SECURITY) if needed
+

--- a/.github/workflows/sbom-and-scan.yml
+++ b/.github/workflows/sbom-and-scan.yml
@@ -1,0 +1,174 @@
+name: sbom-and-scan
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: "0 6 * * 1"  # lunes 06:00 UTC
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ${{ vars.REGISTRY || 'ghcr.io' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || github.repository }}
+  IMAGE: ${{ (vars.REGISTRY || 'ghcr.io') }}/${{ vars.IMAGE_NAME || github.repository }}:${{ github.sha }}
+  SECURITY_GATING: ${{ vars.SECURITY_GATING || 'permissive' }}
+  COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+  COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+
+jobs:
+  build-sbom-and-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/dependency-review-action@v4
+        if: ${{ github.event_name == 'pull_request' }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Build app & dependency SBOM
+        working-directory: quarkus-app
+        run: ./mvnw -B -DskipTests verify
+
+      - name: Build image
+        run: docker build -f quarkus-app/src/main/docker/Dockerfile.jvm -t "$IMAGE" quarkus-app
+
+      - name: Generate image SBOM (Syft CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE }}
+          format: cyclonedx-json
+          output-file: sbom-image.cdx.json
+          upload-artifact: false
+
+      - name: Grype report (no-fail) - table/json/sarif
+        run: |
+          TARGET="${REF:-$IMAGE}"
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.docker/config.json:/root/.docker/config.json:ro" \
+            anchore/grype:latest "$TARGET" -o table > grype-report.txt || true
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.docker/config.json:/root/.docker/config.json:ro" \
+            anchore/grype:latest "$TARGET" -o json  > grype-report.json || true
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.docker/config.json:/root/.docker/config.json:ro" \
+            anchore/grype:latest "$TARGET" -o sarif > grype-report.sarif || true
+          if [ ! -s grype-report.sarif ]; then
+            echo '{"$schema":"https://json.schemastore.org/sarif-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"grype"}},"results":[]}]}' > grype-report.sarif
+          fi
+
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: sboms
+          path: |
+            quarkus-app/target/bom.json
+            sbom-image.cdx.json
+
+      - name: Upload Grype reports (artifacts)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: grype-reports
+          path: |
+            grype-report.txt
+            grype-report.json
+            grype-report.sarif
+
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: grype-report.sarif
+          category: grype
+
+      - name: Add summary to job
+        if: always()
+        run: |
+          echo "### Grype summary" >> $GITHUB_STEP_SUMMARY
+          if command -v jq >/dev/null; then
+            jq -r '[.matches[].vulnerability.severity] | group_by(.) | map({severity: .[0], count: length})' grype-report.json >> $GITHUB_STEP_SUMMARY || true
+          else
+            echo "Install jq to see JSON summary" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      # --- WARN-ONLY (no bloquea) ---
+      - name: Severity threshold (warn-only)
+        if: ${{ env.SECURITY_GATING == 'permissive' || github.event_name == 'pull_request' }}
+        env:
+          FAIL_ON: ${{ github.event_name == 'pull_request' && 'high' || 'critical' }}
+        continue-on-error: true
+        run: |
+          TARGET="${REF:-${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}}"
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.docker/config.json:/root/.docker/config.json:ro" \
+            anchore/grype:latest "$TARGET" --fail-on ${FAIL_ON} -o table
+
+      # --- ENFORCE (bloquea) ---
+      - name: Severity threshold (enforce)
+        if: ${{ env.SECURITY_GATING == 'enforcing' && github.ref == 'refs/heads/main' }}
+        env:
+          FAIL_ON: ${{ github.event_name == 'pull_request' && 'high' || 'critical' }}
+        run: |
+          TARGET="${REF:-${REGISTRY}/${IMAGE_NAME}:${GITHUB_SHA}}"
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.docker/config.json:/root/.docker/config.json:ro" \
+            anchore/grype:latest "$TARGET" --fail-on ${FAIL_ON} -o table
+
+      - name: Push image
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: |
+          if [ "$REGISTRY" = "ghcr.io" ]; then
+            echo "${{ github.token }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          elif [ -n "$QUAY_USERNAME" ] && [ -n "$QUAY_PASSWORD" ]; then
+            echo "$QUAY_PASSWORD" | docker login "$REGISTRY" -u "$QUAY_USERNAME" --password-stdin
+          else
+            echo "Registry credentials not provided; skipping push"
+            exit 0
+          fi
+          docker push "$IMAGE"
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMAGE" | cut -d@ -f2)
+          echo "REF=$REGISTRY/${{ github.repository }}@$DIGEST" >> "$GITHUB_ENV"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Cosign sign (keyless)
+        if: ${{ vars.SIGN_KEYLESS == 'true' }}
+        run: cosign sign --keyless --yes "$REF"
+
+      - name: Write cosign private key
+        if: ${{ env.COSIGN_PRIVATE_KEY != '' }}
+        run: printf "%s" "$COSIGN_PRIVATE_KEY" > cosign.key
+
+      - name: Cosign sign (key-pair)
+        if: ${{ env.COSIGN_PRIVATE_KEY != '' }}
+        env:
+          COSIGN_PASSWORD: ${{ env.COSIGN_PASSWORD }}
+        run: cosign sign --key cosign.key --yes "$REF"
+
+      - name: Cosign attach SBOM
+        if: ${{ vars.SIGN_ATTACH_SBOM == 'true' }}
+        run: cosign attach sbom --sbom sbom-image.cdx.json --type cyclonedx "$REF"
+

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ buildNumber.properties
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# Cosign key material
+cosign.key

--- a/README.md
+++ b/README.md
@@ -68,3 +68,36 @@ redirects back to the event list displaying a confirmation banner.
   This indicates that the OAuth client credentials are incorrect. Verify that `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET` (or the values in `google-oauth-secret.yaml`) match the client configuration in the Google Cloud console and that the redirect URI is registered correctly.
 - **The application supports RP-Initiated Logout but the OpenID Provider does not advertise the end_session_endpoint**
   Google does not publish an RP logout endpoint. Ensure Quarkus' built-in logout is disabled by leaving `quarkus.oidc.logout.path` empty and using the provided `/logout` endpoint instead.
+
+## Supply chain: SBOM & Vulnerabilities
+
+The build generates Software Bill of Materials (SBOM) for dependencies and container images and scans the image for known vulnerabilities.
+
+### Local commands
+
+```bash
+# Build and generate dependency SBOM
+mvn -f quarkus-app/pom.xml -DskipTests verify
+# Generate image SBOM
+syft oci:${REGISTRY}/${IMAGE_NAME}:<tag> -o cyclonedx-json > sbom-image.cdx.json
+# Scan image
+grype oci:${REGISTRY}/${IMAGE_NAME}:<tag> --fail-on High
+```
+
+### CI
+
+- `target/bom.json` and `sbom-image.cdx.json` are uploaded as workflow artifacts (Actions → Artifacts).
+- Vulnerability gating is warning-only unless `vars.SECURITY_GATING` is set to `enforcing`.
+  When enforcing, pushes to `main` fail on **Critical** findings.
+- Images are signed with [Cosign](https://github.com/sigstore/cosign) using keyless signatures when `vars.SIGN_KEYLESS` is `true`, or a private key when `COSIGN_PRIVATE_KEY`/`COSIGN_PASSWORD` secrets are provided.
+- The image SBOM can be attached to the image when `vars.SIGN_ATTACH_SBOM` is `true`.
+
+Required variables and secrets:
+
+- `REGISTRY` – container registry (defaults to `ghcr.io`)
+- `SECURITY_GATING` – `permissive` (default) or `enforcing`
+- `SIGN_KEYLESS=true` – enable keyless signing
+- `SIGN_ATTACH_SBOM=true` – attach SBOM to the image (optional)
+- `COSIGN_PRIVATE_KEY` and `COSIGN_PASSWORD` – key pair for signing (optional)
+
+For coordinated vulnerability disclosure, see [SECURITY.md](SECURITY.md).

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.parameters>true</maven.compiler.parameters>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -107,6 +108,28 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <outputFormat>json</outputFormat>
+                    <schemaVersion>1.5</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeTestScope>false</includeTestScope>
+                    <includeProvidedScope>false</includeProvidedScope>
+                    <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                    <outputName>bom</outputName>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- add CycloneDX Maven plugin to produce aggregate SBOM
- add workflow for SBOM generation, image scanning, keyless-first Cosign signing, and generate Grype reports before pushing image
- document supply-chain steps and add PR checklist; ignore cosign.key
- allow Grype container to access local Docker images via socket mount
- separate vulnerability gating into warn-only and enforce steps controlled by `vars.SECURITY_GATING`
- install Cosign CLI before signing to avoid command not found errors
- log in to container registry before pushing and signing the image

## Testing
- `./mvnw -B -DskipTests verify` *(fails: Network is unreachable)*
- `curl -sSL -o /tmp/actionlint.tar.gz https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz && tar -xzf /tmp/actionlint.tar.gz -C /tmp && /tmp/actionlint -version && /tmp/actionlint .github/workflows/sbom-and-scan.yml`


------
https://chatgpt.com/codex/tasks/task_e_6897b8b226248333b7dbfd1502f25e01