### PR TITLE
chore: specify repo in auto merge workflow

### DIFF
--- a/.github/workflows/auto-merge-after-ci.yml
+++ b/.github/workflows/auto-merge-after-ci.yml
@@ -26,7 +26,7 @@ jobs:
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
 
           for i in {1..60}; do
-            PENDING=$(gh pr view "$PR_NUMBER" --json statusCheckRollup \
+            PENDING=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json statusCheckRollup \
               --jq '[.statusCheckRollup[] | select(.conclusion != "SUCCESS")] | length')
             if [ "$PENDING" -eq 0 ]; then
               break
@@ -40,4 +40,4 @@ jobs:
             exit 1
           fi
 
-          gh pr merge "$PR_NUMBER" --squash --delete-branch
+          gh pr merge "$PR_NUMBER" --squash --delete-branch --repo "$REPO"


### PR DESCRIPTION
## Summary
- allow gh CLI commands to run without local checkout by passing --repo

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898dab1aa348333ae96d405f0d2ad06