### PR TITLE
fix: prevent metrics refresh error loop

### DIFF
--- a/docs/metrics-dashboard.md
+++ b/docs/metrics-dashboard.md
@@ -69,6 +69,7 @@
 - Intervalo por defecto: 5 s (configurable).
 - Coalesce de solicitudes: si hay un refresh en curso, no inicia otro.
 - Re-render condicional por hash de datos.
+- Notifica fallos de actualización solo una vez hasta un refresco exitoso.
 - Controles: `Pausar/Continuar` (`data-testid="metrics-refresh-toggle"`, `aria-pressed`) y `Refrescar ahora` (`data-testid="metrics-refresh-now"`, throttle 2 s).
 
 ### Copys/UX

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -262,13 +262,18 @@ Visitas a escenarios: {data.stageVisits}
     let inflight = false;
     let throttle = false;
     let lastHash = {data.lastUpdateMillis};
+    let errorShown = false;
     function refreshStatus() {
         if (paused || inflight) return;
         inflight = true;
         fetch('/private/admin/metrics/status' + window.location.search)
-            .then(r => r.json())
+            .then(r => {
+                if (!r.ok) throw new Error();
+                return r.json();
+            })
             .then(d => {
                 inflight = false;
+                errorShown = false;
                 const badge = document.querySelector('[data-testid="metrics-health-badge"]');
                 if (badge) {
                     badge.className = 'metrics-health ' + d.css;
@@ -286,7 +291,10 @@ Visitas a escenarios: {data.stageVisits}
             })
             .catch(() => {
                 inflight = false;
-                showNotification('error', 'No pudimos actualizar; reintentaremos');
+                if (!errorShown) {
+                    showNotification('error', 'No pudimos actualizar; reintentaremos');
+                    errorShown = true;
+                }
             });
     }
     setInterval(refreshStatus, REFRESH_INTERVAL);


### PR DESCRIPTION
## Summary
- avoid repeated error notifications in admin metrics refresh
- document single-notification behavior for auto-refresh failures

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e586177788333800e0c4b74eefe28