### PR TITLE
fix: ensure jakarta.validation upper bound

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -28,6 +28,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>3.1.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Summary
- add explicit jakarta.validation-api 3.1.1 dependency management to satisfy enforcer upper bound rule

## Testing
- `mvn -q -e -ntp test` *(fails: Non-resolvable import POM: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.24.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0830daa6c8333845a4798f1b5547e