### PR TITLE
Allow adjacent talks and encode admin error messages

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -252,9 +252,12 @@ public class AdminEventResource {
         if (talkId == null || talkId.isBlank() || location == null || location.isBlank()
                 || startTime == null || startTime.isBlank()) {
             LOG.warnf("accion=charla_crear_validacion_fallida causa=faltan_campos usuario=%s eventoId=%s requestId=%s", user, eventId, reqId);
+            String msg = java.net.URLEncoder.encode(
+                    "Campos obligatorios",
+                    java.nio.charset.StandardCharsets.UTF_8);
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location",
-                            "/private/admin/events/" + eventId + "/edit?msg=Campos+obligatorios")
+                            "/private/admin/events/" + eventId + "/edit?msg=" + msg)
                     .build();
         }
         Talk base = speakerId != null && !speakerId.isBlank()
@@ -262,9 +265,12 @@ public class AdminEventResource {
                 : speakerService.findTalk(talkId);
         if (base == null) {
             LOG.warnf("accion=charla_crear_validacion_fallida causa=charla_no_encontrada talkId=%s eventoId=%s requestId=%s", talkId, eventId, reqId);
+            String msg = java.net.URLEncoder.encode(
+                    "Charla no encontrada",
+                    java.nio.charset.StandardCharsets.UTF_8);
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location",
-                            "/private/admin/events/" + eventId + "/edit?msg=Charla+no+encontrada")
+                            "/private/admin/events/" + eventId + "/edit?msg=" + msg)
                     .build();
         }
         java.time.LocalTime start = java.time.LocalTime.parse(startTime);
@@ -272,9 +278,12 @@ public class AdminEventResource {
         LOG.infof("accion=charla_crear_intento usuario=%s eventoId=%s charlaTitulo=%s fechaInicio=%s fechaFin=%s dia=%d sala=%s requestId=%s", user, eventId, base.getName(), start, end, day, location, reqId);
         if (event.getAgenda().stream().anyMatch(t -> t.getId().equals(talkId))) {
             LOG.warnf("accion=charla_crear_rechazada motivo=duplicado charlaExistenteId=%s eventoId=%s requestId=%s", talkId, eventId, reqId);
+            String msg = java.net.URLEncoder.encode(
+                    "Esta charla ya existe para el evento",
+                    java.nio.charset.StandardCharsets.UTF_8);
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location",
-                            "/private/admin/events/" + eventId + "/edit?msg=Esta+charla+ya+existe+para+el+evento")
+                            "/private/admin/events/" + eventId + "/edit?msg=" + msg)
                     .build();
         }
         Talk talk = new Talk(talkId, base.getName());
@@ -287,7 +296,8 @@ public class AdminEventResource {
         Talk overlap = eventService.findOverlap(eventId, talk);
         if (overlap != null) {
             LOG.warnf("accion=charla_crear_rechazada motivo=conflicto_agenda charlaExistenteId=%s eventoId=%s requestId=%s", overlap.getId(), eventId, reqId);
-            String msg = String.format("No+se+pudo+agregar:+hay+un+solapamiento+en+%s+dia+%d+%s+con+'%s'", location, day, start, overlap.getName());
+            String raw = String.format("No se pudo agregar: hay un solapamiento en %s dia %d %s con '%s'", location, day, start, overlap.getName());
+            String msg = java.net.URLEncoder.encode(raw, java.nio.charset.StandardCharsets.UTF_8);
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
                     .build();
@@ -303,7 +313,9 @@ public class AdminEventResource {
                     .build();
         } catch (Exception e) {
             LOG.errorf(e, "accion=charla_crear_error motivo=excepcion requestId=%s", reqId);
-            String msg = "No+pudimos+agregar+la+charla+en+este+momento.+Intenta+nuevamente";
+            String msg = java.net.URLEncoder.encode(
+                    "No pudimos agregar la charla en este momento. Intenta nuevamente",
+                    java.nio.charset.StandardCharsets.UTF_8);
             return Response.status(Response.Status.SEE_OTHER)
                     .header("Location", "/private/admin/events/" + eventId + "/edit?msg=" + msg)
                     .build();

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -127,10 +127,10 @@ public class EventService {
                 .filter(t -> {
                     java.time.LocalTime s = t.getStartTime();
                     java.time.LocalTime e = t.getEndTime();
-                    if (s == null) {
+                    if (s == null || e == null) {
                         return false;
                     }
-                    return !start.isAfter(e) && !end.isBefore(s);
+                    return start.isBefore(e) && end.isAfter(s);
                 })
                 .findFirst()
                 .orElse(null);

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/EventServiceOverlapTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/EventServiceOverlapTest.java
@@ -1,0 +1,61 @@
+package com.scanales.eventflow.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class EventServiceOverlapTest {
+
+    @Inject
+    EventService eventService;
+
+    private static final String EVENT_ID = "e-overlap";
+
+    @BeforeEach
+    public void setup() {
+        Event event = new Event(EVENT_ID, "Event", "desc");
+        Talk t1 = new Talk("t1", "Talk 1");
+        t1.setLocation("room");
+        t1.setDay(1);
+        t1.setStartTime(LocalTime.of(9, 0));
+        t1.setDurationMinutes(30); // ends 09:30
+        event.getAgenda().add(t1);
+        eventService.saveEvent(event);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        eventService.deleteEvent(EVENT_ID);
+    }
+
+    @Test
+    public void touchingTalksDoNotOverlap() {
+        Talk t2 = new Talk("t2", "Talk 2");
+        t2.setLocation("room");
+        t2.setDay(1);
+        t2.setStartTime(LocalTime.of(9, 30)); // starts when previous ends
+        t2.setDurationMinutes(30);
+        assertNull(eventService.findOverlap(EVENT_ID, t2));
+    }
+
+    @Test
+    public void overlappingTalksAreDetected() {
+        Talk t2 = new Talk("t3", "Talk 3");
+        t2.setLocation("room");
+        t2.setDay(1);
+        t2.setStartTime(LocalTime.of(9, 25)); // starts before previous ends
+        t2.setDurationMinutes(30);
+        assertNotNull(eventService.findOverlap(EVENT_ID, t2));
+    }
+}


### PR DESCRIPTION
## Summary
- Relax overlap detection so back-to-back talks don't conflict
- URL-encode admin talk messages so errors display correctly
- Test that adjacent talks are accepted and overlaps are detected

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a9811a2388333a626641dd5314ffb