### PR TITLE
ci: add diff-aware coverage workflow

### DIFF
--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -1,0 +1,165 @@
+name: PR Quality — Tests & Coverage
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qa-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  COV_LINES_MIN: "70"        # umbral líneas (%)
+  COV_BRANCHES_MIN: "70"     # umbral ramas (%)
+  COVERAGE_GATING: ${{ vars.COVERAGE_GATING || 'warn' }}  # 'warn' | 'enforcing'
+  RUN_PIT: ${{ vars.RUN_PIT || 'auto' }}                  # 'auto' | 'off' | 'on'
+
+jobs:
+  tests-coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      # 1) Ejecuta tests y genera jacoco.xml (ajusta el perfil 'coverage' en tu POM)
+      - name: Build & Test (JaCoCo)
+        run: |
+          cd quarkus-app
+          mvn -B -ntp -DskipITs=false verify -Pcoverage
+          JACOCO_XML=$(git ls-files -z | tr '\0' '\n' | grep -E 'target/site/jacoco/jacoco\.xml$' | head -n1 || true)
+          if [ -z "$JACOCO_XML" ]; then
+            echo "No se encontró jacoco.xml"; exit 1
+          fi
+          mkdir -p ../reports
+          cp "$JACOCO_XML" ../reports/jacoco.xml
+
+      # 2) Archivos cambiados del PR
+      - name: Collect changed files (diff)
+        id: diff
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --paginate \
+            | jq -r '.[].filename' > reports/changed-files.txt
+          echo "count=$(wc -l < reports/changed-files.txt)" >> $GITHUB_OUTPUT
+
+      # 3) Cobertura en el diff (parsea jacoco.xml y mapea files->clases)
+      - name: Enforce coverage on diff
+        id: cov
+        run: |
+          python3 - << 'PY'
+          import os, sys, xml.etree.ElementTree as ET, pathlib, re
+          # Config
+          jacoco_path = "reports/jacoco.xml"
+          changed_path = "reports/changed-files.txt"
+          cov_lines_min = int(os.getenv("COV_LINES_MIN","70"))
+          cov_br_min    = int(os.getenv("COV_BRANCHES_MIN","70"))
+          gating        = os.getenv("COVERAGE_GATING","warn").lower()
+
+          if not os.path.isfile(jacoco_path):
+            print("jacoco.xml no encontrado", file=sys.stderr); sys.exit(1)
+
+          changed = []
+          if os.path.isfile(changed_path):
+            with open(changed_path) as f:
+              changed = [l.strip() for l in f if l.strip()]
+          # Filtra solo código fuente principal
+          src_files = [p for p in changed if re.search(r"src/(main|core)/java/.*\.java$", p)]
+
+          # Mapa class->(missed/covered) acumulado
+          tree = ET.parse(jacoco_path); root = tree.getroot()
+          classes = []
+          for pkg in root.findall(".//package"):
+            pname = pkg.get("name","").replace("/", ".")
+            for cls in pkg.findall("./class"):
+              cname = cls.get("name","").replace("/", ".")
+              fqcn = cname if cname.count(".")>0 else (pname+"."+cname if pname else cname)
+              # Suma counters LINE y BRANCH a nivel de clase
+              cm = {"LINE":(0,0),"BRANCH":(0,0)}
+              for c in cls.findall("./counter"):
+                typ = c.get("type")
+                if typ in ("LINE","BRANCH"):
+                  missed = int(c.get("missed","0")); covered = int(c.get("covered","0"))
+                  cm[typ] = (missed, covered)
+              classes.append((fqcn, cm["LINE"], cm["BRANCH"]))
+
+          # Función para derivar FQCN base a partir de ruta fuente
+          def path_to_fqcn(p):
+            # .../src/main/java/io/eventflow/foo/Bar.java -> io.eventflow.foo.Bar
+            m = re.search(r"src/(?:main|core)/java/(.*)\.java$", p)
+            if not m: return None
+            return m.group(1).replace("/", ".")
+
+          targets = {}
+          for sf in src_files:
+            base = path_to_fqcn(sf)
+            if not base: continue
+            # Agregar todas las clases cuyo nombre empieza con base (maneja inner classes $)
+            line_missed=line_cov=branch_missed=branch_cov=0
+            for (fqcn, (lm, lc), (bm, bc)) in classes:
+              if fqcn==base or fqcn.startswith(base+"$"):
+                line_missed+=lm; line_cov+=lc; branch_missed+=bm; branch_cov+=bc
+            targets[sf]=(line_missed,line_cov,branch_missed,branch_cov)
+
+          total_lm=total_lc=total_bm=total_bc=0
+          for (lm,lc,bm,bc) in targets.values():
+            total_lm+=lm; total_lc+=lc; total_bm+=bm; total_bc+=bc
+
+          def pct(c, m): 
+            den = c+m
+            return (100.0*c/den) if den>0 else 100.0
+
+          covL = pct(total_lc, total_lm)
+          covB = pct(total_bc, total_bm)
+
+          # Summary
+          print("### Coverage (diff)")
+          print(f"- Files in diff: {len(src_files)}")
+          print(f"- Lines: {covL:.1f}% (min {cov_lines_min}%)")
+          print(f"- Branches: {covB:.1f}% (min {cov_br_min}%)")
+          # Guardar para el job
+          with open(os.getenv("GITHUB_STEP_SUMMARY"),"a") as s:
+            s.write(f"### Coverage (diff)\n- Files in diff: {len(src_files)}\n- Lines: {covL:.1f}% (min {cov_lines_min}%)\n- Branches: {covB:.1f}% (min {cov_br_min}%)\n")
+
+          fail = (covL < cov_lines_min) or (covB < cov_br_min)
+          if gating=="enforcing" and fail and len(src_files)>0:
+            sys.exit(2)
+          PY
+
+      # 4) (Opcional) Mutación acotada con PIT
+      - name: Run PIT (scoped)
+        if: ${{ env.RUN_PIT != 'off' && steps.diff.outputs.count != '0' }}
+        run: |
+          PKGS=$(awk -F'src/(main|core)/java/' '/\.java$/{print $2}' reports/changed-files.txt \
+                | sed -E 's#/[^/]+\.java$##' | tr '/' '.' | sort -u)
+          if [ -z "$PKGS" ] && [ "${RUN_PIT}" = "auto" ]; then
+            echo "Sin paquetes claros en el diff; omito PIT (auto)"; exit 0
+          fi
+          INCLUDES=$(echo "$PKGS" | sed 's/$/.*/' | paste -sd, -)
+          echo "PIT targetClasses: ${INCLUDES:-io.eventflow.*}"
+          cd quarkus-app
+          mvn -B -ntp -DskipTests \
+            org.pitest:pitest-maven:1.16.1:mutationCoverage \
+            -DtargetClasses="${INCLUDES:-io.eventflow.*}" \
+            -Djunit5PluginVersion=1.2.0 \
+            -Dthreads=2 -DmutationThreshold=0 || true
+          mkdir -p ../reports/pit && cp -r target/pit-reports/* ../reports/pit/ 2>/dev/null || true
+          echo "### PIT (scoped) ejecutado" >> $GITHUB_STEP_SUMMARY
+
+      # 5) Subir artefactos
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-tests-coverage
+          path: reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,3 +121,10 @@ Follow these quick steps before opening a pull request:
 | `chore: update deps` | maintenance or tooling |
 
 If CI reports a failure, apply the suggested command (usually formatting or dependency check), commit the fix and push again.
+
+### Test coverage & mutation
+
+- `mvn -f quarkus-app/pom.xml verify -Pcoverage` genera `quarkus-app/target/site/jacoco/index.html`.
+- Mantén **≥ 70%** de líneas y ramas en el diff de tu PR.
+- Opcional: `mvn -f quarkus-app/pom.xml org.pitest:pitest-maven:1.16.1:mutationCoverage -DtargetClasses='io.eventflow.*'`.
+- Si falla el gate de cobertura, agrega o ajusta tests de las clases tocadas y vuelve a ejecutar.

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -182,6 +182,32 @@
 
     <profiles>
         <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.12</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>native</id>
             <activation>
                 <property>


### PR DESCRIPTION
## Summary
- add PR workflow to run tests, measure diff coverage, and scoped mutation testing
- document how to run coverage and mutation tests locally
- provide Maven profile for generating JaCoCo reports

## Testing
- `mvn -f quarkus-app/pom.xml -B -ntp -DskipITs=false verify -Pcoverage`

------
https://chatgpt.com/codex/tasks/task_e_68a103ce1c8483339bb36797c0d4a9e0