### PR TITLE
Ensure JaCoCo XML report is generated in target directory

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -193,6 +193,12 @@
                                 <goals>
                                     <goal>report</goal>
                                 </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
## Summary
- configure jacoco report to emit XML coverage file directly in the `target` directory

## Testing
- `mvn -Pcoverage verify`
- `mvn -Pcoverage -DskipTests verify`


------
https://chatgpt.com/codex/tasks/task_e_68a110774a388333921d1f4c0cbb39ae