### PR TITLE
Configure Maven Enforcer rules

### DIFF
--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -146,23 +146,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
+                <configuration>
+                    <fail>true</fail>
+                    <rules>
+                        <requireJavaVersion>
+                            <version>21</version>
+                        </requireJavaVersion>
+                        <banDuplicatePomDependencyVersions/>
+                        <requireUpperBoundDeps/>
+                        <dependencyConvergence/>
+                    </rules>
+                </configuration>
                 <executions>
                     <execution>
                         <id>enforce</id>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
-                        <configuration>
-                            <fail>true</fail>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>21</version>
-                                </requireJavaVersion>
-                                <banDuplicatePomDependencyVersions/>
-                                <requireUpperBoundDeps/>
-                                <dependencyConvergence/>
-                            </rules>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary
- add explicit rules for Maven Enforcer plugin, including Java version and dependency checks

## Testing
- `mvn -ntp -B enforcer:enforce`
- `mvn -ntp -B test` *(fails: Tests run: 48, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fdec61e483339c419db13adac01b