### PR TITLE
Trigger native build after successful build workflow

### DIFF
--- a/.github/workflows/build-native-on-build.yml
+++ b/.github/workflows/build-native-on-build.yml
@@ -1,0 +1,13 @@
+name: Build Native on Build Completion
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  build-native:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/build-native.yml
+    secrets: inherit

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,9 +1,10 @@
 ---
 name: Build Native
 
-'on':
+on:
   push:
     branches: ['main']
+  workflow_call:
 
 jobs:
   build-native:


### PR DESCRIPTION
## Summary
- allow `Build Native` workflow to be called by other workflows
- add workflow to run native build after the `Build` workflow completes successfully

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Non-resolvable import POM: The following artifacts could not be resolved: io.quarkus.platform:quarkus-bom:pom:3.24.3 (absent): Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a6fcff4848333b94e5e8079b80fde