### PR TITLE
feat: add metrics health check and guide

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -478,6 +478,26 @@ public class UsageMetricsService {
         }
     }
 
+    /** Test helper to reset internal state between tests. */
+    void reset() {
+        counters.clear();
+        talkViews.clear();
+        eventViews.clear();
+        stageVisits.clear();
+        pageViews.clear();
+        rates.clear();
+        discardedByReason.clear();
+        bufferSize.set(0);
+        bufferWarned = false;
+        dirty.set(false);
+        writesOk.set(0);
+        writesFail.set(0);
+        flushFailures.set(0);
+        lastFlushTime = System.currentTimeMillis();
+        lastError = null;
+        currentState = HealthState.OK;
+    }
+
     private static class RateLimiter {
         long secondStart = System.currentTimeMillis();
         int secondCount = 0;

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/guide.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/guide.html
@@ -1,0 +1,26 @@
+{#include layout/base}
+{#title}Guía rápida de operación{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><a href="/private/admin/metrics">Métricas</a><span class="sep">/</span><span>Guía</span>{/breadcrumbs}
+{#main}
+<section class="admin-metrics">
+    <h1>Guía rápida de operación</h1>
+    <p>Revisa primero el panel de salud del sistema de métricas. Observa el semáforo, descartes y la marca <code>lastFlush</code>.</p>
+    <h2>Acciones sugeridas por estado</h2>
+    <ul>
+        <li><strong>OK:</strong> sin acción requerida.</li>
+        <li><strong>DEGRADADO:</strong> revisar espacio en disco o ajustar <code>flushInterval</code> y tope de buffer.</li>
+        <li><strong>ERROR:</strong> revisar logs, exportar respaldo y considerar restaurar una copia válida.</li>
+    </ul>
+    <h2>Exportar/Restaurar</h2>
+    <p>El archivo de métricas está en <code>data/metrics-v2.json</code>. Copia este archivo para respaldos y reemplázalo para restaurar.</p>
+    <h2>Parámetros clave</h2>
+    <ul>
+        <li><code>flushInterval</code>: frecuencia de escritura a disco.</li>
+        <li><code>buffer.maxSize</code>: eventos acumulados antes de flush.</li>
+        <li>Retención/rotación: mantener solo el archivo actual.</li>
+    </ul>
+    <p>Buenas prácticas: no editar manualmente el JSON, validar tamaño y corrupción antes de restaurar.</p>
+    <a href="/private/admin/metrics" class="btn btn-secondary">Volver</a>
+</section>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -31,6 +31,24 @@
         <div class="card">Última actualización: {data.lastUpdate}</div>
     </div>
     <p>Umbral mínimo de vistas para ranking: {data.minViews}. Política de conversión de evento: promedio ponderado (A).</p>
+
+    <h2>Salud del sistema de métricas</h2>
+    <div class="health health-{data.health.estado}">
+        <strong>{data.health.estado}</strong>
+        {#if data.health.estado == 'OK'}<span>Todo en orden</span>{/if}
+        {#if data.health.estado == 'DEGRADADO'}<span>Revisar espacio en disco o ajustar flush/buffer</span>{/if}
+        {#if data.health.estado == 'ERROR'}<span>Ver guía operativa y revisar logs</span>{/if}
+    </div>
+    <ul>
+        <li>lastFlush: {data.health.lastFlush}</li>
+        <li>flushInterval: {data.health.flushIntervalMillis} ms</li>
+        <li>buffer: {data.health.bufferCurrentSize}/{data.health.bufferMaxSize}</li>
+        <li>writes ok/fail: {data.health.writesOk}/{data.health.writesFail}</li>
+        <li>fileSizeBytes: {data.health.fileSizeBytes}</li>
+        <li>Último error: {#if data.health.lastError}{data.health.lastError}{#else}—{/if}</li>
+        <li>Descartes: dedupe {data.discards.get('dedupe')}, bot {data.discards.get('bot')}, burst {data.discards.get('burst')}, invalid {data.discards.get('invalid')}, buffer_full {data.discards.get('buffer_full')}</li>
+    </ul>
+    <p><a href="guide">Guía rápida de operación</a></p>
     <h2>Calidad de datos</h2>
     <ul>
         <li>Ventana talk_view: {data.config.talkViewWindowSeconds}s</li>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceBufferTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceBufferTest.java
@@ -1,0 +1,30 @@
+package com.scanales.eventflow.service;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+public class UsageMetricsServiceBufferTest {
+
+    @Inject
+    UsageMetricsService metrics;
+
+    @Test
+    public void bufferFullIsCountedAndDiscarded() {
+        metrics.recordPageView("route1", "s1", "Mozilla/5.0");
+        metrics.recordPageView("route2", "s2", "Mozilla/5.0");
+        metrics.recordPageView("route3", "s3", "Mozilla/5.0");
+        Map<String, Long> snap = metrics.snapshot();
+        Assertions.assertNotNull(snap.get("page_view:route1"));
+        Assertions.assertNotNull(snap.get("page_view:route2"));
+        Assertions.assertNull(snap.get("page_view:route3"));
+        Map<String, Long> disc = metrics.getDiscarded();
+        Assertions.assertEquals(1L, disc.getOrDefault("buffer_full", 0L));
+    }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceBufferTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceBufferTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -14,6 +15,11 @@ public class UsageMetricsServiceBufferTest {
 
     @Inject
     UsageMetricsService metrics;
+
+    @BeforeEach
+    void reset() {
+        metrics.reset();
+    }
 
     @Test
     public void bufferFullIsCountedAndDiscarded() {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceQualityTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceQualityTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -14,6 +15,11 @@ public class UsageMetricsServiceQualityTest {
 
     @Inject
     UsageMetricsService metrics;
+
+    @BeforeEach
+    void reset() {
+        metrics.reset();
+    }
 
     @Test
     public void talkViewDedupesAndBotsDiscarded() {

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -1,1 +1,3 @@
 quarkus.oidc.tenant-enabled=false
+metrics.buffer.max-size=2
+metrics.flush-interval=PT1H


### PR DESCRIPTION
## Summary
- track buffer and flush state to report metrics module health
- add admin endpoints and UI panel for health with operation guide
- document buffer overflow handling and add regression test

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c068065488333adfcb5ea5fdc0779