### PR TITLE
chore: set GH_TOKEN for gh CLI

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -23,6 +23,7 @@ env:
   GKE_CLUSTER:   ${{ vars.GKE_CLUSTER }}
   GKE_LOCATION:  ${{ vars.GKE_LOCATION }}
   GKE_NAMESPACE: ${{ vars.GKE_NAMESPACE || 'prod' }}
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- set `GH_TOKEN` env variable in main deploy workflow

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d5c6ca8083339545186e9da91b0e