### PR TITLE
feat: add data health banner with auto-refresh

### DIFF
--- a/docs/metrics-dashboard.md
+++ b/docs/metrics-dashboard.md
@@ -51,3 +51,31 @@
 - When a table has no data, export button is disabled and shows the no-data message.
 - Keyboard navigation reaches all `Ver` and `Exportar CSV` buttons and aria labels describe the destination.
 - Confirm CSV contains no personal identifiers such as emails or personal IDs.
+
+## Salud de datos y auto-refresh
+
+### Reglas de “Salud de datos”
+- Hoy: desactualizado si la edad del snapshot supera 2 min.
+- Últimos 7 días: desactualizado si > 15 min.
+- Últimos 30 días: desactualizado si > 30 min.
+- Todo el evento: desactualizado si > 60 min.
+- “Sin datos”: todas las tarjetas en 0 y todas las tablas vacías tras aplicar filtros/rango.
+
+### Semántica de “Última actualización”
+- Se toma del timestamp del snapshot de datos, nunca del reloj del cliente.
+- Se muestra en formato relativo: “hace 2 min”, “hace 45 s”; para <1 s usar “justo ahora”.
+
+### Auto-refresh
+- Intervalo por defecto: 5 s (configurable).
+- Coalesce de solicitudes: si hay un refresh en curso, no inicia otro.
+- Re-render condicional por hash de datos.
+- Controles: `Pausar/Continuar` (`data-testid="metrics-refresh-toggle"`, `aria-pressed`) y `Refrescar ahora` (`data-testid="metrics-refresh-now"`, throttle 2 s).
+
+### Copys/UX
+- Estados: “OK”, “Desactualizado”, “Sin datos”.
+- Mensajes: “No pudimos actualizar; reintentaremos”, “Sin datos suficientes en este rango/segmento”.
+- Accesibilidad: `aria-live` en estado y “Última actualización”; botones con `aria-pressed` y tooltips.
+
+### Privacidad y performance
+- Cero PII en mensajes o datos mostrados.
+- Evitar parpadeos: sólo recargar al cambiar el hash de datos.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -316,6 +316,18 @@ public class UsageMetricsService {
         increment("cta:" + name + ":" + today);
     }
 
