### PR TITLE
feat: add metrics schema versioning

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -45,7 +45,9 @@ public class AdminMetricsResource {
             List<Row> topSpeakers,
             List<Row> stageVisitsTable,
             boolean empty,
-            String range
+            String range,
+            int schemaVersion,
+            long fileSizeBytes
     ) {}
 
     @CheckedTemplate
@@ -166,7 +168,8 @@ public class AdminMetricsResource {
         long last = metrics.getLastUpdatedMillis();
         String lastStr = last > 0 ? Instant.ofEpochMilli(last).toString() : "—";
         return new MetricsData(eventsViewed, talksViewed, talksRegistered, stageVisits,
-                lastStr, summary.discarded(), metrics.getConfig(), topRegs, topViews, topSpeakers, stageTable, empty, range);
+                lastStr, summary.discarded(), metrics.getConfig(), topRegs, topViews, topSpeakers,
+                stageTable, empty, range, metrics.getSchemaVersion(), metrics.getFileSizeBytes());
     }
 
     private static long sumByPrefix(Map<String, Long> data, String prefix) {

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -38,6 +38,13 @@
         <li>bot: {data.discards.get('bot')}</li>
         <li>burst: {data.discards.get('burst')}</li>
         <li>invalid: {data.discards.get('invalid')}</li>
+        <li>buffer_full: {data.discards.get('buffer_full')}</li>
+    </ul>
+
+    <h2>Mantenimiento de métricas</h2>
+    <ul>
+        <li>Versión de esquema: {data.schemaVersion}</li>
+        <li>Tamaño actual: {data.fileSizeBytes} bytes</li>
     </ul>
 
     <h2>Top 10 charlas más registradas</h2>


### PR DESCRIPTION
## Summary
- add schema version awareness and migrate metrics file to v2 format
- expose schema version and file size in admin metrics page
- show buffer_full discards in metrics view

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c004037488333b85bb289203c8196