### PR TITLE
fix: always include header in metrics CSV export

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/AdminMetricsResource.java
@@ -264,12 +264,10 @@ public class AdminMetricsResource {
         StringBuilder sb = new StringBuilder();
         if ("ctas".equals(tableName)) {
             List<CtaDayRow> rows = filterCtaRows(data.ctas().rows(), query);
-            if (!rows.isEmpty()) {
-                sb.append("Fecha,Releases,Issues,Ko-fi,Total\n");
-                for (CtaDayRow r : rows) {
-                    sb.append(r.date()).append(',').append(r.releases()).append(',').append(r.issues()).append(',')
-                            .append(r.kofi()).append(',').append(r.total()).append('\n');
-                }
+            sb.append("Fecha,Releases,Issues,Ko-fi,Total\n");
+            for (CtaDayRow r : rows) {
+                sb.append(r.date()).append(',').append(r.releases()).append(',').append(r.issues()).append(',')
+                        .append(r.kofi()).append(',').append(r.total()).append('\n');
             }
         } else {
             List<ConversionRow> rows;
@@ -293,7 +291,7 @@ public class AdminMetricsResource {
                 }
             }
             rows = filterRows(rows, query, sort, dir);
-            if (!header.isEmpty() && !rows.isEmpty()) {
+            if (!header.isEmpty()) {
                 sb.append(header).append('\n');
                 for (ConversionRow r : rows) {
                     sb.append(r.name()).append(',').append(r.views()).append(',')

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
@@ -1,0 +1,73 @@
+package com.scanales.eventflow.private_;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Speaker;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.SpeakerService;
+import com.scanales.eventflow.service.UsageMetricsService;
+
+/** Tests for the CSV export in {@link AdminMetricsResource}. */
+@QuarkusTest
+public class AdminMetricsExportTest {
+
+    @Inject
+    EventService eventService;
+
+    @Inject
+    SpeakerService speakerService;
+
+    @Inject
+    UsageMetricsService metrics;
+
+    @BeforeEach
+    void setUp() {
+        // Basic event with a single talk and speaker
+        Speaker sp = new Speaker();
+        sp.setId("sp1");
+        sp.setName("Alice");
+        speakerService.saveSpeaker(sp);
+
+        Talk talk = new Talk();
+        talk.setId("t1");
+        talk.setName("Talk 1");
+        talk.setLocation("st1");
+        talk.setSpeakers(List.of(sp));
+
+        Scenario sc = new Scenario("st1", "Stage");
+
+        Event ev = new Event("ev1", "Event", "Desc");
+        ev.getScenarios().add(sc);
+        ev.getAgenda().add(talk);
+        eventService.saveEvent(ev);
+
+        metrics.recordTalkView("t1", "sess", "ua");
+        metrics.recordTalkRegister("t1", List.of(sp), "ua");
+    }
+
+    @Test
+    @TestSecurity(user = "admin")
+    public void exportTalksHeaderWhenNoRows() {
+        String csv = given()
+                .when().get("/private/admin/metrics/export?table=talks&q=nomatch")
+                .then().statusCode(200)
+                .extract().asString();
+
+        // The CSV must contain the header even when there are no data rows
+        assertTrue(csv.startsWith("Charla,Vistas,Registros,Conversion"));
+    }
+}
+

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
@@ -59,7 +59,7 @@ public class AdminMetricsExportTest {
     }
 
     @Test
-    @TestSecurity(user = "admin")
+    @TestSecurity(user = "sergio.canales.e@gmail.com")
     public void exportTalksHeaderWhenNoRows() {
         String csv = given()
                 .when().get("/private/admin/metrics/export?table=talks&q=nomatch")

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -3,3 +3,5 @@ metrics.buffer.max-size=2
 metrics.flush-interval=PT1H
 metrics.trend.min-baseline=20
 metrics.trend.decimals=1
+ADMIN_LIST=admin
+metrics.min-view-threshold=0

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -3,5 +3,4 @@ metrics.buffer.max-size=2
 metrics.flush-interval=PT1H
 metrics.trend.min-baseline=20
 metrics.trend.decimals=1
-ADMIN_LIST=admin
 metrics.min-view-threshold=0


### PR DESCRIPTION
## Summary
- ensure admin metrics CSV export always writes header even when no rows
- add test covering empty result export

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fd151179c8333b2cc089e5a4106ce