### PR TITLE
Ensure co-speakers persist across event reloads

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -38,6 +38,13 @@ public class SpeakerService {
     void init() {
         speakers.putAll(persistence.loadSpeakers());
         LOG.infof("Loaded %d speakers into memory", speakers.size());
+        // Ensure talks within events include the latest speaker information.
+        // When the application restarts the agenda loaded from persistence may
+        // miss co-speakers if events were stored before the speaker data was
+        // updated. By refreshing each speaker's talks we propagate the
+        // canonical speaker list back into the events' agenda ensuring
+        // co-speakers remain visible after a redeploy.
+        speakers.values().forEach(this::refreshEventsForSpeaker);
     }
 
     public List<Speaker> listSpeakers() {


### PR DESCRIPTION
## Summary
- Refresh events on startup so agendas keep co-speaker data
- Test co-speaker persistence after service reload

## Testing
- `./mvnw -q test -Dtest=SpeakerServiceCoSpeakerTest#coSpeakerPersistsAfterReload` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b5d6d95cc83339eb4a1380b87ddb1