### PR TITLE
Group my talks by event

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/MyTalksResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/MyTalksResource.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.TalkInfo;
 import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.UserScheduleService;
@@ -23,19 +24,19 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 /**
- * Compact view of the talks registered by the current user grouped by day.
+ * Compact view of the talks registered by the current user grouped by event.
  */
 @Path("/private/my-talks")
 public class MyTalksResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance myTalks(List<DayGroup> days,
+        static native TemplateInstance myTalks(List<EventGroup> events,
                 Map<String, TalkDetails> info);
     }
 
-    /** Talks grouped by day. */
-    public record DayGroup(int day, List<TalkInfo> talks) {}
+    /** Talks grouped by event. */
+    public record EventGroup(Event event, List<TalkInfo> talks) {}
 
     @Inject
     SecurityIdentity identity;
@@ -57,14 +58,16 @@ public class MyTalksResource {
                 .map(eventService::findTalkInfo)
                 .filter(java.util.Objects::nonNull)
                 .sorted(java.util.Comparator
-                        .comparingInt((TalkInfo ti) -> ti.talk().getDay())
+                        .comparing((TalkInfo ti) -> ti.event().getTitle(), String.CASE_INSENSITIVE_ORDER)
+                        .thenComparing(ti -> ti.talk().getDay())
                         .thenComparing(ti -> ti.talk().getStartTime(),
                                 java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
                 .toList();
 
-        Map<Integer, DayGroup> grouped = new LinkedHashMap<>();
+        Map<String, EventGroup> grouped = new LinkedHashMap<>();
         for (TalkInfo ti : entries) {
-            grouped.computeIfAbsent(ti.talk().getDay(), d -> new DayGroup(d, new ArrayList<>()))
+            Event ev = ti.event();
+            grouped.computeIfAbsent(ev.getId(), id -> new EventGroup(ev, new ArrayList<>()))
                     .talks().add(ti);
         }
 

--- a/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
+++ b/quarkus-app/src/main/resources/templates/MyTalksResource/myTalks.html
@@ -2,12 +2,12 @@
 {#title}Mis Charlas{/title}
 {#main}
 <h1>Mis Charlas</h1>
-{#if days.isEmpty()}
+{#if events.isEmpty()}
 <p>No has agregado ninguna charla.</p>
 {#else}
-{#for d in days}
-  <h2 class="day-title">Día {d.day}</h2>
-  {#for t in d.talks}
+{#for e in events}
+  <h2 class="event-title">{e.event.title}</h2>
+  {#for t in e.talks}
     <div class="talk-row" data-talk-id="{t.talk.id}" data-attended="{info.get(t.talk.id).attended}" data-rated="{info.get(t.talk.id).rating??}">
       <span class="talk-time">{t.talk.startTimeStr} - {t.talk.endTimeStr}</span>
       <span class="talk-title"><a href="/talk/{t.talk.id}">{t.talk.name}</a></span>


### PR DESCRIPTION
## Summary
- Group "My Talks" view by parent event instead of day
- Update My Talks template to display talks under their event titles

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c7516b5c883338d7f5e8fbead62d1