### PR TITLE
Run deployment workflow on merged PRs

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -1,7 +1,14 @@
+---
 name: Build Native and Deploy
 
-on:
+'on':
   push:
+    branches: [main]
+    paths:
+      - 'quarkus-app/**'
+      - 'deployment/**'
+  pull_request:
+    types: [closed]
     branches: [main]
     paths:
       - 'quarkus-app/**'
@@ -9,6 +16,10 @@ on:
 
 jobs:
   build:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- run Build Native and Deploy workflow when a pull request merges to `main`
- guard jobs so they only run on pushes or merged PRs

## Testing
- `yamllint .github/workflows/main-deploy.yml`
- `mvn -f quarkus-app/pom.xml -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68a1538671c48333bb4658aade5fcce2