### PR TITLE
Add admin guide page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminResource.java
@@ -19,6 +19,7 @@ public class AdminResource {
     @CheckedTemplate
     static class Templates {
         static native TemplateInstance admin(String name);
+        static native TemplateInstance guide();
     }
 
     @Inject
@@ -37,5 +38,16 @@ public class AdminResource {
             name = email;
         }
         return Response.ok(Templates.admin(name)).build();
+    }
+
+    @GET
+    @Path("guide")
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public Response guide() {
+        if (!AdminUtils.isAdmin(identity)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        return Response.ok(Templates.guide()).build();
     }
 }

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -10,6 +10,7 @@
         <a href="/private/admin/speakers" class="btn">Administrar oradores</a>
         <a href="/private/admin/metrics" class="btn">Métricas</a>
         <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
+        <a href="/private/admin/guide" class="btn">Guía</a>
         <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
     </div>
 </section>

--- a/quarkus-app/src/main/resources/templates/AdminResource/guide.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/guide.html
@@ -1,0 +1,17 @@
+{#include layout/base}
+{#title}Guía de administración{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Guía</span>{/breadcrumbs}
+{#main}
+<section class="admin-guide">
+    <h1>Guía de administración</h1>
+    <p>Este panel permite gestionar eventos, oradores, métricas y respaldos.</p>
+    <ul>
+        <li>Revisa <em>Eventos</em> para crear o modificar eventos.</li>
+        <li>Administra <em>Oradores</em> vinculados a las charlas.</li>
+        <li>Consulta <em>Métricas</em> para ver uso del sistema.</li>
+        <li>Usa <em>Respaldo de datos</em> para exportar o importar información.</li>
+    </ul>
+    <p><a href="/private/admin" class="btn btn-secondary">Volver al panel</a></p>
+</section>
+{/main}
+{/include}


### PR DESCRIPTION
## Summary
- Add `/private/admin/guide` endpoint and template
- Link guide from admin panel

## Testing
- `mvn -q test` *(fails: could not resolve dependencies - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c6761ee5c8333a5fcb102545324a3