### PR TITLE
chore: fix formatting and enforce java version

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -156,7 +156,7 @@
                             <fail>true</fail>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[21,)</version>
+                                    <version>21</version>
                                 </requireJavaVersion>
                                 <banDuplicatePomDependencyVersions/>
                                 <requireUpperBoundDeps/>

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -62,7 +62,7 @@ public class HomeResource {
             "releasesUrl", "https://github.com/scanalesespinoza/eventflow/releases",
             "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
-      return Templates.home(events, today, "2.1.4", stats, links);
+    return Templates.home(events, today, "2.1.4", stats, links);
   }
 
   @GET

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
@@ -74,4 +74,3 @@ public class HtmlSessionExpiryFilter implements ContainerRequestFilter {
     return exp != null && exp <= (System.currentTimeMillis() / 1000L);
   }
 }
-

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/SessionResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/SessionResource.java
@@ -31,4 +31,3 @@ public class SessionResource {
     return Map.of("active", true, "exp", exp);
   }
 }
-

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/UnauthorizedMapper.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/UnauthorizedMapper.java
@@ -20,4 +20,3 @@ public class UnauthorizedMapper implements ExceptionMapper<UnauthorizedException
         .build();
   }
 }
-

--- a/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionExpiryFilterTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionExpiryFilterTest.java
@@ -41,4 +41,3 @@ public class SessionExpiryFilterTest {
                 "Bearer realm=\"eventflow\", error=\"invalid_token\", error_description=\"expired\""));
   }
 }
-


### PR DESCRIPTION
## Summary
- format security and public resources with Spotless
- configure Maven Enforcer to require Java 21

## Testing
- `mvn -ntp test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f8de7308833384ee298c88258851