### PR TITLE
feat: add trend calculation utilities

### DIFF
--- a/docs/metrics-dashboard.md
+++ b/docs/metrics-dashboard.md
@@ -23,6 +23,10 @@
 - Disabled export message: `Sin datos para exportar en este rango.`
 - Toast: `CSV descargado`
 
+## Tendencias
+- Cada tarjeta y fila de tabla puede mostrar un badge de tendencia con la variación vs. el período anterior.
+- La lógica de cálculo y reglas se describen en `metrics-trends.md`.
+
 ## QA / Checklist
 - Verify that applying range, search and order is reflected in the exported CSV.
 - Clicking `Ver` opens the correct admin page and preserves context when returning.

--- a/docs/metrics-trends.md
+++ b/docs/metrics-trends.md
@@ -1,0 +1,32 @@
+# Dashboard de Métricas – Tendencias
+
+## Definición de tendencia
+- **Δ% = (Actual − Base) / Base × 100** cuando `Base ≥ min-baseline`.
+- Ventanas comparativas (misma zona horaria del evento):
+  - **Hoy** → comparado con *Ayer*.
+  - **Últimos 7 días** → comparado con los *7 días anteriores*.
+  - **Últimos 30 días** → comparado con los *30 días anteriores*.
+  - **Todo el evento** → tendencia deshabilitada (`N/A`).
+
+## Reglas de casos límite
+- `Base < min-baseline` → mostrar `muestra baja` (sin porcentaje).
+- `Base = 0` y `Actual > 0` → badge `nuevo +n` (Δ absoluto).
+- `Actual = 0` y `Base ≥ min-baseline` → `▼ 100%`.
+- Redondeo: 1 decimal si `|Δ| < 10%`, enteros en caso contrario. Límite `"<0.1%"` y sin `−0%`.
+
+## Tablas y ranking de crecimiento
+- Cada fila de las tablas Top 10 incluye un badge Δ con las reglas anteriores.
+- Tabla adicional: **Top 5 crecimiento (rango)** para *Registros a Mis Charlas*.
+  - Columnas: `Charla · Evento · Registros · Δ`.
+  - Orden principal por Δ absoluto descendente; desempates por Δ% y luego nombre.
+  - Placeholder: `Datos insuficientes para calcular tendencias en este rango.`
+
+## Copys / UX
+- Badges: `nuevo`, `muestra baja`, `N/A (todo el evento)`.
+- Tooltip: `Comparado con {período anterior}`.
+- `aria-label` ejemplos: `Subió X% respecto al período anterior`, `Bajó…`.
+
+## QA / Validaciones
+- Matriz de pruebas con ejemplos de `base=0`, `base < min-baseline`, caídas y crecimientos.
+- Confirmar que los Δ respetan el rango seleccionado y la zona horaria del evento.
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -47,4 +47,12 @@ Las claves se mapean a entidades existentes usando los servicios en memoria:
 
 Para evitar sesgos se aplica un umbral mínimo de vistas (`metrics.min-view-threshold`, default 20) para que una charla, escenario u orador aparezca en los rankings.
 
+### Tendencias
+
+El cálculo de variaciones utiliza los parámetros:
+
+- `metrics.trend.min-baseline` (default 20): mínimo de la base para mostrar porcentajes.
+- `metrics.trend.decimals` (default 1): decimales cuando |Δ| < 10%.
+
+
 Si no hay datos suficientes el panel muestra un mensaje informativo en lugar de tablas vacías.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/TrendUtils.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/TrendUtils.java
@@ -1,0 +1,52 @@
+package com.scanales.eventflow.util;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
+/** Utility methods to compute and format metric trends. */
+public final class TrendUtils {
+    private TrendUtils() {}
+
+    /** Result of a trend calculation. */
+    public record Trend(String badge, String ariaLabel) {}
+
+    /**
+     * Calculates the trend between current and base values following product rules.
+     * @param current value for the selected range
+     * @param base value for the previous equivalent range
+     * @param minBaseline minimum base value to display percentages
+     * @param decimals decimals when |Δ|<10%
+     * @return trend with badge text and aria label
+     */
+    public static Trend calculate(long current, long base, int minBaseline, int decimals) {
+        if (base == 0 && current > 0) {
+            return new Trend("nuevo +" + current, "Nuevo respecto al período anterior");
+        }
+        if (base < minBaseline) {
+            return new Trend("muestra baja", "Muestra baja respecto al período anterior");
+        }
+        if (current == 0) {
+            if (base >= minBaseline) {
+                return new Trend("\u25BC 100%", "Bajó 100% respecto al período anterior");
+            }
+            return new Trend("muestra baja", "Muestra baja respecto al período anterior");
+        }
+        double pct = (double) (current - base) / base * 100d;
+        String sign = pct >= 0 ? "\u25B2" : "\u25BC"; // ▲ ▼
+        double absPct = Math.abs(pct);
+        String formatted;
+        String prefix = pct >= 0 ? "+" : "-";
+        if (absPct < 0.1d) {
+            formatted = "<0.1%";
+            prefix = ""; // no sign for very small changes
+        } else if (absPct < 10d) {
+            DecimalFormat df = new DecimalFormat("#0." + "0".repeat(decimals), DecimalFormatSymbols.getInstance(Locale.US));
+            formatted = df.format(absPct) + "%";
+        } else {
+            formatted = Math.round(absPct) + "%";
+        }
+        String aria = (pct >= 0 ? "Subió " : "Bajó ") + formatted + " respecto al período anterior";
+        return new Trend(sign + " " + prefix + formatted, aria);
+    }
+}

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -41,3 +41,7 @@ ADMIN_LIST=sergio.canales.e@gmail.com
 # Snapshot read refresh configuration
 read.window=PT2S
 read.max-stale=PT10S
+
+# Trend configuration
+metrics.trend.min-baseline=20
+metrics.trend.decimals=1

--- a/quarkus-app/src/test/java/com/scanales/eventflow/util/TrendUtilsTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/util/TrendUtilsTest.java
@@ -1,0 +1,31 @@
+package com.scanales.eventflow.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class TrendUtilsTest {
+
+    @Test
+    public void testPositiveTrend() {
+        TrendUtils.Trend t = TrendUtils.calculate(100, 80, 20, 1);
+        Assertions.assertEquals("\u25B2 +25%", t.badge());
+    }
+
+    @Test
+    public void testLowSample() {
+        TrendUtils.Trend t = TrendUtils.calculate(30, 10, 20, 1);
+        Assertions.assertEquals("muestra baja", t.badge());
+    }
+
+    @Test
+    public void testNew() {
+        TrendUtils.Trend t = TrendUtils.calculate(12, 0, 20, 1);
+        Assertions.assertEquals("nuevo +12", t.badge());
+    }
+
+    @Test
+    public void testFullDrop() {
+        TrendUtils.Trend t = TrendUtils.calculate(0, 50, 20, 1);
+        Assertions.assertEquals("\u25BC 100%", t.badge());
+    }
+}

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -1,3 +1,5 @@
 quarkus.oidc.tenant-enabled=false
 metrics.buffer.max-size=2
 metrics.flush-interval=PT1H
+metrics.trend.min-baseline=20
+metrics.trend.decimals=1


### PR DESCRIPTION
## Summary
- add TrendUtils helper to format metric deltas
- document trend rules and configuration for dashboard
- configure default trend baseline and decimals

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e2479be6c8333a0cc6c0fd9a816c0