### PR TITLE
Increase deployment resource limits for load testing

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -80,14 +80,15 @@ spec:
                   name: google-oauth
                   key: redirect-uri
           resources:
-            limits:
-              cpu: 500m
-              ephemeral-storage: 1Gi
-              memory: 100Mi
+            # Allow burst for ~10k concurrent users while keeping baseline small
             requests:
               cpu: 50m
               ephemeral-storage: 1Gi
               memory: 52Mi
+            limits:
+              cpu: "4"
+              memory: 1Gi
+              ephemeral-storage: 2Gi
           volumeMounts:
             - name: data
               mountPath: /work/data

--- a/deployment/pvc.yaml
+++ b/deployment/pvc.yaml
@@ -10,5 +10,5 @@ spec:
   resources:
     requests:
       # 1000 events * 1KB + 500 speakers * 1KB + 1500 talks * 1KB ≈ 3MB
-      # Allocate with buffer for growth
-      storage: 10Mi
+      # Allocate with buffer for growth and sustained writes
+      storage: 1Gi


### PR DESCRIPTION
## Summary
- raise CPU, memory and ephemeral-storage limits to handle ~10k concurrent users while keeping original resource requests small
- grow persistent volume size to support heavier write throughput

## Testing
- `cd quarkus-app && ./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c6dd76af88333bd3c74803841249d