### PR TITLE
feat: improve agenda layout

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -368,6 +368,22 @@ button:focus-visible {
     margin-right: 0.25rem;
 }
 
+/* Prevent wrapping and trim long agenda entries */
+.agenda-time {
+    white-space: nowrap;
+}
+
+.agenda-title {
+    white-space: nowrap;
+}
+
+.agenda-title .agenda-title-text {
+    display: inline-block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .action-group {
     display: flex;
     gap: 1rem;

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -63,7 +63,7 @@ Evento
     </div>
     {/if}
     {#if !event.agenda.isEmpty()}
-    <div class="card" id="agenda">
+    <div class="card agenda" id="agenda">
       <h2 class="card-title"><span class="icon">🗓️</span>Agenda</h2>
       {#for d in event.dayList}
         <details class="agenda-day" open>
@@ -83,7 +83,11 @@ Evento
                 <td class="agenda-time">{t.startTimeStr} - {t.endTimeStr}</td>
                 <td class="agenda-title">
                   <span class="icon">{#if t.break}☕{#else}🗣️{/if}</span>
-                  {#if t.break}{t.name}{#else}<a href="/talk/{t.id}">{t.name}</a>{/if}
+                  {#if t.break}
+                    <span class="agenda-title-text">{t.name}</span>
+                  {#else}
+                    <a href="/talk/{t.id}" class="agenda-title-text">{t.name}</a>
+                  {/if}
                 </td>
                 <td class="agenda-speakers">
                   {#if !t.break && !t.speakers.isEmpty()}


### PR DESCRIPTION
## Summary
- Align agenda card styling with event summary
- Prevent time wrapping and truncate long activity titles in agenda table

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b6440526483339df9ec9d487745c8