### PR TITLE
Register TalkDetails for reflection to ensure persistence

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /** In-memory store for user schedules and talk details. */
 @ApplicationScoped
@@ -80,6 +81,7 @@ public class UserScheduleService {
     }
 
     /** Details tracked for each talk registered by a user. */
+    @RegisterForReflection
     public static class TalkDetails {
         public Set<String> motivations = ConcurrentHashMap.newKeySet();
         public boolean attended;


### PR DESCRIPTION
## Summary
- Register `UserScheduleService.TalkDetails` for reflection so Jackson can serialize user talk details in native image.

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d3ebcdce883338ac8b189724b95e7