### PR TITLE
Fix CSV export path for admin metrics

### DIFF
--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -23,7 +23,7 @@
         <option value="{sp.id}">{sp.name}</option>
       {/for}
     </datalist>
-    <a href="export?range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary" data-testid="export-csv">Exportar CSV</a>
+    <a href="/private/admin/metrics/export?range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary" data-testid="export-csv">Exportar CSV</a>
   </form>
 
   <div class="cards-grid">


### PR DESCRIPTION
## Summary
- fix admin metrics CSV export link to point to correct path

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable import POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fc68c847c8333a579c8b16c04c073