### PR TITLE
fix: add DateTimeFormatter import

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.private_;
 
 import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## Summary
- add missing DateTimeFormatter import to AdminMetricsResource to fix compilation error

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e21b11f44833382bd1d7563d7467c