### PR TITLE
Use card and box layout for speaker event list

### DIFF
--- a/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/SpeakerResource/detail.html
@@ -33,12 +33,14 @@
       <li class="talk-item">
         <h3>{t.name}{#if t.speakers[0].id != speaker.id} (Co Speaker){/if}</h3>
         {#if talkEvents.get(t.id) != null}
-        <p><strong>Eventos:</strong></p>
-        <ul class="event-list">
-          {#for e in talkEvents.get(t.id)}
-          <li><a href="/event/{e.id}">{e.title}</a></li>
-          {/for}
-        </ul>
+        <div class="card events-card">
+          <h4 class="card-title"><span class="icon">🗓️</span>Eventos</h4>
+          <div class="events-boxes">
+            {#for e in talkEvents.get(t.id)}
+            <div class="box event-box"><a href="/event/{e.id}">{e.title}</a></div>
+            {/for}
+          </div>
+        </div>
         {/if}
         <a href="/talk/{t.id}" class="btn btn-secondary">Ver charla</a>
       </li>


### PR DESCRIPTION
## Summary
- Show each talk's events for a speaker inside a card with box-styled entries

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c9de0dc83339e34e1bfa4c6642e