### PR TITLE
feat: enable metrics dashboard navigation and csv export

### DIFF
--- a/docs/metrics-dashboard.md
+++ b/docs/metrics-dashboard.md
@@ -1,0 +1,31 @@
+# Metrics Dashboard
+
+## Navigation Map
+- **Talks:** each row links to the admin view of the talk at `/private/admin/events/{eventId}/edit` with the specific talk in context.
+- **Events:** rows navigate to `/private/admin/events/{eventId}/edit`.
+- **Speakers:** rows navigate to the speaker administration view at `/private/admin/speakers` focused on the selected speaker.
+- **Scenarios:** rows navigate to `/private/admin/events/{eventId}/edit` with the scenario highlighted.
+- The dashboard preserves the selected time range and event filter when navigating to and returning from these pages.
+
+## Export specification
+- Export only the rows and columns visible in the current table, respecting time range, search terms and order.
+- Columns per table:
+  - **Talks:** `Charla`, `Evento`, `Registros`
+  - **Events:** `Evento`, `Visitas`
+  - **Speakers:** `Orador/a`, `Visitas a perfil`
+  - **Scenarios:** `Escenario`, `Evento`, `Visitas`
+- File name format: `metrics-<tabla>-<rango>-<YYYYMMDD-HHMM>.csv` using the event's timezone.
+- CSV never includes personal identifiable information.
+
+## Copy & UX
+- Buttons: `Ver`, `Exportar CSV`
+- Placeholder: `Buscar…`
+- Disabled export message: `Sin datos para exportar en este rango.`
+- Toast: `CSV descargado`
+
+## QA / Checklist
+- Verify that applying range, search and order is reflected in the exported CSV.
+- Clicking `Ver` opens the correct admin page and preserves context when returning.
+- When a table has no data, export button is disabled and shows the no-data message.
+- Keyboard navigation reaches all `Ver` and `Exportar CSV` buttons and aria labels describe the destination.
+- Confirm CSV contains no personal identifiers such as emails or personal IDs.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AppTemplateExtensions.java
@@ -21,6 +21,7 @@ import io.quarkus.security.identity.SecurityIdentity;
 import com.scanales.eventflow.util.AdminUtils;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
 
 @TemplateExtension(namespace = "app")
 public class AppTemplateExtensions {
@@ -200,5 +201,25 @@ public class AppTemplateExtensions {
             case "Finalizada" -> "past";
             default -> "success";
         };
+    }
+
+    /** Returns the event id that contains the given talk. */
+    public static String eventIdByTalk(String talkId) {
+        EventService es = Arc.container().instance(EventService.class).get();
+        if (es == null || talkId == null) {
+            return null;
+        }
+        Event ev = es.findEventByTalk(talkId);
+        return ev != null ? ev.getId() : null;
+    }
+
+    /** Returns the event id that contains the given scenario. */
+    public static String eventIdByScenario(String scenarioId) {
+        EventService es = Arc.container().instance(EventService.class).get();
+        if (es == null || scenarioId == null) {
+            return null;
+        }
+        Event ev = es.findEventByScenario(scenarioId);
+        return ev != null ? ev.getId() : null;
     }
 }

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -75,37 +75,82 @@
     </ul>
 
     <h2>Charlas con mejor conversión</h2>
