### PR TITLE
Trigger GKE deployment after native build success

### DIFF
--- a/.github/workflows/deploy-on-build-native.yml
+++ b/.github/workflows/deploy-on-build-native.yml
@@ -1,0 +1,13 @@
+name: Deploy on Build Native Completion
+
+on:
+  workflow_run:
+    workflows: ["Build Native"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,10 @@
 name: Deploy to GKE
 
 on:
-  workflow_run:
-    workflows: ["Build Native"]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     container:
       image: google/cloud-sdk:latest


### PR DESCRIPTION
## Summary
- Make `Deploy to GKE` workflow reusable
- Run GKE deployment when `Build Native` workflow completes successfully

## Testing
- `mvn -B -f quarkus-app/pom.xml test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a75d5d63c8333bb7c2d6e16947f40