### PR TITLE
fix: add sbomExpected job for required check

### DIFF
--- a/.github/workflows/sbom-and-scan.yml
+++ b/.github/workflows/sbom-and-scan.yml
@@ -125,6 +125,20 @@ jobs:
           cosign sign --key cosign.key --yes "$REF"
           rm -f cosign.key
 
+  sbomExpected:
+    name: sbomExpected
+    needs: build-sbom-and-scan
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check build result
+        run: |
+          if [ "${{ needs.build-sbom-and-scan.result }}" != "success" ]; then
+            echo "build-sbom-and-scan job failed" >&2
+            exit 1
+          fi
+          echo "build-sbom-and-scan job succeeded"
+
   promote:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure sbom status is reported on pull requests

## Testing
- `mvn -B test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68981f69c26083338cbd0c9791bddbf6