### PR TITLE
Handle missing PR info when resolving image digest

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -48,8 +48,23 @@ jobs:
         run: |
           set -euo pipefail
           prs=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls -H "Accept: application/vnd.github+json")
-          pr=$(echo "$prs"   | jq -r '.[0].number')
-          head=$(echo "$prs" | jq -r '.[0].head.sha')
+          pr=$(echo "$prs"   | jq -r '.[0].number // empty')
+          head=$(echo "$prs" | jq -r '.[0].head.sha // empty')
+
+          if [ -z "$pr" ] || [ -z "$head" ]; then
+            # Fallback for squash merges: parse PR number from commit message
+            pr=$(git show -s --format=%s HEAD | sed -n 's/.*(#\([0-9]\+\)).*/\1/p')
+            if [ -n "$pr" ]; then
+              pr_json=$(gh api repos/${{ github.repository }}/pulls/$pr -H "Accept: application/vnd.github+json")
+              head=$(echo "$pr_json" | jq -r '.head.sha // empty')
+            fi
+          fi
+
+          if [ -z "$pr" ] || [ -z "$head" ]; then
+            echo "Failed to determine PR information" >&2
+            exit 1
+          fi
+
           DIGEST=$(docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:pr-${pr}-${head}" --format '{{json .Manifest.Digest}}' | tr -d '"')
           if [ -z "$DIGEST" ]; then
             echo "Failed to resolve image digest" >&2


### PR DESCRIPTION
## Summary
- handle missing PR data by parsing PR number from commit message
- fail fast with clearer error when PR info unavailable

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/actionlint`

------
https://chatgpt.com/codex/tasks/task_e_68993bc06cf48333a507c95cfe555d74