### PR TITLE
Fix talk state calculation based on event date

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -256,7 +256,7 @@ Nuevo Evento
       <h4>{sc.name}</h4>
       <ul class="agenda-list">
         {#for t in event.getAgendaForDayAndScenario(d, sc.id)}
-          <li class="agenda-item"><span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>{t.startTimeStr} - {t.endTimeStr} | {t.name} <span class="badge {app:talkStateClass(t)}">{app:talkState(t)}</span></li>
+          <li class="agenda-item"><span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>{t.startTimeStr} - {t.endTimeStr} | {t.name} <span class="badge {app:talkStateClass(t, event)}">{app:talkState(t, event)}</span></li>
         {/for}
       </ul>
       {/if}

--- a/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
+++ b/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
@@ -11,7 +11,7 @@
     <div class="talk-row" data-talk-id="{t.talk.id}" data-attended="{info.get(t.talk.id).attended}" data-rated="{info.get(t.talk.id).rating??}">
       <span class="talk-time">{t.talk.startTimeStr} - {t.talk.endTimeStr}</span>
       <span class="talk-title"><a href="/talk/{t.talk.id}">{t.talk.name}</a></span>
-      <span class="badge talk-state {app:talkStateClass(t.talk)}">{app:talkState(t.talk)}</span>
+      <span class="badge talk-state {app:talkStateClass(t.talk, t.event)}">{app:talkState(t.talk, t.event)}</span>
       <div class="talk-actions">
         <label class="attended-label" title="Asistí"><input type="checkbox" class="attended-checkbox" data-talk-id="{t.talk.id}" {#if info.get(t.talk.id).attended}checked{/if}></label>
         <select class="rating-select" data-talk-id="{t.talk.id}" title="Valorar">

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -26,7 +26,7 @@
           <span class="attendance-icon">{#if info.get(t.id).attended}✅{#else}❌{/if}</span>
           <span class="talk-time">{t.startTimeStr} - {t.endTimeStr}</span>
           <span class="talk-title"><a href="/talk/{t.id}">{t.name}</a></span>
-          <span class="badge talk-state {app:talkStateClass(t)}">{app:talkState(t)}</span>
+          <span class="badge talk-state {app:talkStateClass(t, g.event)}">{app:talkState(t, g.event)}</span>
           <div class="talk-actions">
             <div class="motivation-list">
               {#for m in info.get(t.id).motivations}


### PR DESCRIPTION
## Summary
- compute talk status using event date and day
- pass event context to templates when rendering talk states

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b22092d7c8333a4eeef420f690d49