### PR TITLE
chore: add quality gate and contributor guide

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,2 @@
+extends:
+  - '@commitlint/config-conventional'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,51 @@
+name: Quality Gate
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'quarkus-app/**'
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Format
+        id: format
+        run: mvn -q -f quarkus-app/pom.xml spotless:check
+        continue-on-error: true
+      - name: Dependencies
+        id: deps
+        run: mvn -q -f quarkus-app/pom.xml enforcer:enforce
+        continue-on-error: true
+      - name: Commit message
+        id: commits
+        uses: wagoid/commitlint-github-action@v6
+        continue-on-error: true
+      - name: Summary
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const format='${{ steps.format.outcome }}';
+            const deps='${{ steps.deps.outcome }}';
+            const commits='${{ steps.commits.outcome }}';
+            const body = `### Quality checks\n- Format: ${format}\n- Dependencies: ${deps}\n- Commits: ${commits}\n`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+      - name: Fail if checks failed
+        if: steps.format.outcome == 'failure' || steps.deps.outcome == 'failure' || steps.commits.outcome == 'failure'
+        run: exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,3 +100,24 @@ git commit -m "feat: add sticky navigation to Talk Detail"
 # Push and open a Draft PR
 git push -u origin feat/<short-slug>
 ```
+
+## How Your PR Passes
+
+Follow these quick steps before opening a pull request:
+
+1. **Install prerequisites** – Java 21 and Maven 3.9 or newer.
+2. **Format code** – `mvn -f quarkus-app/pom.xml spotless:apply`.
+3. **Check dependencies** – `mvn -f quarkus-app/pom.xml enforcer:enforce`.
+4. **Commit with Conventional Commits** (see table below).
+5. **Push and open the PR** – fix issues reported by CI and re-push.
+
+### Conventional Commit examples
+
+| Commit message | Use when |
+|----------------|---------|
+| `feat: add new endpoint` | introducing a feature |
+| `fix: handle null user` | fixing a bug |
+| `docs: update README` | documentation only |
+| `chore: update deps` | maintenance or tooling |
+
+If CI reports a failure, apply the suggested command (usually formatting or dependency check), commit the fix and push again.

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -135,6 +135,42 @@
                     <outputName>bom</outputName>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[3.9.0,)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[21,)</version>
+                                </requireJavaVersion>
+                                <dependencyConvergence/>
+                                <requireUpperBoundDeps/>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.43.0</version>
+                <configuration>
+                    <java>
+                        <googleJavaFormat/>
+                    </java>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Summary
- enforce java/maven version, dependency convergence, and formatting via Spotless and Maven Enforcer
- add commitlint config and PR quality workflow with format/dependency/commit checks
- document quick quality steps and commit examples in CONTRIBUTING

## Testing
- `mvn -q spotless:apply && mvn -q enforcer:enforce` *(fails: Non-resolvable import POM... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0046f74a8833394f3e000c2a22972