### PR TITLE
feat: improve admin talk creation feedback

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -246,7 +246,7 @@ public class AdminEventResource {
                 || startTime == null || startTime.isBlank()) {
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location",
-                            "/private/admin/events/" + eventId + "/edit?msg=Campos+obligatorios")
+                            "/private/admin/events/" + eventId + "/edit?error=Campos+obligatorios")
                     .build();
         }
         Talk base = speakerId != null && !speakerId.isBlank()
@@ -255,7 +255,7 @@ public class AdminEventResource {
         if (base == null) {
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location",
-                            "/private/admin/events/" + eventId + "/edit?msg=Charla+no+encontrada")
+                            "/private/admin/events/" + eventId + "/edit?error=Charla+no+encontrada")
                     .build();
         }
         Talk talk = new Talk(talkId, base.getName());
@@ -269,12 +269,12 @@ public class AdminEventResource {
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location",
                             "/private/admin/events/" + eventId
-                                    + "/edit?msg=Horario+solapado")
+                                    + "/edit?error=Horario+solapado")
                     .build();
         }
         eventService.saveTalk(eventId, talk);
         return Response.status(Response.Status.SEE_OTHER)
-                .header("Location", "/private/admin/events/" + eventId + "/edit")
+                .header("Location", "/private/admin/events/" + eventId + "/edit?success=Charla+agregada")
                 .build();
     }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -83,6 +83,9 @@ public class EventService {
         }
         event.getAgenda().removeIf(t -> t.getId().equals(talk.getId()));
         event.getAgenda().add(talk);
+        event.getAgenda().sort(java.util.Comparator
+                .comparingInt(Talk::getDay)
+                .thenComparing(Talk::getStartTime, java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())));
         persistence.saveEvents(new ConcurrentHashMap<>(events));
     }
 


### PR DESCRIPTION
## Summary
- show success and error notifications when adding talks in admin UI
- order event agenda chronologically after saving a talk

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899e4df00688333940529183606f39a