### PR TITLE
Fix admin capacity trend rendering

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/CapacityService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/CapacityService.java
@@ -22,7 +22,12 @@ public class CapacityService {
             double memoryPercent,
             double diskFreePercent,
             Instant lastEvaluation,
-            Trend trend) {}
+            Trend trend) {
+
+        public String trendNameLower() {
+            return trend.name().toLowerCase();
+        }
+    }
 
     @Inject
     PersistenceService persistence;

--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -10,7 +10,7 @@
         <li>% de memoria usada: {status.memoryPercent}%</li>
         <li>% de disco libre: {status.diskFreePercent}%</li>
         <li>Última evaluación: {status.lastEvaluation}</li>
-        <li>Tendencia: {status.trend.name().toLowerCase()}</li>
+        <li>Tendencia: {status.trendNameLower}</li>
     </ul>
     <h2 class="page-title">Lecturas</h2>
     <ul class="card">


### PR DESCRIPTION
## Summary
- expose lowercase trend name in capacity status
- use new trend field in admin capacity template

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d4533d07083339eb681a575a53820