### PR TITLE
Add liveness and readiness probes for Quarkus

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -27,6 +27,20 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /q/health/live
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /q/health/ready
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            failureThreshold: 3
           env:
             - name: JAVA_TOOL_OPTIONS
               value: "-XX:+UseContainerSupport -Deventflow.data.dir=/work/data"

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -66,6 +66,10 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Summary
- enable SmallRye Health extension
- configure liveness and readiness probes in the Kubernetes deployment

## Testing
- `mvn -q -e test` *(fails: Non-resolvable import POM: io.quarkus.platform:quarkus-bom)*

------
https://chatgpt.com/codex/tasks/task_e_689936437d608333b55981be31b5b9bc