### PR TITLE
fix: register admin status payload for reflection

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -21,6 +21,7 @@ import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -40,6 +41,7 @@ public class AdminMetricsResource {
 
     public record DataHealth(String state, String css, String tooltip) {}
 
+    @RegisterForReflection
     public record StatusPayload(String state, String css, String tooltip, String last, long hash) {}
 
     public record CtaData(


### PR DESCRIPTION
## Summary
- register AdminMetricsResource.StatusPayload for reflection to allow Jackson serialization in native image

## Testing
- `mvn test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fbeba7b4c8333a777794f3ba6951a