### PR TITLE
Fix metrics export NPE when table param missing

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -259,9 +259,10 @@ public class AdminMetricsResource {
         if (!AdminUtils.isAdmin(identity)) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
+        String tableName = (table == null || table.isBlank()) ? "talks" : table;
         MetricsData data = buildData(range, eventId, stageId, speakerId);
         StringBuilder sb = new StringBuilder();
-        if ("ctas".equals(table)) {
+        if ("ctas".equals(tableName)) {
             List<CtaDayRow> rows = filterCtaRows(data.ctas().rows(), query);
             if (!rows.isEmpty()) {
                 sb.append("Fecha,Releases,Issues,Ko-fi,Total\n");
@@ -273,7 +274,7 @@ public class AdminMetricsResource {
         } else {
             List<ConversionRow> rows;
             String header;
-            switch (table) {
+            switch (tableName) {
                 case "talks" -> {
                     rows = data.topTalks();
                     header = "Charla,Vistas,Registros,Conversion";
@@ -303,7 +304,7 @@ public class AdminMetricsResource {
         String ts = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmm"));
         String safeRange = range == null || range.isBlank() ? "all" : range;
         return Response.ok(sb.toString())
-                .header("Content-Disposition", "attachment; filename=metrics-" + table + "-" + safeRange + "-" + ts + ".csv")
+                .header("Content-Disposition", "attachment; filename=metrics-" + tableName + "-" + safeRange + "-" + ts + ".csv")
                 .build();
     }
 

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -23,7 +23,7 @@
         <option value="{sp.id}">{sp.name}</option>
       {/for}
     </datalist>
-    <a href="/private/admin/metrics/export?range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary" data-testid="export-csv">Exportar CSV</a>
+    <a href="/private/admin/metrics/export?table=talks&amp;range={data.range}{#if data.eventId}&amp;event={data.eventId}{/if}" class="btn btn-secondary" data-testid="export-csv">Exportar CSV</a>
   </form>
 
   <div class="cards-grid">


### PR DESCRIPTION
## Summary
- Default metrics export `table` parameter to `talks` and avoid null pointer errors
- Include explicit table parameter in admin metrics export link

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fcdea326c8333bcda25cac4bb6df3