### PR TITLE
Show co-speakers in talk detail and avatars in agendas

### DIFF
--- a/quarkus-app/src/main/resources/templates/MyEventsResource/myEvents.html
+++ b/quarkus-app/src/main/resources/templates/MyEventsResource/myEvents.html
@@ -17,8 +17,21 @@
       <a href="/event/{group.event.id}" class="btn btn-outline">Ver evento</a>
       <ul class="talk-list">
         {#for t in group.talks}
-          <li>
+          <li class="talk-item">
             <a href="/talk/{t.id}">{t.name}</a> – {t.startTimeStr} ({t.durationMinutes} min)
+            {#if !t.speakers.isEmpty()}
+              <span class="speaker-avatars">
+                {#for s in t.speakers}
+                  <a href="/speaker/{s.id}" title="{s.name}">
+                    {#if app:validUrl(s.photoUrl)}
+                      <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+                    {#else}
+                      <span class="avatar placeholder">👤</span>
+                    {/if}
+                  </a>
+                {/for}
+              </span>
+            {/if}
           </li>
         {/for}
       </ul>

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -19,11 +19,21 @@
   {/if}
   {#if talk.description}<p>{talk.description}</p>{/if}
   {#if !talk.speakers.isEmpty()}
-    <p><strong>Orador{#if talk.speakers.size > 1}es{/if}:</strong>
+    <div class="speaker-avatars">
       {#for s in talk.speakers}
-        <a href="/speaker/{s.id}">{s.name}</a>{#if s_hasNext} & {/if}
+        <a href="/speaker/{s.id}" title="{s.name}">
+          {#if app:validUrl(s.photoUrl)}
+            <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+          {#else}
+            <span class="avatar placeholder">👤</span>
+          {/if}
+        </a>
       {/for}
-    </p>
+    </div>
+    <p><strong>Orador:</strong> <a href="/speaker/{talk.speakers[0].id}">{talk.speakers[0].name}</a></p>
+    {#if talk.speakers.size > 1}
+      <p><strong>Co-Speaker:</strong> <a href="/speaker/{talk.speakers[1].id}">{talk.speakers[1].name}</a></p>
+    {/if}
   {/if}
   <p><strong>Horario:</strong> {#if talk.startTimeStr}{talk.startTimeStr}{#else}Por confirmar{/if}</p>
   <p><strong>Ubicación:</strong>


### PR DESCRIPTION
## Summary
- Display speaker and co-speaker avatars on talk detail page
- Add clickable speaker avatars to My Events agenda entries

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b45c4f5e48333a44db3dc79a161de