### PR TITLE
feat: add admin metrics dashboard

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,3 +23,19 @@ Los contadores se mantienen en memoria y se guardan periódicamente en `data/met
    ```
 2. Navegar por el sitio y registrar una charla.
 3. Ver archivo `quarkus-app/data/metrics-v1.json` para observar los contadores.
+
+## Lectura en Admin → Métricas
+
+La vista de administración lee directamente `data/metrics-v1.json` y muestra:
+
+- Tarjetas de resumen con vistas de eventos, charlas vistas, registros y visitas a escenarios.
+- Tablas Top 10 de charlas y oradores, junto con visitas por escenario.
+- Exportación a CSV del contenido visible.
+
+Las claves se mapean a entidades existentes usando los servicios en memoria:
+
+- `talk_*` → título de la charla (`EventService.findTalk`).
+- `speaker_popularity:*` → nombre del orador (`SpeakerService.getSpeaker`).
+- `stage_visit:*` → nombre del escenario (`EventService.findScenario`).
+
+Si no hay datos suficientes el panel muestra un mensaje informativo en lugar de tablas vacías.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -1,5 +1,15 @@
 package com.scanales.eventflow.private_;
 
+import java.time.*;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.model.Speaker;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.SpeakerService;
 import com.scanales.eventflow.service.UsageMetricsService;
 import com.scanales.eventflow.service.UsageMetricsService.Summary;
 import com.scanales.eventflow.util.AdminUtils;
@@ -12,16 +22,34 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-/** Simple admin page for usage metrics. */
+/** Admin page for usage metrics with simple reporting and CSV export. */
 @Path("/private/admin/metrics")
 public class AdminMetricsResource {
 
+    public record Row(String name, long value) {}
+
+    public record MetricsData(
+            long eventsViewed,
+            long talksViewed,
+            long talksRegistered,
+            long stageVisits,
+            String lastUpdate,
+            long discarded,
+            List<Row> topRegistrations,
+            List<Row> topViews,
+            List<Row> topSpeakers,
+            List<Row> stageVisitsTable,
+            boolean empty,
+            String range
+    ) {}
+
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance index(long totalKeys, long estimatedSize, long discarded);
+        static native TemplateInstance index(MetricsData data);
     }
 
     @Inject
