### PR TITLE
style: keep constant button background color

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -340,11 +340,6 @@ button:focus-visible {
     transition: background-color 0.3s ease, transform 0.1s ease;
 }
 
-.btn:hover {
-    background-color: var(--color-accent);
-    color: var(--color-light);
-}
-
 .btn:active {
     transform: scale(0.97);
 }
@@ -359,10 +354,6 @@ button:focus-visible {
     color: var(--color-light);
 }
 
-.btn-secondary:hover {
-    background-color: var(--color-primary);
-    color: var(--color-light);
-}
 
 .agenda-list {
     list-style: none;
@@ -627,7 +618,6 @@ p.note {
 
 .side-btn:hover {
     box-shadow: 0 6px 16px rgba(0,0,0,.1);
-    filter: brightness(1.03);
 }
 
 .side-btn:focus-visible {


### PR DESCRIPTION
## Summary
- remove hover styles so buttons retain a consistent background color in all states

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom)*

------
https://chatgpt.com/codex/tasks/task_e_689baa04587c8333ad1eadfb80fc9a54