### PR TITLE
Remove Admin Panel link from profile page

### DIFF
--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -69,7 +69,6 @@
   </div>
 {/for}
 {/if}
-  <p><a href="/private/admin">Admin Panel</a></p>
   <p><a href="/logout">Salir</a></p>
   <script>
   (function() {


### PR DESCRIPTION
## Summary
- remove Admin Panel link from user profile page

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c0bc0042c8333a888109799fb90be