### PR TITLE
Trigger Build Native on PR merge

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -3,9 +3,14 @@ name: Build Native
 on:
   push:
     branches: ["main"]
+  pull_request:
+    branches: ["main"]
+    types:
+      - closed
 
 jobs:
   build-native:
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       IMAGE_VERSION: v2.0.0


### PR DESCRIPTION
## Summary
- run Build Native workflow when a pull request to main is merged or code is pushed directly

## Testing
- `mvn -B -f quarkus-app/pom.xml package` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom from central)*

------
https://chatgpt.com/codex/tasks/task_e_6899f642604c83339e91bf346495f79f