@@ -30,14 +58,149 @@ public class AdminMetricsResource {
     @Inject
     UsageMetricsService metrics;
 
+    @Inject
+    EventService eventService;
+
+    @Inject
+    SpeakerService speakerService;
+
     @GET
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
-    public Response metrics() {
+    public Response metrics(@QueryParam("range") String range) {
         if (!AdminUtils.isAdmin(identity)) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
-        Summary s = metrics.getSummary();
-        return Response.ok(Templates.index(s.totalKeys(), s.estimatedSize(), s.discardedEvents())).build();
+        MetricsData data = buildData(range);
+        return Response.ok(Templates.index(data)).build();
+    }
+
+    @GET
+    @Path("export")
+    @Authenticated
+    @Produces("text/csv")
+    public Response export(@QueryParam("table") String table, @QueryParam("range") String range) {
+        if (!AdminUtils.isAdmin(identity)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        MetricsData data = buildData(range);
+        List<Row> rows;
+        String header;
+        switch (table) {
+            case "registrations" -> {
+                rows = data.topRegistrations();
+                header = "Charla,Registros";
+            }
+            case "views" -> {
+                rows = data.topViews();
+                header = "Charla,Vistas";
+            }
+            case "speakers" -> {
+                rows = data.topSpeakers();
+                header = "Orador,Registros";
+            }
+            case "stages" -> {
+                rows = data.stageVisitsTable();
+                header = "Escenario,Visitas";
+            }
+            default -> {
+                rows = List.of();
+                header = "";
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        if (!header.isEmpty()) {
+            sb.append(header).append('\n');
+            for (Row r : rows) {
+                sb.append(r.name()).append(',').append(r.value()).append('\n');
+            }
+        }
+        return Response.ok(sb.toString())
+                .header("Content-Disposition", "attachment; filename=metrics-" + table + ".csv")
+                .build();
+    }
+
+    private MetricsData buildData(String range) {
+        Map<String, Long> snap = metrics.snapshot();
+        Summary summary = metrics.getSummary();
+        boolean empty = snap.isEmpty();
+        long eventsViewed = sumByPrefix(snap, "event_view:");
+        long talksViewed = sumByPrefix(snap, "talk_view:");
+        long talksRegistered = sumByPrefix(snap, "talk_register:");
+
+        Map<String, Long> regMap = extractMap(snap, "talk_register:");
+        List<Row> topRegs = topRows(regMap, 10, this::talkName);
+        Map<String, Long> viewMap = extractMap(snap, "talk_view:");
+        List<Row> topViews = topRows(viewMap, 10, this::talkName);
+        Map<String, Long> speakerMap = extractMap(snap, "speaker_popularity:");
+        List<Row> topSpeakers = topRows(speakerMap, 10, this::speakerName);
+
+        LocalDate today = LocalDate.now();
+        LocalDate start;
+        if ("today".equals(range)) {
+            start = today;
+        } else if ("7".equals(range)) {
+            start = today.minusDays(6);
+        } else if ("30".equals(range)) {
+            start = today.minusDays(29);
+        } else {
+            start = LocalDate.MIN;
+            range = "all";
+        }
+        Map<String, Long> stageMap = new HashMap<>();
+        for (Map.Entry<String, Long> e : snap.entrySet()) {
+            if (e.getKey().startsWith("stage_visit:")) {
+                String[] parts = e.getKey().split(":");
+                if (parts.length == 3) {
+                    LocalDate d = LocalDate.parse(parts[2]);
+                    if (!d.isBefore(start)) {
+                        stageMap.merge(parts[1], e.getValue(), Long::sum);
+                    }
+                }
+            }
+        }
+        long stageVisits = stageMap.values().stream().mapToLong(Long::longValue).sum();
+        List<Row> stageTable = topRows(stageMap, 10, this::stageName);
+
+        long last = metrics.getLastUpdatedMillis();
+        String lastStr = last > 0 ? Instant.ofEpochMilli(last).toString() : "—";
+        return new MetricsData(eventsViewed, talksViewed, talksRegistered, stageVisits,
+                lastStr, summary.discardedEvents(), topRegs, topViews, topSpeakers, stageTable, empty, range);
+    }
+
+    private static long sumByPrefix(Map<String, Long> data, String prefix) {
+        return data.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .mapToLong(Map.Entry::getValue)
+                .sum();
+    }
+
+    private static Map<String, Long> extractMap(Map<String, Long> data, String prefix) {
+        return data.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .collect(Collectors.toMap(e -> e.getKey().substring(prefix.length()), Map.Entry::getValue));
+    }
+
+    private List<Row> topRows(Map<String, Long> map, int limit, Function<String, String> nameFn) {
+        return map.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(limit)
+                .map(e -> new Row(nameFn.apply(e.getKey()), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private String talkName(String id) {
+        Talk t = eventService.findTalk(id);
+        return t != null && t.getName() != null ? t.getName() : id;
+    }
+
+    private String speakerName(String id) {
+        Speaker s = speakerService.getSpeaker(id);
+        return s != null && s.getName() != null ? s.getName() : id;
+    }
+
+    private String stageName(String id) {
+        Scenario sc = eventService.findScenario(id);
+        return sc != null && sc.getName() != null ? sc.getName() : id;
     }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -155,5 +155,22 @@ public class UsageMetricsService {
         increment("discarded_events");
         discarded.incrementAndGet();
     }
+
+    /** Returns a snapshot of all counters for read-only purposes. */
+    public Map<String, Long> snapshot() {
+        return Map.copyOf(counters);
+    }
+
+    /** Returns the last modification time of the metrics file or {@code 0} if unavailable. */
+    public long getLastUpdatedMillis() {
+        try {
+            if (Files.exists(metricsPath)) {
+                return Files.getLastModifiedTime(metricsPath).toMillis();
+            }
+        } catch (IOException e) {
+            LOG.debug("Failed to read metrics timestamp", e);
+        }
+        return 0L;
+    }
 }
 

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -2,11 +2,75 @@
 {#title}Métricas{/title}
 {#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Métricas</span>{/breadcrumbs}
 {#main}
-<section class="admin-overview">
-    <h1 class="page-title">Métricas activas: recopilando datos</h1>
-    <p>Total de claves: {totalKeys}</p>
-    <p>Tamaño estimado: {estimatedSize} bytes</p>
-    <p>Eventos descartados: {discarded}</p>
+<section class="admin-metrics">
+    <h1 class="page-title">Métricas</h1>
+    {#if data.empty}
+        <p>Sin datos suficientes todavía. Navega por eventos y registra charlas para generar métricas.</p>
+    {#else}
+    <form method="get" class="metrics-filter">
+        <label>Rango:
+            <select name="range">
+                <option value="all"{#if data.range == 'all'} selected{/if}>Todo el evento</option>
+                <option value="today"{#if data.range == 'today'} selected{/if}>Hoy</option>
+                <option value="7"{#if data.range == '7'} selected{/if}>Últimos 7 días</option>
+                <option value="30"{#if data.range == '30'} selected{/if}>Últimos 30 días</option>
+            </select>
+        </label>
+        <button type="submit">Aplicar</button>
+    </form>
+    <div class="cards">
+        <div class="card">Eventos vistos: {data.eventsViewed}</div>
+        <div class="card">Charlas vistas: {data.talksViewed}</div>
+        <div class="card">Charlas registradas: {data.talksRegistered}</div>
+        <div class="card">Visitas a escenarios: {data.stageVisits}</div>
+        <div class="card">Última actualización: {data.lastUpdate}</div>
+    </div>
+    <p>Eventos descartados: {data.discarded}</p>
+
+    <h2>Top 10 charlas más registradas</h2>
+    <table>
+        <thead><tr><th>Charla</th><th>Registros</th></tr></thead>
+        <tbody>
+        {#for row in data.topRegistrations}
+            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+        {/for}
+        </tbody>
+    </table>
+    <a href="export?table=registrations&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+
+    <h2>Top 10 charlas más vistas</h2>
+    <table>
+        <thead><tr><th>Charla</th><th>Vistas</th></tr></thead>
+        <tbody>
+        {#for row in data.topViews}
+            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+        {/for}
+        </tbody>
+    </table>
+    <a href="export?table=views&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+
+    <h2>Top 10 oradores más populares</h2>
+    <table>
+        <thead><tr><th>Orador</th><th>Registros agregados</th></tr></thead>
+        <tbody>
+        {#for row in data.topSpeakers}
+            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+        {/for}
+        </tbody>
+    </table>
+    <a href="export?table=speakers&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+
+    <h2>Visitas por escenario</h2>
+    <table>
+        <thead><tr><th>Escenario</th><th>Visitas del día</th></tr></thead>
+        <tbody>
+        {#for row in data.stageVisitsTable}
+            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+        {/for}
+        </tbody>
+    </table>
+    <a href="export?table=stages&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+    {/if}
     <a href="/private/admin" class="btn btn-secondary">Volver</a>
 </section>
 {/main}


### PR DESCRIPTION
## Summary
- Add in-memory metrics snapshot access and last-update timestamp
- Build Admin metrics dashboard with summary cards, Top 10 tables and CSV export
- Document how metrics are read and mapped to domain entities

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689be840437c8333906214549e22442f