### PR TITLE
feat: surface persistence queue stats

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminCapacityResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminCapacityResource.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.private_;
 
 import com.scanales.eventflow.service.CapacityService;
 import com.scanales.eventflow.service.UserScheduleService;
+import com.scanales.eventflow.service.PersistenceService;
 import com.scanales.eventflow.util.AdminUtils;
 
 import io.quarkus.qute.CheckedTemplate;
@@ -23,7 +24,8 @@ public class AdminCapacityResource {
     @CheckedTemplate
     static class Templates {
         static native TemplateInstance index(CapacityService.Status status,
-                UserScheduleService.ReadMetrics reads);
+                UserScheduleService.ReadMetrics reads,
+                PersistenceService.QueueStats writes);
     }
 
     @Inject
@@ -35,6 +37,9 @@ public class AdminCapacityResource {
     @Inject
     UserScheduleService schedules;
 
+    @Inject
+    PersistenceService persistence;
+
     @GET
     @Authenticated
     @Produces(MediaType.TEXT_HTML)
@@ -44,7 +49,8 @@ public class AdminCapacityResource {
         }
         CapacityService.Status status = capacity.evaluate();
         UserScheduleService.ReadMetrics reads = schedules.getReadMetrics();
-        return Response.ok(Templates.index(status, reads)).build();
+        PersistenceService.QueueStats writes = persistence.getQueueStats();
+        return Response.ok(Templates.index(status, reads, writes)).build();
     }
 }
 

--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -21,6 +21,23 @@
         <li>Duración p95 (ms): {reads.refreshP95Ms}</li>
         <li>Lecturas servidas en refresco: {reads.staleServed}</li>
     </ul>
+    <h2 class="page-title">Escrituras</h2>
+    <ul class="card">
+        <li>Cola: {writes.depth}/{writes.max}</li>
+        <li>Antigüedad más vieja (ms): {writes.oldestAgeMs}</li>
+        <li>OK: {writes.writesOk} &middot; Fallos: {writes.writesFail} &middot; Reintentos: {writes.writesRetries}</li>
+        <li>Descartados por capacidad: {writes.droppedDueCapacity}</li>
+        {#if writes.lastError}
+        <li>Último error: {writes.lastError}</li>
+        {/if}
+    </ul>
+    <button class="btn btn-secondary" onclick="copyState()">Copiar estado</button>
+    <script>
+    function copyState() {
+        const text = `Modo: {status.mode.name()}\nMemoria usada: {status.memoryPercent}%\nDisco libre: {status.diskFreePercent}%\nLecturas: {reads.memory}\nCola escrituras: {writes.depth}/{writes.max}`;
+        navigator.clipboard.writeText(text);
+    }
+    </script>
     <a href="/private/admin" class="btn btn-secondary">Volver a admin</a>
 </section>
 {/main}


### PR DESCRIPTION
## Summary
- Extend capacity admin panel to include persistence queue metrics
- Add copy state helper for quick status sharing

## Testing
- `mvn -f quarkus-app/pom.xml test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce1d700a08333a4a9009195b86c18