### PR TITLE
fix: install syft in manual deploy workflow

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -84,6 +84,10 @@ jobs:
           cosign sign --key cosign.key --yes "${REGISTRY}/${IMAGE_NAME}:${VERSION}" || true
           rm -f cosign.key
 
+      - name: Install Syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
       - name: Attach SBOM
         run: |
           if [ ! -f sbom-image.cdx.json ]; then

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      - name: Install Syft
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
       - name: Build & test
         run: mvn -B -f quarkus-app/pom.xml package
 


### PR DESCRIPTION
## Summary
- install Syft in manual deploy workflow before build
- install Syft in build-native workflow to allow SBOM generation

## Testing
- `cd quarkus-app && ./mvnw -q test && cd -` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2248093b883339fda16805be7e3b7