### PR TITLE
feat: add refresh window for user schedules

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminCapacityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminCapacityResource.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.private_;
 
 import com.scanales.eventflow.service.CapacityService;
+import com.scanales.eventflow.service.UserScheduleService;
 import com.scanales.eventflow.util.AdminUtils;
 
 import io.quarkus.qute.CheckedTemplate;
@@ -21,7 +22,8 @@ public class AdminCapacityResource {
 
     @CheckedTemplate
     static class Templates {
-        static native TemplateInstance index(CapacityService.Status status);
+        static native TemplateInstance index(CapacityService.Status status,
+                UserScheduleService.ReadMetrics reads);
     }
 
     @Inject
@@ -29,6 +31,9 @@ public class AdminCapacityResource {
 
     @Inject
     CapacityService capacity;
+
+    @Inject
+    UserScheduleService schedules;
 
     @GET
     @Authenticated
@@ -38,7 +43,8 @@ public class AdminCapacityResource {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
         CapacityService.Status status = capacity.evaluate();
-        return Response.ok(Templates.index(status)).build();
+        UserScheduleService.ReadMetrics reads = schedules.getReadMetrics();
+        return Response.ok(Templates.index(status, reads)).build();
     }
 }
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -1,14 +1,28 @@
 package com.scanales.eventflow.service;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.time.Duration;
 import java.time.Year;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 /** In-memory store for user schedules and talk details. */
@@ -23,6 +37,23 @@ public class UserScheduleService {
     /** Loaded historical schedules per year. */
     private final Map<Integer, Map<String, Map<String, TalkDetails>>> historical = new ConcurrentHashMap<>();
 
+    @ConfigProperty(name = "read.window", defaultValue = "PT2S")
+    Duration readWindow;
+
+    @ConfigProperty(name = "read.max-stale", defaultValue = "PT10S")
+    Duration maxStale;
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
+    private volatile Future<?> refreshTask;
+    private final AtomicInteger windowReads = new AtomicInteger();
+    private volatile long lastRefreshDurationMs;
+    private final List<Long> refreshDurations = Collections.synchronizedList(new ArrayList<>());
+    private final AtomicLong readsMemory = new AtomicLong();
+    private final AtomicLong refreshCount = new AtomicLong();
+    private final AtomicLong refreshCoalesced = new AtomicLong();
+    private final AtomicLong staleServed = new AtomicLong();
+
     @Inject
     PersistenceService persistence;
 
@@ -35,6 +66,14 @@ public class UserScheduleService {
     void init() {
         activeYear = persistence.findLatestUserScheduleYear();
         schedules.putAll(persistence.loadUserSchedules(activeYear));
+        long secs = readWindow.getSeconds();
+        if (secs < 1) readWindow = Duration.ofSeconds(1);
+        if (secs > 2) readWindow = Duration.ofSeconds(2);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        scheduler.shutdown();
     }
 
     /** Details tracked for each talk registered by a user. */
@@ -66,6 +105,7 @@ public class UserScheduleService {
 
     /** Returns the set of talk ids registered by the user. */
     public Set<String> getTalksForUser(String email) {
+        recordRead();
         if (email == null) {
             return java.util.Set.of();
         }
@@ -75,6 +115,7 @@ public class UserScheduleService {
 
     /** Returns the map of talk details for the user. */
     public Map<String, TalkDetails> getTalkDetailsForUser(String email) {
+        recordRead();
         if (email == null) {
             return java.util.Map.of();
         }
@@ -126,6 +167,7 @@ public class UserScheduleService {
     public record Summary(int total, long attended, long rated) {}
 
     public Summary getSummaryForUser(String email) {
+        recordRead();
         if (email == null) {
             return new Summary(0, 0, 0);
         }
@@ -188,6 +230,69 @@ public class UserScheduleService {
 
     /** Returns the set of years for which schedule files exist. */
     public Set<Integer> getAvailableYears() {
+        recordRead();
         return persistence.listUserScheduleYears();
+    }
+
+    private void recordRead() {
+        readsMemory.incrementAndGet();
+        if (refreshInProgress.get()) {
+            staleServed.incrementAndGet();
+        }
+        if (refreshTask == null) {
+            windowReads.set(1);
+            refreshTask = scheduler.schedule(this::refreshSnapshot,
+                    readWindow.toMillis(), TimeUnit.MILLISECONDS);
+        } else {
+            windowReads.incrementAndGet();
+        }
+    }
+
+    private void refreshSnapshot() {
+        refreshInProgress.set(true);
+        long reads = windowReads.getAndSet(0);
+        refreshCoalesced.addAndGet(reads);
+        long start = System.currentTimeMillis();
+        try {
+            Map<String, Map<String, TalkDetails>> data =
+                    persistence.loadUserSchedules(activeYear);
+            schedules.clear();
+            schedules.putAll(data);
+        } catch (Exception e) {
+            LOG.warn("refresh_failed", e);
+        } finally {
+            lastRefreshDurationMs = System.currentTimeMillis() - start;
+            synchronized (refreshDurations) {
+                refreshDurations.add(lastRefreshDurationMs);
+                if (refreshDurations.size() > 100) {
+                    refreshDurations.remove(0);
+                }
+            }
+            refreshCount.incrementAndGet();
+            refreshInProgress.set(false);
+            refreshTask = null;
+        }
+    }
+
+    public record ReadMetrics(long memory, long refreshCount, long refreshCoalesced,
+            long refreshLastDurationMs, long refreshP95Ms, long staleServed) {}
+
+    public ReadMetrics getReadMetrics() {
+        long p95 = 0L;
+        List<Long> copy;
+        synchronized (refreshDurations) {
+            copy = new ArrayList<>(refreshDurations);
+        }
+        if (!copy.isEmpty()) {
+            Collections.sort(copy);
+            int index = (int) Math.ceil(copy.size() * 0.95) - 1;
+            if (index < 0) {
+                index = 0;
+            }
+            p95 = copy.get(index);
+        }
+        return new ReadMetrics(readsMemory.get(), refreshCount.get(),
+                refreshCoalesced.get(), lastRefreshDurationMs, p95,
+                staleServed.get());
     }
 }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -32,3 +32,7 @@ ADMIN_LIST=sergio.canales.e@gmail.com
 
 # Metrics flush interval (ISO-8601 duration, default PT10S)
 # metrics.flush-interval=PT10S
+
+# Snapshot read refresh configuration
+read.window=PT2S
+read.max-stale=PT10S

--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -12,6 +12,15 @@
         <li>Última evaluación: {status.lastEvaluation}</li>
         <li>Tendencia: {status.trend.name().toLowerCase()}</li>
     </ul>
+    <h2 class="page-title">Lecturas</h2>
+    <ul class="card">
+        <li>Lecturas desde memoria: {reads.memory}</li>
+        <li>Refrescos ejecutados: {reads.refreshCount}</li>
+        <li>Lecturas coalescidas: {reads.refreshCoalesced}</li>
+        <li>Duración último refresco (ms): {reads.refreshLastDurationMs}</li>
+        <li>Duración p95 (ms): {reads.refreshP95Ms}</li>
+        <li>Lecturas servidas en refresco: {reads.staleServed}</li>
+    </ul>
     <a href="/private/admin" class="btn btn-secondary">Volver a admin</a>
 </section>
 {/main}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleHistoricalServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleHistoricalServiceTest.java
@@ -54,6 +54,7 @@ public class UserScheduleHistoricalServiceTest {
 
     private void flush(UserScheduleService svc) throws Exception {
         getPersistence(svc).flush();
+        svc.shutdown();
     }
 
     @Test

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleServiceTest.java
@@ -42,6 +42,7 @@ public class UserScheduleServiceTest {
 
     private void flush(UserScheduleService svc) throws Exception {
         getPersistence(svc).flush();
+        svc.shutdown();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- cache user schedules in memory with asynchronous refresh window and metrics
- show read refresh metrics in admin capacity page
- expose read window configuration in application properties

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb6048c9083338f05da6fc5529f13