### PR TITLE
Show admin event errors

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -113,6 +113,11 @@ function handleNotificationsFromUrl() {
     if (params.has('error')) {
         showNotification('error', params.get('error'));
     }
+    if (params.has('msg')) {
+        const msg = params.get('msg');
+        const type = msg.startsWith('✅') ? 'success' : 'error';
+        showNotification(type, msg);
+    }
 }
 
 function restoreScroll() {


### PR DESCRIPTION
## Summary
- Show notifications for `msg` query parameters so admin pages surface event errors

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689abba4044c8333b78d5f18bf3c1713