### PR TITLE
feat: preserve scroll position after talk deletion

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -87,6 +87,8 @@ function handleForms() {
                 e.preventDefault();
                 return;
             }
+            sessionStorage.setItem('scrollPos', String(window.scrollY));
+            sessionStorage.setItem('scrollPath', window.location.pathname);
             showLoading('los datos');
             const btn = form.querySelector('button[type="submit"]');
             if (btn) btn.disabled = true;
@@ -113,6 +115,16 @@ function handleNotificationsFromUrl() {
     }
 }
 
+function restoreScroll() {
+    const path = sessionStorage.getItem('scrollPath');
+    const pos = sessionStorage.getItem('scrollPos');
+    if (path === window.location.pathname && pos !== null) {
+        window.scrollTo(0, parseInt(pos, 10));
+    }
+    sessionStorage.removeItem('scrollPath');
+    sessionStorage.removeItem('scrollPos');
+}
+
 window.addEventListener('DOMContentLoaded', () => {
     setupMenu();
     setupUserMenu();
@@ -121,6 +133,7 @@ window.addEventListener('DOMContentLoaded', () => {
     handleForms();
     highlightNav();
     handleNotificationsFromUrl();
+    restoreScroll();
     hideLoading();
     if (document.querySelector('.no-events')) {
         hideLoading();


### PR DESCRIPTION
## Summary
- store current scroll position before submitting admin forms
- restore saved scroll position on page load to keep context after refresh

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: could not resolve io.quarkus.platform:quarkus-bom due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898e3e8c4408333ba51e1faf7ae9390