### PR TITLE
ci: run build-native on main branch updates

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -3,14 +3,9 @@ name: Build Native
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
-    types:
-      - closed
 
 jobs:
   build-native:
-    if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       IMAGE_VERSION: v2.0.0


### PR DESCRIPTION
## Summary
- run native build workflow on every push to `main`

## Testing
- `mvn -q test` *(fails: could not resolve artifacts from Maven Central, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6899fded70688333aae9bd48246223da