### PR TITLE
feat(metrics): add conversion analytics and contextual navigation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,7 +29,8 @@ Los contadores se mantienen en memoria y se guardan periódicamente en `data/met
 La vista de administración lee directamente `data/metrics-v1.json` y muestra:
 
 - Tarjetas de resumen con vistas de eventos, charlas vistas, registros y visitas a escenarios.
-- Tablas Top 10 de charlas y oradores, junto con visitas por escenario.
+- Conversión global y asistentes esperados (aprox. suma de registros).
+- Tablas Top 10 de charlas, oradores y escenarios con mejor conversión.
 - Exportación a CSV del contenido visible.
 
 Las claves se mapean a entidades existentes usando los servicios en memoria:
@@ -37,5 +38,13 @@ Las claves se mapean a entidades existentes usando los servicios en memoria:
 - `talk_*` → título de la charla (`EventService.findTalk`).
 - `speaker_popularity:*` → nombre del orador (`SpeakerService.getSpeaker`).
 - `stage_visit:*` → nombre del escenario (`EventService.findScenario`).
+
+### Conversión
+
+- **Charlas:** `talk_register:{talkId} / talk_view:{talkId}`. Si las vistas son 0 se muestra "—".
+- **Evento:** se utiliza la política **A** (suma de registros / suma de vistas de sus charlas). La alternativa **B** (promedio simple por charla) se consideró pero no se utiliza actualmente.
+- **Escenarios y oradores:** agregados de las charlas asociadas.
+
+Para evitar sesgos se aplica un umbral mínimo de vistas (`metrics.min-view-threshold`, default 20) para que una charla, escenario u orador aparezca en los rankings.
 
 Si no hay datos suficientes el panel muestra un mensaje informativo en lugar de tablas vacías.

--- a/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
+++ b/quarkus-app/src/main/resources/templates/AdminEventResource/list.html
@@ -27,6 +27,7 @@
           <td>{ev.title}</td>
           <td class="action-group">
             <a href="/private/admin/events/{ev.id}/edit" class="btn btn-secondary">Editar</a>
+            <a href="/private/admin/metrics?event={ev.id}&amp;range=all" class="btn btn-secondary">Ver métricas</a>
             <form method="post" action="/private/admin/events/{ev.id}/delete" style="display:inline" class="needs-confirm">
               <button type="submit" class="btn btn-secondary">Eliminar</button>
             </form>

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -16,6 +16,9 @@
                 <option value="30"{#if data.range == '30'} selected{/if}>Últimos 30 días</option>
             </select>
         </label>
+        {#if data.eventId}
+        <input type="hidden" name="event" value="{data.eventId}">
+        {/if}
         <button type="submit">Aplicar</button>
     </form>
     <div class="cards">
@@ -23,8 +26,11 @@
         <div class="card">Charlas vistas: {data.talksViewed}</div>
         <div class="card">Charlas registradas: {data.talksRegistered}</div>
         <div class="card">Visitas a escenarios: {data.stageVisits}</div>
+        <div class="card">Conversión global: {data.globalConversion}</div>
+        <div class="card">Asistentes esperados: {data.expectedAttendees}</div>
         <div class="card">Última actualización: {data.lastUpdate}</div>
     </div>
+    <p>Umbral mínimo de vistas para ranking: {data.minViews}. Política de conversión de evento: promedio ponderado (A).</p>
     <h2>Calidad de datos</h2>
     <ul>
         <li>Ventana talk_view: {data.config.talkViewWindowSeconds}s</li>
@@ -47,49 +53,38 @@
         <li>Tamaño actual: {data.fileSizeBytes} bytes</li>
     </ul>
 
-    <h2>Top 10 charlas más registradas</h2>
+    <h2>Charlas con mejor conversión</h2>
     <table>
-        <thead><tr><th>Charla</th><th>Registros</th></tr></thead>
+        <thead><tr><th>Charla</th><th>Vistas</th><th>Registros</th><th>Conv.</th></tr></thead>
         <tbody>
-        {#for row in data.topRegistrations}
-            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+        {#for row in data.topTalks}
+            <tr><td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td></tr>
         {/for}
         </tbody>
     </table>
-    <a href="export?table=registrations&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+    <a href="export?table=talks&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary">Exportar CSV</a>
 
-    <h2>Top 10 charlas más vistas</h2>
+    <h2>Oradores con mejor conversión</h2>
     <table>
-        <thead><tr><th>Charla</th><th>Vistas</th></tr></thead>
-        <tbody>
-        {#for row in data.topViews}
-            <tr><td>{row.name}</td><td>{row.value}</td></tr>
-        {/for}
-        </tbody>
-    </table>
-    <a href="export?table=views&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
-
-    <h2>Top 10 oradores más populares</h2>
-    <table>
-        <thead><tr><th>Orador</th><th>Registros agregados</th></tr></thead>
+        <thead><tr><th>Orador</th><th>Vistas</th><th>Registros</th><th>Conv.</th></tr></thead>
         <tbody>
         {#for row in data.topSpeakers}
-            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+            <tr><td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td></tr>
         {/for}
         </tbody>
     </table>
-    <a href="export?table=speakers&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+    <a href="export?table=speakers&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary">Exportar CSV</a>
 
-    <h2>Visitas por escenario</h2>
+    <h2>Escenarios con mejor conversión</h2>
     <table>
-        <thead><tr><th>Escenario</th><th>Visitas del día</th></tr></thead>
+        <thead><tr><th>Escenario</th><th>Vistas</th><th>Registros</th><th>Conv.</th></tr></thead>
         <tbody>
-        {#for row in data.stageVisitsTable}
-            <tr><td>{row.name}</td><td>{row.value}</td></tr>
+        {#for row in data.topScenarios}
+            <tr><td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td></tr>
         {/for}
         </tbody>
     </table>
-    <a href="export?table=stages&amp;range={data.range}" class="btn btn-secondary">Exportar CSV</a>
+    <a href="export?table=scenarios&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary">Exportar CSV</a>
     {/if}
     <a href="/private/admin" class="btn btn-secondary">Volver</a>
 </section>


### PR DESCRIPTION
## Summary
- compute conversion metrics for talks, speakers and scenarios with global conversion and attendee estimate
- enable filtering by event and expose min view threshold
- add quick navigation from admin events list to metrics page

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_689c02d8c540833388cb406140e84bb9