### PR TITLE
Display co-speaker talks on profile

### DIFF
--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -31,7 +31,7 @@
     <ul class="talk-list">
       {#for t in speaker.talks}
       <li class="talk-item">
-        <h3>{t.name}</h3>
+        <h3>{t.name}{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
         <a href="/talk/{t.id}" class="btn btn-secondary">Ver charla</a>
       </li>
       {/for}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/SpeakerServiceCoSpeakerTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/SpeakerServiceCoSpeakerTest.java
@@ -43,5 +43,28 @@ public class SpeakerServiceCoSpeakerTest {
         assertEquals(2, stored.getSpeakers().size());
         assertEquals("main", stored.getSpeakers().get(0).getId());
         assertEquals("co", stored.getSpeakers().get(1).getId());
+
+        Talk coStored = speakerService.getTalk("co", "talk1");
+        assertNotNull(coStored);
+        assertEquals("main", coStored.getSpeakers().get(0).getId());
+        assertEquals("co", coStored.getSpeakers().get(1).getId());
+    }
+
+    @Test
+    public void deletesTalkFromCoSpeaker() {
+        Speaker main = new Speaker("main", "Main");
+        Speaker co = new Speaker("co", "Co");
+        speakerService.saveSpeaker(main);
+        speakerService.saveSpeaker(co);
+
+        Talk talk = new Talk("talk1", "Test Talk");
+        talk.setDurationMinutes(30);
+        talk.setSpeakers(List.of(co));
+
+        speakerService.saveTalk("main", talk);
+        speakerService.deleteTalk("main", "talk1");
+
+        assertNull(speakerService.getTalk("main", "talk1"));
+        assertNull(speakerService.getTalk("co", "talk1"));
     }
 }


### PR DESCRIPTION
## Summary
- Ensure talks propagate to co-speakers so they appear in their profiles
- Mark co-speaker talks with `(Co Speaker)` in speaker profiles
- Cover co-speaker propagation and deletion with new tests

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b420eb9748333bfb818a8ed50eddb