### PR TITLE
feat: add logging and feedback for admin talk creation

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -104,9 +104,18 @@ public class EventService {
      * @return {@code true} if an overlap is detected
      */
     public boolean hasOverlap(String eventId, Talk talk) {
+        return findOverlap(eventId, talk) != null;
+    }
+
+    /**
+     * Returns an existing talk that overlaps with the given one or {@code null}
+     * if none. Two talks overlap when they occur on the same day and scenario
+     * and their times intersect.
+     */
+    public Talk findOverlap(String eventId, Talk talk) {
         Event event = events.get(eventId);
         if (event == null || talk.getStartTime() == null) {
-            return false;
+            return null;
         }
         java.time.LocalTime start = talk.getStartTime();
         java.time.LocalTime end = talk.getEndTime();
@@ -115,14 +124,16 @@ public class EventService {
                         && t.getDay() == talk.getDay()
                         && t.getLocation() != null
                         && t.getLocation().equals(talk.getLocation()))
-                .anyMatch(t -> {
+                .filter(t -> {
                     java.time.LocalTime s = t.getStartTime();
                     java.time.LocalTime e = t.getEndTime();
                     if (s == null) {
                         return false;
                     }
                     return !start.isAfter(e) && !end.isBefore(s);
-                });
+                })
+                .findFirst()
+                .orElse(null);
     }
 
     public Scenario findScenario(String scenarioId) {


### PR DESCRIPTION
## Summary
- improve admin talk creation with request-scoped logging and error handling
- add overlap lookup helper in EventService for detailed conflict feedback

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a935f9b9883339c6d1ad782b64a0d