+    <form method="get" class="table-search">
+        <input type="hidden" name="range" value="{data.range}">
+        {#if data.eventId}<input type="hidden" name="event" value="{data.eventId}">{/if}
+        <input type="hidden" name="speakerQ" value="{data.speakerQ}">
+        <input type="hidden" name="scenarioQ" value="{data.scenarioQ}">
+        <input type="text" name="talkQ" placeholder="Buscar…" value="{data.talkQ}" data-testid="table-talks-search">
+    </form>
     <table>
-        <thead><tr><th>Charla</th><th>Vistas</th><th>Registros</th><th>Conv.</th></tr></thead>
+        <thead><tr><th>Charla</th><th>Vistas</th><th>Registros</th><th>Conv.</th><th>Acciones</th></tr></thead>
         <tbody>
         {#for row in data.topTalks}
-            <tr><td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td></tr>
+            <tr>
+                <td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td>
+                <td><a href="/private/admin/events/{app:eventIdByTalk(row.id)}/edit" aria-label="Ver charla {row.name}" data-testid="table-talks-view-{row.id}">Ver</a></td>
+            </tr>
         {/for}
         </tbody>
     </table>
-    <a href="export?table=talks&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary">Exportar CSV</a>
+    {#if !data.topTalks.isEmpty}
+    <a href="export?table=talks&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}{#if data.talkQ}&amp;q={data.talkQ}{/if}" class="btn btn-secondary" data-testid="table-talks-export">Exportar CSV</a>
+    {#else}
+    <button class="btn btn-secondary" disabled data-testid="table-talks-export">Exportar CSV</button>
+    <p>Sin datos para exportar en este rango.</p>
+    {/if}
 
     <h2>Oradores con mejor conversión</h2>
+    <form method="get" class="table-search">
+        <input type="hidden" name="range" value="{data.range}">
+        {#if data.eventId}<input type="hidden" name="event" value="{data.eventId}">{/if}
+        <input type="hidden" name="talkQ" value="{data.talkQ}">
+        <input type="hidden" name="scenarioQ" value="{data.scenarioQ}">
+        <input type="text" name="speakerQ" placeholder="Buscar…" value="{data.speakerQ}" data-testid="table-speakers-search">
+    </form>
     <table>
-        <thead><tr><th>Orador</th><th>Vistas</th><th>Registros</th><th>Conv.</th></tr></thead>
+        <thead><tr><th>Orador</th><th>Vistas</th><th>Registros</th><th>Conv.</th><th>Acciones</th></tr></thead>
         <tbody>
         {#for row in data.topSpeakers}
-            <tr><td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td></tr>
+            <tr>
+                <td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td>
+                <td><a href="/private/admin/speakers" aria-label="Ver orador {row.name}" data-testid="table-speakers-view-{row.id}">Ver</a></td>
+            </tr>
         {/for}
         </tbody>
     </table>
-    <a href="export?table=speakers&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary">Exportar CSV</a>
+    {#if !data.topSpeakers.isEmpty}
+    <a href="export?table=speakers&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}{#if data.speakerQ}&amp;q={data.speakerQ}{/if}" class="btn btn-secondary" data-testid="table-speakers-export">Exportar CSV</a>
+    {#else}
+    <button class="btn btn-secondary" disabled data-testid="table-speakers-export">Exportar CSV</button>
+    <p>Sin datos para exportar en este rango.</p>
+    {/if}
 
     <h2>Escenarios con mejor conversión</h2>
+    <form method="get" class="table-search">
+        <input type="hidden" name="range" value="{data.range}">
+        {#if data.eventId}<input type="hidden" name="event" value="{data.eventId}">{/if}
+        <input type="hidden" name="talkQ" value="{data.talkQ}">
+        <input type="hidden" name="speakerQ" value="{data.speakerQ}">
+        <input type="text" name="scenarioQ" placeholder="Buscar…" value="{data.scenarioQ}" data-testid="table-scenarios-search">
+    </form>
     <table>
-        <thead><tr><th>Escenario</th><th>Vistas</th><th>Registros</th><th>Conv.</th></tr></thead>
+        <thead><tr><th>Escenario</th><th>Vistas</th><th>Registros</th><th>Conv.</th><th>Acciones</th></tr></thead>
         <tbody>
         {#for row in data.topScenarios}
-            <tr><td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td></tr>
+            <tr>
+                <td>{row.name}</td><td>{row.views}</td><td>{row.registrations}</td><td>{row.conversion}</td>
+                <td><a href="/private/admin/events/{app:eventIdByScenario(row.id)}/edit" aria-label="Ver escenario {row.name}" data-testid="table-scenarios-view-{row.id}">Ver</a></td>
+            </tr>
         {/for}
         </tbody>
     </table>
-    <a href="export?table=scenarios&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary">Exportar CSV</a>
+    {#if !data.topScenarios.isEmpty}
+    <a href="export?table=scenarios&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}{#if data.scenarioQ}&amp;q={data.scenarioQ}{/if}" class="btn btn-secondary" data-testid="table-scenarios-export">Exportar CSV</a>
+    {#else}
+    <button class="btn btn-secondary" disabled data-testid="table-scenarios-export">Exportar CSV</button>
+    <p>Sin datos para exportar en este rango.</p>
+    {/if}
     {/if}
     <a href="/private/admin" class="btn btn-secondary">Volver</a>
 </section>


### PR DESCRIPTION
## Summary
- add identifiers to metrics rows and enrich data model with search parameters
- implement server-side filtering, CSV export with timestamped filenames, and view links
- expose helpers to resolve event IDs for talks and scenarios in templates

## Testing
- `./mvnw -q test` *(fails: java.net.SocketException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e192a36488333b895a917c2046618