### PR TITLE
Ensure bash shell for deployment workflow

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -52,6 +52,7 @@ jobs:
         id: ref
         env:
           GH_TOKEN: ${{ github.token }}
+        shell: bash
         run: |
           set -euo pipefail
           prs=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls -H "Accept: application/vnd.github+json")
@@ -83,6 +84,7 @@ jobs:
 
       - name: Promote digest to semver tags (aliases)
         if: steps.ref.outcome == 'success'
+        shell: bash
         run: |
           set -euo pipefail
           REF="${{ steps.ref.outputs.ref }}"


### PR DESCRIPTION
## Summary
- use bash shell for digest resolution and promotion steps to support pipefail

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68994f81f5b88333825aa33ed8072c3a