### PR TITLE
Add auto-merge workflow after PR CI success

### DIFF
--- a/.github/workflows/auto-merge-after-ci.yml
+++ b/.github/workflows/auto-merge-after-ci.yml
@@ -1,0 +1,27 @@
+---
+name: Auto-merge after PR CI success
+
+'on':
+  workflow_run:
+    workflows: ["PR CI (Build, Native, SBOM/Scan)"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  merge:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge PR (squash + delete branch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          PR_JSON=$(gh api repos/$REPO/commits/$SHA/pulls \
+            -H "Accept: application/vnd.github+json")
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+          gh pr merge "$PR_NUMBER" --squash --delete-branch


### PR DESCRIPTION
## Summary
- auto-merge PRs as soon as PR CI workflow completes successfully

## Testing
- `yamllint ../.github/workflows/auto-merge-after-ci.yml`
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d2be51b88333ba1749f3a49447dc