+    /** Records a refresh attempt for the admin metrics dashboard. */
+    public void recordRefresh(boolean ok, long durationMs) {
+        increment("refresh.count");
+        if (ok) {
+            increment("refresh.ok");
+        } else {
+            increment("refresh.error");
+        }
+        counters.put("refresh.last_duration_ms", durationMs);
+        dirty.set(true);
+    }
+
     private void increment(String key) {
         int size = bufferSize.incrementAndGet();
         if (size > bufferMaxSize) {

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -253,6 +253,30 @@ button:focus-visible {
     margin-right: 0.25rem;
 }
 
+.metrics-health {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+}
+.metrics-health .icon {
+    margin-right: 0.25rem;
+}
+.metrics-health.ok {
+    background: #e8f5e9;
+    color: #2e7d32;
+}
+.metrics-health.stale {
+    background: #fff3e0;
+    color: #ef6c00;
+}
+.metrics-health.empty {
+    background: #eeeeee;
+    color: #616161;
+}
+
 @media (max-width: 600px) {
     .menu-toggle {
         display: block;

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -4,8 +4,17 @@
 {#main}
 <section class="admin-metrics">
     <h1 class="page-title">Métricas</h1>
+    <div class="metrics-health {data.dataHealth.css}" title="{data.dataHealth.tooltip}" aria-live="polite" data-testid="metrics-health-badge">
+        <span class="icon">{#if data.dataHealth.css == 'ok'}✔{/if}{#if data.dataHealth.css == 'stale'}⚠{/if}{#if data.dataHealth.css == 'empty'}∅{/if}</span>
+        <span class="text">{data.dataHealth.state}</span>
+        <span class="updated" aria-live="polite">Última actualización: {data.lastUpdateRel}</span>
+        <span class="controls">
+            <button type="button" id="refreshToggle" aria-pressed="false" data-testid="metrics-refresh-toggle">Pausar</button>
+            <button type="button" id="refreshNow" data-testid="metrics-refresh-now">Refrescar ahora</button>
+        </span>
+    </div>
     {#if data.empty}
-        <p>Sin datos suficientes todavía. Navega por eventos y registra charlas para generar métricas.</p>
+        <p>Sin datos suficientes en este rango/segmento.</p>
     {#else}
     <form method="get" class="metrics-filter">
         <label>Rango:
@@ -59,7 +68,7 @@
         <div class="card" data-testid="metrics-card-stage-visits">Visitas a escenarios: {data.stageVisits}</div>
         <div class="card" data-testid="metrics-card-conversion">Conversión global: {data.globalConversion}</div>
         <div class="card" data-testid="metrics-card-expected">Asistentes esperados: {data.expectedAttendees}</div>
-        <div class="card" data-testid="metrics-card-updated">Última actualización: {data.lastUpdate}</div>
+        <div class="card" data-testid="metrics-last-updated" aria-live="polite">Última actualización: {data.lastUpdateRel}</div>
         <div class="card" data-testid="ctas-card">
             <div>Releases: {data.ctas.releases} | Reportar issue: {data.ctas.issues} | Ko-fi: {data.ctas.kofi}</div>
             <div class="legend" title="Promedio diario calculado solo con días del rango.">Promedio diario en este rango: R={data.ctas.avgReleases} Issues={data.ctas.avgIssues} Ko-fi={data.ctas.avgKofi}</div>
@@ -246,6 +255,53 @@ Charlas registradas: {data.talksRegistered}
 Visitas a escenarios: {data.stageVisits}
 Última actualización: {data.lastUpdate}`;
         navigator.clipboard.writeText(text).then(() => showNotification('success', 'Resumen copiado'));
+    });
+
+    const REFRESH_INTERVAL = 5000;
+    let paused = false;
+    let inflight = false;
+    let throttle = false;
+    let lastHash = {data.lastUpdateMillis};
+    function refreshStatus() {
+        if (paused || inflight) return;
+        inflight = true;
+        fetch('/private/admin/metrics/status' + window.location.search)
+            .then(r => r.json())
+            .then(d => {
+                inflight = false;
+                const badge = document.querySelector('[data-testid="metrics-health-badge"]');
+                if (badge) {
+                    badge.className = 'metrics-health ' + d.css;
+                    badge.title = d.tooltip;
+                    badge.querySelector('.text').textContent = d.state;
+                    const up = badge.querySelector('.updated');
+                    if (up) up.textContent = 'Última actualización: ' + d.last;
+                }
+                const card = document.querySelector('[data-testid="metrics-last-updated"]');
+                if (card) card.textContent = 'Última actualización: ' + d.last;
+                if (lastHash !== d.hash) {
+                    lastHash = d.hash;
+                    location.reload();
+                }
+            })
+            .catch(() => {
+                inflight = false;
+                showNotification('error', 'No pudimos actualizar; reintentaremos');
+            });
+    }
+    setInterval(refreshStatus, REFRESH_INTERVAL);
+    document.getElementById('refreshToggle')?.addEventListener('click', () => {
+        paused = !paused;
+        const btn = document.getElementById('refreshToggle');
+        btn.setAttribute('aria-pressed', paused ? 'true' : 'false');
+        btn.textContent = paused ? 'Continuar' : 'Pausar';
+        if (!paused) refreshStatus();
+    });
+    document.getElementById('refreshNow')?.addEventListener('click', () => {
+        if (throttle) return;
+        throttle = true;
+        setTimeout(() => throttle = false, 2000);
+        refreshStatus();
     });
     </script>
 </section>


### PR DESCRIPTION
## Summary
- show data health banner with OK/Desactualizado/Sin datos states and last update message
- add auto-refresh with pause/refresh controls and telemetry
- document data health rules, last update semantics and refresh behavior

## Testing
- `mvn -q -f quarkus-app/pom.xml test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e49d1564c8333b072b0d4745ab9c1