### PR TITLE
Fix Jacoco report lookup in workflow

### DIFF
--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cd quarkus-app
           mvn -B -ntp -DskipITs=false verify -Pcoverage
-          JACOCO_XML=$(git ls-files -z | tr '\0' '\n' | grep -E 'target/site/jacoco/jacoco\.xml$' | head -n1 || true)
+          JACOCO_XML=$(find . -path '*/target/site/jacoco/jacoco.xml' | head -n1 || true)
           if [ -z "$JACOCO_XML" ]; then
             echo "No se encontró jacoco.xml"; exit 1
           fi


### PR DESCRIPTION
## Summary
- search Jacoco report with `find` instead of `git ls-files` so coverage step locates generated `jacoco.xml`

## Testing
- `mvn -q -DskipITs=false verify -Pcoverage` *(fails: ProfileResourceTest.addTalkJson)*

------
https://chatgpt.com/codex/tasks/task_e_68a11b73d2c88333bbda4dde82faf385