### PR TITLE
feat: add compact my talks view

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/MyTalksResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/MyTalksResource.java
@@ -1,0 +1,93 @@
+package com.scanales.eventflow.private_;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.scanales.eventflow.model.TalkInfo;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.UserScheduleService;
+import com.scanales.eventflow.service.UserScheduleService.TalkDetails;
+
+import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Compact view of the talks registered by the current user grouped by day.
+ */
+@Path("/private/my-talks")
+public class MyTalksResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance myTalks(List<DayGroup> days,
+                Map<String, TalkDetails> info);
+    }
+
+    /** Talks grouped by day. */
+    public record DayGroup(int day, List<TalkInfo> talks) {}
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    EventService eventService;
+
+    @Inject
+    UserScheduleService userSchedule;
+
+    @GET
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public TemplateInstance show() {
+        String email = getEmail();
+        var info = userSchedule.getTalkDetailsForUser(email);
+        var talkIds = info.keySet();
+        List<TalkInfo> entries = talkIds.stream()
+                .map(eventService::findTalkInfo)
+                .filter(java.util.Objects::nonNull)
+                .sorted(java.util.Comparator
+                        .comparingInt((TalkInfo ti) -> ti.talk().getDay())
+                        .thenComparing(ti -> ti.talk().getStartTime(),
+                                java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
+                .toList();
+
+        Map<Integer, DayGroup> grouped = new LinkedHashMap<>();
+        for (TalkInfo ti : entries) {
+            grouped.computeIfAbsent(ti.talk().getDay(), d -> new DayGroup(d, new ArrayList<>()))
+                    .talks().add(ti);
+        }
+
+        return Templates.myTalks(new ArrayList<>(grouped.values()), info);
+    }
+
+    private String getClaim(String claimName) {
+        Object value = null;
+        if (identity.getPrincipal() instanceof OidcJwtCallerPrincipal oidc) {
+            value = oidc.getClaim(claimName);
+        }
+        if (value == null) {
+            value = identity.getAttribute(claimName);
+        }
+        return value == null ? null : value.toString();
+    }
+
+    private String getEmail() {
+        String email = getClaim("email");
+        if (email == null) {
+            email = identity.getPrincipal().getName();
+        }
+        return email;
+    }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -89,7 +89,7 @@ public class AppTemplateExtensions {
     /** Returns a human-readable state for the given talk based on current time. */
     public static String talkState(Talk t) {
         if (t == null || t.getStartTime() == null) {
-            return "A tiempo";
+            return "Programada";
         }
         LocalTime now = LocalTime.now();
         LocalTime start = t.getStartTime();
@@ -102,15 +102,15 @@ public class AppTemplateExtensions {
         }
         long minutes = Duration.between(now, start).toMinutes();
         if (minutes <= 15) {
-            return "Pronto";
+            return "Por comenzar";
         }
-        return "A tiempo";
+        return "Programada";
     }
 
     /** CSS class for the talk state badge. */
     public static String talkStateClass(Talk t) {
         return switch (talkState(t)) {
-            case "Pronto" -> "warning";
+            case "Por comenzar" -> "warning";
             case "En curso" -> "info";
             case "Finalizada" -> "past";
             default -> "success";

--- a/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
+++ b/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
@@ -1,0 +1,100 @@
+{#include layout/base}
+{#title}Mis Charlas{/title}
+{#main}
+<h1>Mis Charlas</h1>
+{#if days.isEmpty()}
+<p>No has agregado ninguna charla.</p>
+{#else}
+{#for d in days}
+  <h2 class="day-title">Día {d.day}</h2>
+  {#for t in d.talks}
+    <div class="talk-row" data-talk-id="{t.talk.id}" data-attended="{info.get(t.talk.id).attended}" data-rated="{info.get(t.talk.id).rating??}">
+      <span class="talk-time">{t.talk.startTimeStr} - {t.talk.endTimeStr}</span>
+      <span class="talk-title"><a href="/talk/{t.talk.id}">{t.talk.name}</a></span>
+      <span class="badge talk-state {app:talkStateClass(t.talk)}">{app:talkState(t.talk)}</span>
+      <div class="talk-actions">
+        <label class="attended-label" title="Asistí"><input type="checkbox" class="attended-checkbox" data-talk-id="{t.talk.id}" {#if info.get(t.talk.id).attended}checked{/if}></label>
+        <select class="rating-select" data-talk-id="{t.talk.id}" title="Valorar">
+          <option value="">★</option>
+          <option value="1" {#if info.get(t.talk.id).rating == 1}selected{/if}>1</option>
+          <option value="2" {#if info.get(t.talk.id).rating == 2}selected{/if}>2</option>
+          <option value="3" {#if info.get(t.talk.id).rating == 3}selected{/if}>3</option>
+          <option value="4" {#if info.get(t.talk.id).rating == 4}selected{/if}>4</option>
+          <option value="5" {#if info.get(t.talk.id).rating == 5}selected{/if}>5</option>
+        </select>
+        <button class="btn btn-secondary remove-talk" data-talk-id="{t.talk.id}" title="Eliminar">🗑️</button>
+      </div>
+    </div>
+  {/for}
+{/for}
+{/if}
+<script>
+(function() {
+  const updateTalk = async (id, data) => {
+    try {
+      const res = await fetch('/private/profile/update/' + id, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (!res.ok) {
+        showNotification('error', 'Error al guardar los cambios');
+      }
+    } catch (e) {
+      showNotification('error', 'Error al guardar los cambios');
+    }
+  };
+
+  document.querySelectorAll('.attended-checkbox').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const id = cb.dataset.talkId;
+      const attended = cb.checked;
+      const row = cb.closest('.talk-row');
+      if (row) {
+        row.dataset.attended = attended ? 'true' : 'false';
+      }
+      updateTalk(id, { attended });
+    });
+  });
+
+  document.querySelectorAll('.rating-select').forEach(sel => {
+    sel.addEventListener('change', () => {
+      const id = sel.dataset.talkId;
+      const rating = sel.value ? parseInt(sel.value) : null;
+      const row = sel.closest('.talk-row');
+      if (row) {
+        row.dataset.rated = rating ? 'true' : 'false';
+      }
+      updateTalk(id, { rating });
+    });
+  });
+
+  document.querySelectorAll('.remove-talk').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      if (!confirm('¿Estás seguro?')) return;
+      const id = btn.dataset.talkId;
+      btn.disabled = true;
+      try {
+        const res = await fetch('/private/profile/remove/' + id, {
+          method: 'POST',
+          headers: { 'Accept': 'application/json', 'Content-Type': 'application/json' },
+          body: '{}'
+        });
+        if (res.ok) {
+          const row = btn.closest('.talk-row');
+          if (row) row.remove();
+          showNotification('success', 'Charla eliminada de tu agenda');
+        } else {
+          showNotification('error', 'Ocurrió un error al eliminar la charla');
+        }
+      } catch (e) {
+        showNotification('error', 'Ocurrió un error al eliminar la charla');
+      } finally {
+        btn.disabled = false;
+      }
+    });
+  });
+})();
+</script>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -16,7 +16,7 @@
         <a href="/">Inicio</a>
         {#if app:isAuthenticated()}
             <a href="/my-events">Mis Eventos</a>
-            <a href="/private/profile">Mis Charlas</a>
+            <a href="/private/my-talks">Mis Charlas</a>
             {#if app:isAdmin()}
                 <a href="/private/admin">Admin</a>
             {/if}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/MyTalksResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/MyTalksResourceTest.java
@@ -1,0 +1,20 @@
+package com.scanales.eventflow.private_;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+
+@QuarkusTest
+public class MyTalksResourceTest {
+
+    @Test
+    @TestSecurity(user = "user@example.com")
+    public void getMyTalks() {
+        given()
+          .when().get("/private/my-talks")
+          .then().statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary
- implement compact "Mis Charlas" agenda grouped by day
- expose new `/private/my-talks` page and navigation link
- align talk state labels with admin view

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899f404ca6083338eec159f77680287