### PR TITLE
feat: add capacity control for logins

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/capacity/CapacityLoginFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/capacity/CapacityLoginFilter.java
@@ -1,0 +1,62 @@
+package com.scanales.eventflow.capacity;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+import com.scanales.eventflow.service.CapacityService;
+
+/**
+ * Blocks new logins when memory or disk capacity is low.
+ */
+@Provider
+@Priority(Priorities.AUTHORIZATION)
+public class CapacityLoginFilter implements ContainerRequestFilter {
+
+    private static final String MESSAGE = "Debido a alta demanda, no podemos gestionar tus datos en este momento. Inténtalo más tarde.";
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    CapacityService capacity;
+
+    @Override
+    public void filter(ContainerRequestContext ctx) {
+        if (identity == null || identity.isAnonymous()) {
+            return;
+        }
+        String path = ctx.getUriInfo().getPath();
+        if (!path.startsWith("private")) {
+            return;
+        }
+        String email = getEmail();
+        if (!capacity.isAdmitted(email)) {
+            CapacityService.Status status = capacity.evaluate();
+            if (status.mode() == CapacityService.Mode.CONTAINING) {
+                ctx.abortWith(Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                        .entity(MESSAGE)
+                        .type(MediaType.TEXT_PLAIN)
+                        .build());
+                return;
+            }
+            capacity.markAdmitted(email);
+        }
+    }
+
+    private String getEmail() {
+        Object value = identity.getAttribute("email");
+        if (value == null) {
+            value = identity.getPrincipal().getName();
+        }
+        return value == null ? null : value.toString();
+    }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminCapacityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminCapacityResource.java
@@ -1,0 +1,44 @@
+package com.scanales.eventflow.private_;
+
+import com.scanales.eventflow.service.CapacityService;
+import com.scanales.eventflow.util.AdminUtils;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/** Admin panel for capacity status. */
+@Path("/private/admin/capacity")
+public class AdminCapacityResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance index(CapacityService.Status status);
+    }
+
+    @Inject
+    SecurityIdentity identity;
+
+    @Inject
+    CapacityService capacity;
+
+    @GET
+    @Authenticated
+    @Produces(MediaType.TEXT_HTML)
+    public Response show() {
+        if (!AdminUtils.isAdmin(identity)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        CapacityService.Status status = capacity.evaluate();
+        return Response.ok(Templates.index(status)).build();
+    }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/CapacityService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/CapacityService.java
@@ -1,0 +1,77 @@
+package com.scanales.eventflow.service;
+
+import java.time.Instant;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Tracks memory and disk capacity for user data and decides if new logins can be admitted.
+ */
+@ApplicationScoped
+public class CapacityService {
+
+    public enum Mode { ADMITTING, CONTAINING }
+    public enum Trend { STABLE, UP, DOWN }
+
+    public record Status(
+            Mode mode,
+            int activeUsers,
+            double memoryPercent,
+            double diskFreePercent,
+            Instant lastEvaluation,
+            Trend trend) {}
+
+    @Inject
+    PersistenceService persistence;
+
+    private final Set<String> admittedUsers = ConcurrentHashMap.newKeySet();
+    private volatile double lastMemory = 0;
+    private volatile double lastDiskFree = 0;
+    private volatile Status lastStatus = new Status(Mode.ADMITTING, 0, 0, 0, Instant.EPOCH, Trend.STABLE);
+
+    /** Evaluates current capacity and returns the status. */
+    public synchronized Status evaluate() {
+        long used = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
+        long max = Runtime.getRuntime().maxMemory();
+        double mem = max == 0 ? 0 : ((double) used / max) * 100d;
+        double diskFree = 100d - persistence.getDiskUsage();
+
+        Trend t = Trend.STABLE;
+        if (mem > lastMemory + 1 || diskFree < lastDiskFree - 1) {
+            t = Trend.UP;
+        } else if (mem < lastMemory - 1 || diskFree > lastDiskFree + 1) {
+            t = Trend.DOWN;
+        }
+        lastMemory = mem;
+        lastDiskFree = diskFree;
+
+        Mode m = canAdmit(mem, diskFree) ? Mode.ADMITTING : Mode.CONTAINING;
+        lastStatus = new Status(m, admittedUsers.size(), mem, diskFree, Instant.now(), t);
+        return lastStatus;
+    }
+
+    /** Returns the last computed status. */
+    public Status getStatus() {
+        return lastStatus;
+    }
+
+    /** Marks a user as admitted. */
+    public void markAdmitted(String email) {
+        if (email != null) {
+            admittedUsers.add(email);
+        }
+    }
+
+    /** Checks if the user was previously admitted. */
+    public boolean isAdmitted(String email) {
+        return email != null && admittedUsers.contains(email);
+    }
+
+    private boolean canAdmit(double memPercent, double diskFreePercent) {
+        return memPercent < 80 && diskFreePercent > 10;
+    }
+}
+

--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -1,0 +1,18 @@
+{#include layout/base}
+{#title}Capacidad{/title}
+{#breadcrumbs}<a href="/private/profile">Perfil</a><span class="sep">/</span><a href="/private/admin">Admin</a><span class="sep">/</span><span>Capacidad</span>{/breadcrumbs}
+{#main}
+<section>
+    <h1 class="page-title">Control de capacidad</h1>
+    <ul class="card">
+        <li>Modo actual: {status.mode.name() == 'ADMITTING' ? 'Admitiendo' : 'Conteniendo nuevos logins'}</li>
+        <li>Usuarios activos en memoria: {status.activeUsers}</li>
+        <li>% de memoria usada: {status.memoryPercent}%</li>
+        <li>% de disco libre: {status.diskFreePercent}%</li>
+        <li>Última evaluación: {status.lastEvaluation}</li>
+        <li>Tendencia: {status.trend.name().toLowerCase()}</li>
+    </ul>
+    <a href="/private/admin" class="btn btn-secondary">Volver a admin</a>
+</section>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -9,6 +9,7 @@
         <a href="/private/admin/events" class="btn">Administrar eventos</a>
         <a href="/private/admin/speakers" class="btn">Administrar oradores</a>
         <a href="/private/admin/metrics" class="btn">Métricas</a>
+        <a href="/private/admin/capacity" class="btn">Capacidad</a>
         <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
         <a href="/private/admin/guide" class="btn">Guía</a>
         <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>


### PR DESCRIPTION
## Summary
- track memory/disk usage and admitted users with new `CapacityService`
- block new logins under low capacity using `CapacityLoginFilter`
- add admin capacity page with current utilization and link from admin panel
- fix admin capacity template to use valid Qute expressions
- flush persistence in schedule service tests to avoid leftover files

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Could not transfer artifact from Maven Central — Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ca22bd54c833399ac17e72424fa5e