### PR TITLE
Verify JWTs using Google JWKS

### DIFF
--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -86,3 +86,18 @@ mvn quarkus:dev
 3. Visit [https://eventflow.opensourcesantiago.io/private](https://eventflow.opensourcesantiago.io/private). You will be redirected to authenticate with Google.
 4. After login the private page shows your name, email and profile picture.
 
+## JWT verification in production
+
+Configure SmallRye JWT to validate Google ID tokens against Google's public keys:
+
+```
+%prod.mp.jwt.verify.issuer=https://accounts.google.com
+%prod.smallrye.jwt.verify.key-location=https://www.googleapis.com/oauth2/v3/certs
+%prod.mp.jwt.verify.audiences=${GOOGLE_CLIENT_ID}
+%prod.smallrye.jwt.verify.algorithm=RS256
+```
+
+Set the `GOOGLE_CLIENT_ID` environment variable to your OAuth client ID so that
+tokens with a matching `aud` claim are accepted. Adjust the `issuer` value if
+your tokens use `accounts.google.com` without the `https` scheme.
+

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -12,6 +12,11 @@ quarkus.oidc.authentication.user-info-required=false
 # Rely on the ID token for user attributes
 quarkus.oidc.authentication.id-token-required=true
 quarkus.oidc.token.principal-claim=id_token
+# Verify Google ID tokens in production
+%prod.mp.jwt.verify.issuer=https://accounts.google.com
+%prod.smallrye.jwt.verify.key-location=https://www.googleapis.com/oauth2/v3/certs
+%prod.mp.jwt.verify.audiences=${GOOGLE_CLIENT_ID}
+%prod.smallrye.jwt.verify.algorithm=RS256
 # Application version
 quarkus.application.version=2.1.2
 # Logging configuration


### PR DESCRIPTION
## Summary
- validate Google ID tokens using SmallRye JWT against Google's JWKS
- document production JWT verification properties and required `GOOGLE_CLIENT_ID`

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d544601148333a38a76acb1d5156e