### PR TITLE
fix: avoid parse error when resolving PR tag

### DIFF
--- a/.github/workflows/sbom-and-scan.yml
+++ b/.github/workflows/sbom-and-scan.yml
@@ -165,9 +165,10 @@ jobs:
 
       - name: Resolve REF from PR tag
         run: |
-          prs=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls -H "Accept: application/vnd.github+json")
-          pr_number=$(echo "$prs" | jq -r '.[0].number')
-          head_sha=$(echo "$prs" | jq -r '.[0].head.sha')
+          pr_number=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
+            -H "Accept: application/vnd.github+json" --jq '.[0].number')
+          head_sha=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls \
+            -H "Accept: application/vnd.github+json" --jq '.[0].head.sha')
           DIGEST="$(skopeo inspect --format '{{.Digest}}' docker://${REGISTRY}/${IMAGE_NAME}:pr-${pr_number}-${head_sha})"
           echo "IMAGE_DIGEST=$DIGEST" >> "$GITHUB_ENV"
           echo "REF=${REGISTRY}/${IMAGE_NAME}@${DIGEST}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- avoid `jq` parse error in Promote job by using `gh api --jq` to read PR info

## Testing
- `mvn -B -f quarkus-app/pom.xml test` *(fails: io.quarkus.platform:quarkus-bom:pom:3.24.3: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68989cba4b40833399afae5152cd4ca1