### PR TITLE
Handle expired OIDC sessions via redirect and headers

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
@@ -1,0 +1,77 @@
+package com.scanales.eventflow.security;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/** Redirects unauthenticated or expired HTML requests to the home page. */
+@Provider
+@PreMatching
+@Priority(Priorities.AUTHORIZATION)
+public class HtmlSessionExpiryFilter implements ContainerRequestFilter {
+
+  private static final Set<String> PUBLIC_PATHS = Set.of("/", "/health", "/metrics");
+  private static final Pattern STATIC_PATTERN = Pattern.compile("^/(css|js|images|static|img)/.*");
+
+  @Inject SecurityIdentity identity;
+
+  @ConfigProperty(name = "app.auth.redirect-on-expire", defaultValue = "true")
+  boolean redirectOnExpire;
+
+  @Override
+  public void filter(ContainerRequestContext ctx) {
+    if (!redirectOnExpire) {
+      return;
+    }
+    String path = "/" + Optional.ofNullable(ctx.getUriInfo().getPath()).orElse("");
+    String accept = Optional.ofNullable(ctx.getHeaderString(HttpHeaders.ACCEPT)).orElse("");
+
+    boolean isHtml = accept.contains(MediaType.TEXT_HTML);
+    boolean isPublic = PUBLIC_PATHS.contains(path) || STATIC_PATTERN.matcher(path).matches();
+
+    if (!isHtml || isPublic) {
+      return;
+    }
+
+    boolean anonymous = identity == null || identity.isAnonymous();
+    boolean expired = isExpired(identity);
+
+    if (anonymous || expired) {
+      ctx.abortWith(
+          Response.status(Response.Status.FOUND)
+              .header(HttpHeaders.LOCATION, "/")
+              .header("X-Redirected-By", "session-expired")
+              .header(HttpHeaders.SET_COOKIE, "q_session=; Path=/; Max-Age=0; HttpOnly; Secure")
+              .build());
+    }
+  }
+
+  private boolean isExpired(SecurityIdentity id) {
+    if (id == null) {
+      return true;
+    }
+    JsonWebToken jwt = null;
+    if (id.getPrincipal() instanceof JsonWebToken jw) {
+      jwt = jw;
+    }
+    if (jwt == null) {
+      return false;
+    }
+    Long exp = jwt.getExpirationTime();
+    return exp != null && exp <= (System.currentTimeMillis() / 1000L);
+  }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/SessionResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/SessionResource.java
@@ -1,0 +1,34 @@
+package com.scanales.eventflow.security;
+
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.util.Map;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/** Simple endpoint to report session status. */
+@Path("/auth/session")
+public class SessionResource {
+
+  @Inject SecurityIdentity identity;
+
+  @GET
+  @Authenticated
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, Object> session() {
+    long exp = 0L;
+    JsonWebToken jwt = null;
+    if (identity.getPrincipal() instanceof JsonWebToken jw) {
+      jwt = jw;
+    }
+    if (jwt != null) {
+      exp = jwt.getExpirationTime();
+    }
+    return Map.of("active", true, "exp", exp);
+  }
+}
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/UnauthorizedMapper.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/UnauthorizedMapper.java
@@ -1,0 +1,23 @@
+package com.scanales.eventflow.security;
+
+import io.quarkus.security.UnauthorizedException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/** Adds headers to unauthorized API responses signalling session expiry. */
+@Provider
+public class UnauthorizedMapper implements ExceptionMapper<UnauthorizedException> {
+
+  @Override
+  public Response toResponse(UnauthorizedException e) {
+    return Response.status(Response.Status.UNAUTHORIZED)
+        .header("X-Session-Expired", "true")
+        .header(
+            HttpHeaders.WWW_AUTHENTICATE,
+            "Bearer realm=\"eventflow\", error=\"invalid_token\", error_description=\"expired\"")
+        .build();
+  }
+}
+

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -1,3 +1,15 @@
+(function(){
+  const origFetch = window.fetch;
+  window.fetch = async function(input, init) {
+    const res = await origFetch(input, init);
+    if (res.status === 401 && res.headers.get('X-Session-Expired') === 'true') {
+      try { sessionStorage.clear(); localStorage.clear(); } catch (e) {}
+      if (location.pathname !== '/') { location.assign('/'); }
+    }
+    return res;
+  };
+})();
+
 function adjustLayout() {
     if (window.innerWidth < 600) {
         document.body.classList.add('mobile');

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -45,3 +45,7 @@ read.max-stale=PT10S
 # Trend configuration
 metrics.trend.min-baseline=20
 metrics.trend.decimals=1
+
+# Session expiration handling
+app.auth.redirect-on-expire=true
+app.auth.redirect-grace-ms=30000

--- a/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionExpiryFilterTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionExpiryFilterTest.java
@@ -1,0 +1,44 @@
+package com.scanales.eventflow.security;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+/** Tests for session expiration handling. */
+@QuarkusTest
+public class SessionExpiryFilterTest {
+
+  @Test
+  public void htmlRedirectsToRootWhenUnauthorized() {
+    given()
+        .redirects()
+        .follow(false)
+        .accept("text/html")
+        .when()
+        .get("/private/admin")
+        .then()
+        .statusCode(302)
+        .header("Location", equalTo("/"))
+        .header("X-Redirected-By", equalTo("session-expired"));
+  }
+
+  @Test
+  public void apiUnauthorizedHasSessionHeader() {
+    given()
+        .redirects()
+        .follow(false)
+        .accept("application/json")
+        .when()
+        .get("/private/admin/metrics/status")
+        .then()
+        .statusCode(401)
+        .header("X-Session-Expired", equalTo("true"))
+        .header(
+            "WWW-Authenticate",
+            equalTo(
+                "Bearer realm=\"eventflow\", error=\"invalid_token\", error_description=\"expired\""));
+  }
+}
+


### PR DESCRIPTION
## Summary
- redirect HTML requests with expired or missing OIDC sessions to `/` and clear cookie
- signal expired sessions on API calls with `X-Session-Expired` and WWW-Authenticate header
- add client-side fetch interceptor and a `/auth/session` endpoint for session status

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68a17b3f457c83339e3a8f9cc0156f29