### PR TITLE
Show events for speaker talks

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/SpeakerResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/SpeakerResource.java
@@ -11,19 +11,30 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-import com.scanales.eventflow.service.SpeakerService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Speaker;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.SpeakerService;
 
 @Path("/speaker")
 public class SpeakerResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance detail(Speaker speaker);
+        static native TemplateInstance detail(Speaker speaker,
+                Map<String, List<Event>> talkEvents);
     }
 
     @Inject
     SpeakerService speakerService;
+
+    @Inject
+    EventService eventService;
 
     @GET
     @Path("{id}")
@@ -31,6 +42,15 @@ public class SpeakerResource {
     @Produces(MediaType.TEXT_HTML)
     public TemplateInstance detail(@PathParam("id") String id) {
         Speaker sp = speakerService.getSpeaker(id);
-        return Templates.detail(sp);
+        Map<String, List<Event>> talkEvents = new HashMap<>();
+        if (sp != null && sp.getTalks() != null) {
+            for (Talk t : sp.getTalks()) {
+                List<Event> events = eventService.findEventsByTalk(t.getId());
+                if (!events.isEmpty()) {
+                    talkEvents.put(t.getId(), events);
+                }
+            }
+        }
+        return Templates.detail(sp, talkEvents);
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -170,6 +170,15 @@ public class EventService {
                 .orElse(null);
     }
 
+    /** Returns all events that include the provided talk id. */
+    public List<Event> findEventsByTalk(String talkId) {
+        return events.values().stream()
+                .filter(e -> e.getAgenda().stream()
+                        .anyMatch(t -> t.getId().equals(talkId)))
+                .sorted(java.util.Comparator.comparing(Event::getId))
+                .toList();
+    }
+
     /** Returns a {@link TalkInfo} containing the talk and its parent event or {@code null}. */
     public TalkInfo findTalkInfo(String talkId) {
         Talk talk = findTalk(talkId);

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -897,6 +897,12 @@ p.note {
     gap: 0.5rem;
 }
 
+.event-list {
+    list-style: none;
+    margin: 0.25rem 0 0;
+    padding: 0;
+}
+
 @media (max-width: 600px) {
     .speaker-summary .speaker-header {
         flex-direction: column;

--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -32,6 +32,14 @@
       {#for t in speaker.talks}
       <li class="talk-item">
         <h3>{t.name}{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
+        {#if talkEvents.get(t.id) != null}
+        <p><strong>Eventos:</strong></p>
+        <ul class="event-list">
+          {#for e in talkEvents.get(t.id)}
+          <li><a href="/event/{e.id}">{e.title}</a></li>
+          {/for}
+        </ul>
+        {/if}
         <a href="/talk/{t.id}" class="btn btn-secondary">Ver charla</a>
       </li>
       {/for}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/SpeakerResourceTalkEventsTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/SpeakerResourceTalkEventsTest.java
@@ -1,0 +1,66 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Speaker;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.SpeakerService;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+public class SpeakerResourceTalkEventsTest {
+
+    @Inject
+    EventService eventService;
+
+    @Inject
+    SpeakerService speakerService;
+
+    private static final String EVENT_ID = "e-speaker";
+    private static final String SPEAKER_ID = "s-speaker";
+    private static final String TALK_ID = "t-speaker";
+
+    @BeforeEach
+    public void setup() {
+        Speaker speaker = new Speaker(SPEAKER_ID, "Speaker");
+        Talk talk = new Talk(TALK_ID, "Charla test");
+        talk.setSpeakers(List.of(speaker));
+        speaker.getTalks().add(talk);
+        speakerService.saveSpeaker(speaker);
+
+        Event event = new Event(EVENT_ID, "Evento de prueba", "desc");
+        Talk eventTalk = new Talk(TALK_ID, "Charla test");
+        eventTalk.setSpeakers(List.of(speaker));
+        eventTalk.setStartTime(LocalTime.of(10, 0));
+        eventTalk.setDurationMinutes(60);
+        event.getAgenda().add(eventTalk);
+        eventService.saveEvent(event);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        eventService.deleteEvent(EVENT_ID);
+        speakerService.deleteSpeaker(SPEAKER_ID);
+    }
+
+    @Test
+    public void speakerViewShowsEventForTalk() {
+        given()
+                .when().get("/speaker/" + SPEAKER_ID)
+                .then()
+                .statusCode(200)
+                .body(containsString("Evento de prueba"));
+    }
+}


### PR DESCRIPTION
## Summary
- list events for each speaker talk using new service method
- render event links in the speaker detail page with basic styling
- add test to ensure speaker view displays event information

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b751b91008333813123d485509e31