### PR TITLE
Add co-speaker support and show avatars in agendas

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminSpeakerResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminSpeakerResource.java
@@ -114,7 +114,8 @@ public class AdminSpeakerResource {
                              @FormParam("talkId") String talkId,
                              @FormParam("name") String name,
                              @FormParam("description") String description,
-                             @FormParam("duration") int duration) {
+                             @FormParam("duration") int duration,
+                             @FormParam("coSpeakerId") String coSpeakerId) {
         if (!isAdmin()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
@@ -133,6 +134,12 @@ public class AdminSpeakerResource {
         Talk talk = new Talk(talkId, name);
         talk.setDescription(description);
         talk.setDurationMinutes(duration);
+        if (coSpeakerId != null && !coSpeakerId.isBlank()) {
+            Speaker co = speakerService.getSpeaker(coSpeakerId);
+            if (co != null) {
+                talk.setSpeakers(List.of(co));
+            }
+        }
         // main speaker will be added in service
         speakerService.saveTalk(speakerId, talk);
         return Response.status(Response.Status.SEE_OTHER)

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -86,10 +86,17 @@ public class SpeakerService {
         if (sp == null || talk == null || talk.getId() == null) {
             return;
         }
-        // ensure the main speaker is present in the talk
-        if (talk.getSpeakers() == null || talk.getSpeakers().isEmpty()) {
-            talk.setSpeakers(List.of(sp));
+        // ensure the main speaker is present and listed first
+        List<Speaker> allSpeakers = new ArrayList<>();
+        allSpeakers.add(sp);
+        if (talk.getSpeakers() != null) {
+            for (Speaker other : talk.getSpeakers()) {
+                if (other != null && !sp.getId().equals(other.getId())) {
+                    allSpeakers.add(other);
+                }
+            }
         }
+        talk.setSpeakers(allSpeakers);
         sp.getTalks().removeIf(t -> t.getId().equals(talk.getId()));
         sp.getTalks().add(talk);
         // propagate updates to all events using this talk

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -145,6 +145,12 @@ button:focus-visible {
     font-size: 1rem;
 }
 
+.speaker-avatars {
+    display: inline-flex;
+    gap: 0.25rem;
+    vertical-align: middle;
+}
+
 .dropdown {
     display: none;
     position: absolute;

--- a/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminSpeakerResource/list.html
@@ -44,6 +44,16 @@
             <div class="field"><label>Título</label><input name="name" value="{t.name}" placeholder="Título"></div>
             <div class="field"><label>Duración</label><input name="duration" type="number" min="1" value="{t.durationMinutes}" placeholder="Duración"></div>
             <div class="field"><label>Descripcion</label><input name="description" value="{t.description}" placeholder="Descripcion"></div>
+            <div class="field"><label><input type="checkbox" class="cospeaker-toggle" name="hasCo" {#if t.speakers.size > 1}checked{/if}> Co-Speaker</label>
+              <select name="coSpeakerId" class="cospeaker-select"{#if t.speakers.size <= 1} hidden{/if}>
+                <option value="">Seleccione co-speaker</option>
+                {#for sp in speakers}
+                  {#if sp.id != s.id}
+                    <option value="{sp.id}" {#if t.speakers.size > 1 && t.speakers[1].id == sp.id}selected{/if}>{sp.name}</option>
+                  {/if}
+                {/for}
+              </select>
+            </div>
           </div>
           <button type="submit">Guardar</button>
         </form>
@@ -62,6 +72,16 @@
             <div class="field"><label>Título</label><input name="name" placeholder="Título"></div>
             <div class="field"><label>Duración</label><input name="duration" type="number" min="1" placeholder="Duración"></div>
             <div class="field"><label>Descripcion</label><input name="description" placeholder="Descripcion"></div>
+            <div class="field"><label><input type="checkbox" class="cospeaker-toggle" name="hasCo"> Co-Speaker</label>
+              <select name="coSpeakerId" class="cospeaker-select" hidden>
+                <option value="">Seleccione co-speaker</option>
+                {#for sp in speakers}
+                  {#if sp.id != s.id}
+                    <option value="{sp.id}">{sp.name}</option>
+                  {/if}
+                {/for}
+              </select>
+            </div>
           </div>
           <button type="submit">Agregar</button>
         </form>
@@ -91,6 +111,16 @@
   </li>
 </ul>
 <p><a href="/private/admin">Volver al panel</a></p>
+<script>
+(function(){
+  document.querySelectorAll('.cospeaker-toggle').forEach(cb => {
+    const sel = cb.closest('.talk-form').querySelector('.cospeaker-select');
+    const update = () => sel.hidden = !cb.checked;
+    cb.addEventListener('change', update);
+    update();
+  });
+})();
+</script>
 {/main}
 {/include}
 

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -70,7 +70,24 @@ Evento
           <summary>Día {d}</summary>
           <ul class="agenda-list">
           {#for t in event.getAgendaForDay(d)}
-            <li class="agenda-item"><span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>{t.startTimeStr} - {t.endTimeStr} | {#if t.break}{t.name}{#else}<a href="/talk/{t.id}">{t.name}</a>{/if} | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></li>
+            <li class="agenda-item">
+              <span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>{t.startTimeStr} - {t.endTimeStr} |
+              {#if t.break}{t.name}{#else}<a href="/talk/{t.id}">{t.name}</a>{/if}
+              {#if !t.break && !t.speakers.isEmpty()}
+              <span class="speaker-avatars">
+                {#for s in t.speakers}
+                  <a href="/speaker/{s.id}" title="{s.name}">
+                    {#if app:validUrl(s.photoUrl)}
+                      <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+                    {#else}
+                      <span class="avatar placeholder">👤</span>
+                    {/if}
+                  </a>
+                {/for}
+              </span>
+              {/if}
+              | <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
+            </li>
           {/for}
           </ul>
         </details>

--- a/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
+++ b/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
@@ -11,6 +11,17 @@
     <div class="talk-row" data-talk-id="{t.talk.id}" data-attended="{info.get(t.talk.id).attended}" data-rated="{info.get(t.talk.id).rating??}">
       <span class="talk-time">{t.talk.startTimeStr} - {t.talk.endTimeStr}</span>
       <span class="talk-title"><a href="/talk/{t.talk.id}">{t.talk.name}</a></span>
+      <div class="speaker-avatars">
+        {#for s in t.talk.speakers}
+          <a href="/speaker/{s.id}" title="{s.name}">
+            {#if app:validUrl(s.photoUrl)}
+              <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+            {#else}
+              <span class="avatar placeholder">👤</span>
+            {/if}
+          </a>
+        {/for}
+      </div>
       <span class="badge talk-state {app:talkStateClass(t.talk, t.event)}">{app:talkState(t.talk, t.event)}</span>
       <div class="talk-actions">
         <label class="attended-label" title="Asistí"><input type="checkbox" class="attended-checkbox" data-talk-id="{t.talk.id}" {#if info.get(t.talk.id).attended}checked{/if}></label>

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -26,6 +26,17 @@
           <span class="attendance-icon">{#if info.get(t.id).attended}✅{#else}❌{/if}</span>
           <span class="talk-time">{t.startTimeStr} - {t.endTimeStr}</span>
           <span class="talk-title"><a href="/talk/{t.id}">{t.name}</a></span>
+          <div class="speaker-avatars">
+            {#for s in t.speakers}
+              <a href="/speaker/{s.id}" title="{s.name}">
+                {#if app:validUrl(s.photoUrl)}
+                  <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+                {#else}
+                  <span class="avatar placeholder">👤</span>
+                {/if}
+              </a>
+            {/for}
+          </div>
           <span class="badge talk-state {app:talkStateClass(t, g.event)}">{app:talkState(t, g.event)}</span>
           <div class="talk-actions">
             <div class="motivation-list">

--- a/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/ScenarioResource/detail.html
@@ -22,14 +22,20 @@ Escenario
   {#for t in talks}
     <li class="talk-item">
       <h3>{t.name}</h3>
-      <p class="talk-time">Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min)</p>
       {#if !t.break && !t.speakers.isEmpty()}
-      <p class="talk-speakers">Orador:
+      <div class="speaker-avatars">
         {#for s in t.speakers}
-          <a href="/speaker/{s.id}">{s.name}</a>{#if s_hasNext} & {/if}
+          <a href="/speaker/{s.id}" title="{s.name}">
+            {#if app:validUrl(s.photoUrl)}
+              <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+            {#else}
+              <span class="avatar placeholder">👤</span>
+            {/if}
+          </a>
         {/for}
-      </p>
+      </div>
       {/if}
+      <p class="talk-time">Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min)</p>
       {#if !t.break}<a href="/talk/{t.id}" class="btn btn-secondary">Ver charla</a>{/if}
     </li>
   {/for}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -19,7 +19,7 @@
   {/if}
   {#if talk.description}<p>{talk.description}</p>{/if}
   {#if !talk.speakers.isEmpty()}
-    <p><strong>Orador:</strong>
+    <p><strong>Orador{#if talk.speakers.size > 1}es{/if}:</strong>
       {#for s in talk.speakers}
         <a href="/speaker/{s.id}">{s.name}</a>{#if s_hasNext} & {/if}
       {/for}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/SpeakerServiceCoSpeakerTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/SpeakerServiceCoSpeakerTest.java
@@ -1,0 +1,47 @@
+package com.scanales.eventflow.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Speaker;
+import com.scanales.eventflow.model.Talk;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class SpeakerServiceCoSpeakerTest {
+
+    @Inject
+    SpeakerService speakerService;
+
+    @AfterEach
+    public void cleanup() {
+        speakerService.deleteSpeaker("main");
+        speakerService.deleteSpeaker("co");
+    }
+
+    @Test
+    public void savesCoSpeakerAndMainSpeaker() {
+        Speaker main = new Speaker("main", "Main");
+        Speaker co = new Speaker("co", "Co");
+        speakerService.saveSpeaker(main);
+        speakerService.saveSpeaker(co);
+
+        Talk talk = new Talk("talk1", "Test Talk");
+        talk.setDurationMinutes(30);
+        talk.setSpeakers(List.of(co));
+
+        speakerService.saveTalk("main", talk);
+
+        Talk stored = speakerService.getTalk("main", "talk1");
+        assertNotNull(stored);
+        assertEquals(2, stored.getSpeakers().size());
+        assertEquals("main", stored.getSpeakers().get(0).getId());
+        assertEquals("co", stored.getSpeakers().get(1).getId());
+    }
+}


### PR DESCRIPTION
## Summary
- Add co-speaker selection in admin speaker panel, including UI checkbox and list
- Ensure main speaker is retained when saving talks with co-speakers
- Display speaker and co-speaker avatars across talk and agenda views
- Test that co-speaker saving keeps main speaker in place

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b3aa5e8c08333905aa7040bd90dcb