### PR TITLE
ci: install Docker CLI in main deploy workflow

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Docker CLI
+        run: |
+          apt-get update && apt-get install -y docker.io
+
       - name: Read version from pom.xml
         id: ver
         working-directory: quarkus-app


### PR DESCRIPTION
## Summary
- install Docker CLI in `main-deploy` workflow to enable registry login and image tagging

## Testing
- `./mvnw -B -ntp test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68994a933c588333a50114d6d1ab59d0