### PR TITLE
Sanitize talk names and limit length

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Talk.java
@@ -68,16 +68,17 @@ public class Talk {
     }
 
     /**
-     * Sanitizes talk names by removing control characters, stripping
-     * unsupported symbols and normalizing whitespace. The result is
-     * truncated to {@link #MAX_NAME_LENGTH} characters.
+     * Sanitizes talk names by replacing control characters with spaces,
+     * stripping unsupported symbols and normalizing whitespace. The result
+     * is truncated to {@link #MAX_NAME_LENGTH} characters.
      */
     public static String sanitizeName(String value) {
         if (value == null) {
             return null;
         }
         String normalized = Normalizer.normalize(value, Normalizer.Form.NFKC);
-        normalized = normalized.replaceAll("\\p{Cntrl}", "");
+        // Replace control characters with spaces to preserve word boundaries
+        normalized = normalized.replaceAll("\\p{Cntrl}", " ");
         normalized = normalized.replaceAll("[^\\p{L}\\p{N}\\p{Punct} ]", "");
         normalized = normalized.replaceAll("\\s+", " ").trim();
         if (normalized.length() > MAX_NAME_LENGTH) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminSpeakerResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminSpeakerResource.java
@@ -115,9 +115,11 @@ public class AdminSpeakerResource {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
+
+        name = Talk.sanitizeName(name);
         if (name == null || name.isBlank() || duration <= 0) {
             return Response.status(Response.Status.SEE_OTHER)
-                    .header("Location", "/private/admin/speakers?msg=Campos+obligatorios")
+                    .header("Location", "/private/admin/speakers?msg=Nombre+inv\u00e1lido")
                     .build();
         }
         if (talkId == null || talkId.isBlank()) {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/model/TalkSanitizationTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/model/TalkSanitizationTest.java
@@ -11,7 +11,7 @@ public class TalkSanitizationTest {
     void removesInvalidCharacters() {
         String raw = "  Name\tWith\u0000Controls \uD83D\uDC7E and emoji  ";
         Talk talk = new Talk("id1", raw);
-        assertEquals("Name WithControls and emoji", talk.getName());
+        assertEquals("Name With Controls and emoji", talk.getName());
     }
 
     @Test

--- a/quarkus-app/src/test/java/com/scanales/eventflow/model/TalkSanitizationTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/model/TalkSanitizationTest.java
@@ -1,0 +1,24 @@
+package com.scanales.eventflow.model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for Talk name sanitization. */
+public class TalkSanitizationTest {
+
+    @Test
+    void removesInvalidCharacters() {
+        String raw = "  Name\tWith\u0000Controls \uD83D\uDC7E and emoji  ";
+        Talk talk = new Talk("id1", raw);
+        assertEquals("Name WithControls and emoji", talk.getName());
+    }
+
+    @Test
+    void truncatesToMaxLength() {
+        String longName = "a".repeat(Talk.MAX_NAME_LENGTH + 5);
+        Talk talk = new Talk("id2", longName);
+        assertEquals(Talk.MAX_NAME_LENGTH, talk.getName().length());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Restrict talk title length and strip unsupported characters
- Sanitize talk names on speaker admin endpoint
- Add unit tests for talk name sanitization

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a9df666ac8333850b57f423b4854f