### PR TITLE
Display talks across multiple agenda slots

### DIFF
--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -138,9 +138,9 @@ Evento
             </tr>
           </thead>
           <tbody>
-            {#for e in event.getAgendaGroupedByStartTime(d).entrySet()}
+            {#for e in event.getAgendaGroupedByTimeSlot(d).entrySet()}
             <tr>
-              <td class="agenda-time">{e.value.get(0).startTimeStr}</td>
+              <td class="agenda-time">{e.key}</td>
               {#for sc in event.scenarios}
               <td>
                 {#for t in e.value}


### PR DESCRIPTION
## Summary
- group agenda items into 30‑minute slots, duplicating talks across slots they span
- use new slot-based grouping in event grid view to show long talks in every affected block

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c72e6e4b0833396770a4f6eba62b7