### PR TITLE
Fix today filter for admin metrics

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -353,7 +353,8 @@ public class AdminMetricsResource {
         long talksViewed = talkStats.values().stream().mapToLong(s -> s.views).sum();
         long talksRegistered = talkStats.values().stream().mapToLong(s -> s.regs).sum();
 
-        LocalDate today = LocalDate.now();
+        // Use UTC dates to match the way metrics are recorded.
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         LocalDate start;
         if ("today".equals(range)) {
             start = today;

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -5,6 +5,7 @@ import java.nio.file.*;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.*;

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -288,8 +288,10 @@ public class UsageMetricsService {
             incrementDiscard("bot");
             return;
         }
-        ZoneId zone = timezone != null ? ZoneId.of(timezone) : ZoneId.systemDefault();
-        LocalDate today = LocalDate.now(zone);
+        // Metrics are tracked using a fixed timezone so that admin filters like
+        // "today" work regardless of the event's timezone. Using a consistent
+        // zone avoids gaps when events are recorded in different regions.
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         if (sessionId != null) {
             if (isBurst(sessionId)) {
                 incrementDiscard("burst");
@@ -311,8 +313,8 @@ public class UsageMetricsService {
             incrementDiscard("invalid");
             return;
         }
-        ZoneId zone = timezone != null ? ZoneId.of(timezone) : ZoneId.systemDefault();
-        LocalDate today = LocalDate.now(zone);
+        // Use the same fixed timezone as stage visits for consistency.
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
         increment("cta:" + name + ":" + today);
     }
 


### PR DESCRIPTION
## Summary
- ensure metrics use UTC dates so the admin 'today' filter works consistently

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7754b80833399aa84b409b235b4