### PR TITLE
Ensure contrasting text for dark UI elements

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -253,6 +253,7 @@ button:focus-visible {
         flex-direction: column;
         width: 100%;
         background-color: var(--color-dark);
+        color: var(--color-light);
         padding: 1rem 0;
     }
 
@@ -274,6 +275,7 @@ button:focus-visible {
         position: static;
         box-shadow: none;
         background-color: var(--color-dark);
+        color: var(--color-light);
     }
 
     .dropdown a {
@@ -344,6 +346,7 @@ button:focus-visible {
 
 .btn-secondary {
     background-color: var(--color-dark);
+    color: var(--color-light);
 }
 
 .btn-secondary:hover {


### PR DESCRIPTION
## Summary
- Fix dark buttons by adding light text color to `btn-secondary` class
- Improve mobile navigation colors for dark backgrounds

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ba356de108333a095ce05d888cb5a