### PR TITLE
Add Santiago timezone with offset details

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -5,6 +5,8 @@ import java.time.LocalTime;
 import java.time.LocalDateTime;
 import java.time.Duration;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.Instant;
 import java.util.List;
 import java.net.URI;
 
@@ -99,6 +101,7 @@ public class AppTemplateExtensions {
                 "America/Sao_Paulo",
                 "America/Argentina/Buenos_Aires",
                 "America/Bogota",
+                "America/Santiago",
                 "Europe/London",
                 "Europe/Madrid",
                 "Europe/Paris",
@@ -106,6 +109,25 @@ public class AppTemplateExtensions {
                 "Asia/Hong_Kong",
                 "Asia/Kolkata",
                 "Australia/Sydney");
+    }
+
+    /** Returns the standard UTC offset of the given time zone, e.g. "UTC-4". */
+    public static String zoneDetail(String zoneId) {
+        try {
+            ZoneOffset offset = ZoneId.of(zoneId).getRules().getStandardOffset(Instant.now());
+            int totalSeconds = offset.getTotalSeconds();
+            if (totalSeconds == 0) {
+                return "UTC";
+            }
+            int hours = totalSeconds / 3600;
+            int minutes = Math.abs((totalSeconds / 60) % 60);
+            if (minutes == 0) {
+                return String.format("UTC%+d", hours);
+            }
+            return String.format("UTC%+d:%02d", hours, minutes);
+        } catch (Exception e) {
+            return "UTC";
+        }
     }
 
     /** Returns a human-readable state for the given talk based on current time. */

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/edit.html
@@ -40,7 +40,7 @@ Nuevo Evento
     <label for="timezone">Zona horaria</label>
     <select id="timezone" name="timezone">
       {#for tz in app:commonTimezones()}
-      <option value="{tz}"{#if tz == event.timezone} selected{/if}>{tz}</option>
+      <option value="{tz}"{#if tz == event.timezone} selected{/if}>{tz} ({app:zoneDetail(tz)})</option>
       {/for}
     </select>
     <label for="days">Días del evento</label>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/util/AppTemplateExtensionsZoneDetailTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/util/AppTemplateExtensionsZoneDetailTest.java
@@ -1,0 +1,17 @@
+package com.scanales.eventflow.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class AppTemplateExtensionsZoneDetailTest {
+
+    @Test
+    void zoneDetailProvidesOffset() {
+        assertEquals("UTC", AppTemplateExtensions.zoneDetail("UTC"));
+        String detail = AppTemplateExtensions.zoneDetail("America/Santiago");
+        assertTrue(detail.startsWith("UTC-"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- include America/Santiago in timezone selections
- show UTC offset alongside timezones in admin dropdown
- cover timezone detail utility with unit test

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b378f0d188333a1d05e32937dc8ff