### PR TITLE
Limit build to app changes and deploy on deployment updates

### DIFF
--- a/.github/workflows/deploy-on-deploy.yml
+++ b/.github/workflows/deploy-on-deploy.yml
@@ -1,0 +1,17 @@
+---
+name: Deploy to GKE on Deployment Changes
+
+'on':
+  push:
+    branches: ['main']
+    paths:
+      - 'deployment/**'
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'deployment/**'
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/docs-root-automerge.yml
+++ b/.github/workflows/docs-root-automerge.yml
@@ -1,0 +1,24 @@
+---
+name: Docs and Root Auto Merge
+
+'on':
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'docs/**'
+      - '*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,8 +1,15 @@
+---
 name: Build
 
-on:
+'on':
+  push:
+    branches: ['main']
+    paths:
+      - 'quarkus-app/**'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
+    paths:
+      - 'quarkus-app/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- build workflow runs only when quarkus-app directory changes
- deploy to GKE whenever files under `deployment/` change
- auto-merge docs and root-level updates

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 200}}}' .github/workflows/deploy-on-build-native.yml .github/workflows/maven.yml .github/workflows/deploy-on-deploy.yml .github/workflows/docs-root-automerge.yml`
- `cd quarkus-app && mvn -q test && cd ..` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dbd2d19248333af30b99fea8369f0