### PR TITLE
chore: refine coverage tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ If CI reports a failure, apply the suggested command (usually formatting or depe
 
 ### Test coverage & mutation
 
-- `mvn -f quarkus-app/pom.xml verify -Pcoverage` genera `quarkus-app/target/site/jacoco/index.html`.
-- Mantén **≥ 70%** de líneas y ramas en el diff de tu PR.
+- Ejecuta `./dev/pr-check.sh` para compilar, correr tests y generar `quarkus-app/target/site/jacoco/index.html`.
+- Mantén **≥ 70 %** de líneas y ramas en el diff de tu PR. El gating es progresivo: primera semana `warn`, luego `enforcing`.
 - Opcional: `mvn -f quarkus-app/pom.xml org.pitest:pitest-maven:1.16.1:mutationCoverage -DtargetClasses='io.eventflow.*'`.
 - Si falla el gate de cobertura, agrega o ajusta tests de las clases tocadas y vuelve a ejecutar.

--- a/dev/pr-check.sh
+++ b/dev/pr-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd quarkus-app
+mvn -B -ntp -DskipITs=false verify -Pcoverage
+REPORT=$(git ls-files -z | tr '\0' '\n' | grep -E 'target/site/jacoco/index\.html$' | head -n1 || true)
+echo
+echo "✅ Build + tests OK. Abre el reporte de cobertura local:"
+echo "   ${REPORT:-<no encontrado>}"
+echo "Recuerda que el gate en CI evaluará SOLO el diff del PR (líneas y branches)."

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -11,7 +11,7 @@
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.24.3</quarkus.platform.version>
         <compiler-plugin.version>3.11.0</compiler-plugin.version>
-        <surefire-plugin.version>3.1.2</surefire-plugin.version>
+        <surefire-plugin.version>3.2.5</surefire-plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
@@ -100,6 +100,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-plugin.version}</version>
                 <configuration>
+                    <useModulePath>false</useModulePath>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <maven.home>${maven.home}</maven.home>
@@ -183,9 +185,14 @@
                         <version>0.8.12</version>
                         <executions>
                             <execution>
+                                <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <configuration>
+                                    <append>true</append>
+                                    <output>file</output>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>report</id>
@@ -194,13 +201,30 @@
                                     <goal>report</goal>
                                 </goals>
                                 <configuration>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <formats>
-                                        <format>XML</format>
-                                    </formats>
+                                    <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                                    <outputDirectory>${project.build.directory}/site/jacoco</outputDirectory>
+                                    <excludes>
+                                        <exclude>**/generated/**</exclude>
+                                        <exclude>**/*$*</exclude>
+                                    </excludes>
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-maven</artifactId>
+                        <version>1.16.1</version>
+                        <configuration>
+                            <junit5PluginVersion>1.2.0</junit5PluginVersion>
+                            <threads>2</threads>
+                            <mutationThreshold>0</mutationThreshold>
+                            <outputFormats>
+                                <param>HTML</param>
+                                <param>XML</param>
+                            </outputFormats>
+                            <timestampedReports>false</timestampedReports>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary
- refine surefire configuration and generate JaCoCo report under `target/site/jacoco`
- add PIT mutation testing configuration in coverage profile
- add `dev/pr-check.sh` for local coverage checks and document progressive gating

## Testing
- `./dev/pr-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a112ba17b4833399b8a5d3e750d3ff