### PR TITLE
Fix deploy workflow repo reference

### DIFF
--- a/.github/workflows/auto-merge-after-ci.yml
+++ b/.github/workflows/auto-merge-after-ci.yml
@@ -46,4 +46,5 @@ jobs:
       - name: Trigger Main Deploy workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run 'main-deploy.yml' --ref main
+          REPO: ${{ github.repository }}
+        run: gh workflow run 'main-deploy.yml' --repo "$REPO" --ref main


### PR DESCRIPTION
## Summary
- ensure `gh workflow run` explicitly targets the repository

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ee1707a08333bbf9cacde4d1995e