### PR TITLE
Limit speaker images to avatar size

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -6,6 +6,7 @@
     --color-dark: #0d47a1;
     --color-text: #333;
     --color-light: #fff;
+    --avatar-size: 80px;
 }
 
 html {
@@ -381,8 +382,10 @@ button:focus-visible {
     margin-bottom: 1rem;
 }
 .speaker-card .speaker-photo {
-    width: 100%;
-    border-radius: 4px;
+    width: var(--avatar-size);
+    height: var(--avatar-size);
+    border-radius: 50%;
+    object-fit: cover;
 }
 
 .speaker-form,
@@ -839,8 +842,10 @@ p.note {
 }
 
 .speaker-summary .speaker-photo {
-    max-width: 150px;
+    width: var(--avatar-size);
+    height: var(--avatar-size);
     border-radius: 50%;
+    object-fit: cover;
 }
 
 .speaker-summary .speaker-info {

--- a/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
@@ -10,7 +10,7 @@
   <li class="card speaker-card">
     <form method="post" action="/private/admin/speakers" class="speaker-form">
       <input type="hidden" name="id" value="{s.id}">
-      {#if app:validUrl(s.photoUrl)}<img src="{s.photoUrl}" alt="{s.name}" class="speaker-photo">{/if}
+      {#if app:validUrl(s.photoUrl)}<img src="{s.photoUrl}" alt="{s.name}" class="speaker-photo" width="80" height="80">{/if}
       <div class="item-header">
         <span class="icon speaker-icon">👤</span>
         <span class="item-id">{s.id}</span>

--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -10,7 +10,7 @@
 <section class="speaker-detail">
   <div class="card speaker-summary">
     <div class="speaker-header">
-      {#if speaker.photoUrl}<img src="{speaker.photoUrl}" alt="Foto de {speaker.name}" class="speaker-photo">{/if}
+      {#if speaker.photoUrl}<img src="{speaker.photoUrl}" alt="Foto de {speaker.name}" class="speaker-photo" width="80" height="80">{/if}
       <div class="speaker-info">
         <h1 class="page-title">{speaker.name}</h1>
         {#if speaker.bio}<p class="speaker-bio">{speaker.bio}</p>{/if}


### PR DESCRIPTION
## Summary
- Constrain speaker images to a predefined avatar size using a new CSS variable.
- Update speaker templates to explicitly size images and reduce space usage.

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689abf40fdb88333ad7f25cad21551aa