### PR TITLE
Add event timezone support and adjust talk status

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -52,6 +52,8 @@ public class Event {
     private String creator;
     /** Day when the event takes place. */
     private LocalDate date;
+    /** Time zone identifier for the event, e.g. "UTC" or "Europe/Madrid". */
+    private String timezone;
 
     public Event() {
     }
@@ -214,6 +216,14 @@ public class Event {
 
     public void setDate(LocalDate date) {
         this.date = date;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
     }
 
     public String getDateStr() {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminEventResource.java
@@ -101,6 +101,7 @@ public class AdminEventResource {
     public Response saveEvent(@FormParam("title") String title,
                               @FormParam("description") String description,
                               @FormParam("date") String date,
+                              @FormParam("timezone") String timezone,
                               @FormParam("days") int days,
                               @FormParam("logoUrl") String logoUrl,
                               @FormParam("mapUrl") String mapUrl,
@@ -117,6 +118,7 @@ public class AdminEventResource {
         String id = java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss").format(now);
         Event event = new Event(id, title, description, days, now, identity.getAttribute("email"));
         event.setDateStr(date);
+        event.setTimezone(sanitizeZone(timezone));
         event.setLogoUrl(sanitizeUrl(logoUrl));
         event.setMapUrl(sanitizeUrl(mapUrl));
         event.setContactEmail(sanitizeEmail(contactEmail));
@@ -138,6 +140,7 @@ public class AdminEventResource {
                                 @FormParam("title") String title,
                                 @FormParam("description") String description,
                                 @FormParam("date") String date,
+                                @FormParam("timezone") String timezone,
                                 @FormParam("days") int days,
                                 @FormParam("logoUrl") String logoUrl,
                                 @FormParam("mapUrl") String mapUrl,
@@ -157,6 +160,7 @@ public class AdminEventResource {
         event.setTitle(title);
         event.setDescription(description);
         event.setDateStr(date);
+        event.setTimezone(sanitizeZone(timezone));
         event.setDays(days);
         event.setLogoUrl(sanitizeUrl(logoUrl));
         event.setMapUrl(sanitizeUrl(mapUrl));
@@ -512,6 +516,17 @@ public class AdminEventResource {
         return email.contains("@") ? email : null;
     }
 
+    private String sanitizeZone(String zone) {
+        if (zone == null || zone.isBlank()) {
+            return null;
+        }
+        try {
+            return java.time.ZoneId.of(zone).getId();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private void fillDefaults(Event event) {
         if (event.getTitle() == null) event.setTitle("VACIO");
         if (event.getDescription() == null) event.setDescription("VACIO");
@@ -523,6 +538,7 @@ public class AdminEventResource {
         if (event.getLinkedin() == null) event.setLinkedin("VACIO");
         if (event.getInstagram() == null) event.setInstagram("VACIO");
         if (event.getTicketsUrl() == null) event.setTicketsUrl("VACIO");
+        if (event.getTimezone() == null) event.setTimezone("UTC");
         if (event.getCreator() == null) event.setCreator("VACIO");
         if (event.getCreatedAt() == null) event.setCreatedAt(java.time.LocalDateTime.now());
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -89,6 +89,25 @@ public class AppTemplateExtensions {
         return email != null && EMAIL_PATTERN.matcher(email).matches();
     }
 
+    /** List of common time zones for event selection. */
+    public static List<String> commonTimezones() {
+        return List.of(
+                "UTC",
+                "America/Los_Angeles",
+                "America/New_York",
+                "America/Mexico_City",
+                "America/Sao_Paulo",
+                "America/Argentina/Buenos_Aires",
+                "America/Bogota",
+                "Europe/London",
+                "Europe/Madrid",
+                "Europe/Paris",
+                "Asia/Tokyo",
+                "Asia/Hong_Kong",
+                "Asia/Kolkata",
+                "Australia/Sydney");
+    }
+
     /** Returns a human-readable state for the given talk based on current time. */
     public static String talkState(Talk t) {
         return talkState(t, null);
@@ -103,7 +122,12 @@ public class AppTemplateExtensions {
             return "Programada";
         }
         if (event != null && event.getDate() != null) {
-            ZoneId zone = ZoneId.systemDefault();
+            ZoneId zone;
+            try {
+                zone = event.getTimezone() != null ? ZoneId.of(event.getTimezone()) : ZoneId.systemDefault();
+            } catch (Exception e) {
+                zone = ZoneId.systemDefault();
+            }
             LocalDateTime now = LocalDateTime.now(zone);
             LocalDateTime start = event.getDate()
                     .plusDays(Math.max(0, t.getDay() - 1L))

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -37,6 +37,12 @@ Nuevo Evento
     <label for="date">Fecha de realización</label>
     <input id="date" name="date" type="date" value="{event.dateStr}">
     <p class="event-time-info">Horario calculado: {#if event.startTimeStr}{event.startTimeStr} - {event.endTimeStr}{#else}Sin charlas{/if}</p>
+    <label for="timezone">Zona horaria</label>
+    <select id="timezone" name="timezone">
+      {#for tz in app:commonTimezones()}
+      <option value="{tz}"{#if tz == event.timezone} selected{/if}>{tz}</option>
+      {/for}
+    </select>
     <label for="days">Días del evento</label>
     <input id="days" name="days" type="number" min="1" max="10" value="{event.days}">
     <label for="logoUrl">Logo URL</label>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -22,7 +22,7 @@ Evento
       <div class="event-info">
         <h1 class="page-title">{event.title}</h1>
         {#if event.formattedDate}
-        <p class="event-datetime">{event.formattedDate} | {event.startTimeStr} – {event.endTimeStr} hrs.</p>
+        <p class="event-datetime">{event.formattedDate} | {event.startTimeStr} – {event.endTimeStr} hrs{#if event.timezone} ({event.timezone}){/if}.</p>
         {/if}
         {#if event.description}
         <p class="event-description">{event.description}</p>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/util/AppTemplateExtensionsTalkStateTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/util/AppTemplateExtensionsTalkStateTest.java
@@ -1,0 +1,32 @@
+package com.scanales.eventflow.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+
+public class AppTemplateExtensionsTalkStateTest {
+
+    @Test
+    void talkStateUsesEventTimezone() {
+        ZoneId tokyo = ZoneId.of("Asia/Tokyo");
+        ZonedDateTime nowUtc = ZonedDateTime.now(ZoneId.of("UTC"));
+        ZonedDateTime nowTokyo = nowUtc.withZoneSameInstant(tokyo);
+
+        Event event = new Event();
+        event.setDate(nowTokyo.toLocalDate());
+        event.setTimezone(tokyo.getId());
+
+        Talk talk = new Talk("id", "name");
+        talk.setStartTime(nowTokyo.minusMinutes(30).toLocalTime());
+        talk.setDurationMinutes(10);
+
+        String state = AppTemplateExtensions.talkState(talk, event);
+        assertEquals("Finalizada", state);
+    }
+}


### PR DESCRIPTION
## Summary
- Add timezone field to events with dropdown list of common zones in admin UI
- Use event timezone when computing talk state
- Display timezone on event page and test that talk state respects it

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b2fdd94f883338fc065050d43b851