### PR TITLE
ci: fail fast on missing digest

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -46,10 +46,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           prs=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls -H "Accept: application/vnd.github+json")
           pr=$(echo "$prs"   | jq -r '.[0].number')
           head=$(echo "$prs" | jq -r '.[0].head.sha')
           DIGEST=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:pr-${pr}-${head}" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          if [ -z "$DIGEST" ]; then
+            echo "Failed to resolve image digest" >&2
+            exit 1
+          fi
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "ref=${REGISTRY}/${IMAGE_NAME}@${DIGEST}" >> $GITHUB_OUTPUT
           echo "REF=${REGISTRY}/${IMAGE_NAME}@${DIGEST}" >> $GITHUB_ENV
@@ -57,8 +62,13 @@ jobs:
       - name: Promote digest to semver tags (aliases)
         if: steps.ref.outcome == 'success'
         run: |
+          set -euo pipefail
           REF="${{ steps.ref.outputs.ref }}"
           V="${{ steps.ver.outputs.v }}"
+          if [ -z "$REF" ]; then
+            echo "Missing image reference" >&2
+            exit 1
+          fi
           MAJOR=${V%%.*}
           MINOR=${V%.*}
           docker buildx imagetools create -t ${REGISTRY}/${IMAGE_NAME}:v$V $REF


### PR DESCRIPTION
## Summary
- abort release workflow when image digest can't be resolved
- guard against empty image references during semver tag promotion

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68991d42352083339c4e87caa264abed