### PR TITLE
fix: avoid redirect loop on expired sessions

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
@@ -36,7 +36,8 @@ public class HtmlSessionExpiryFilter implements ContainerRequestFilter {
     if (!redirectOnExpire) {
       return;
     }
-    String path = "/" + Optional.ofNullable(ctx.getUriInfo().getPath()).orElse("");
+    String rawPath = Optional.ofNullable(ctx.getUriInfo().getPath()).orElse("");
+    String path = rawPath.startsWith("/") ? rawPath : "/" + rawPath;
     String accept = Optional.ofNullable(ctx.getHeaderString(HttpHeaders.ACCEPT)).orElse("");
 
     boolean isHtml = accept.contains(MediaType.TEXT_HTML);


### PR DESCRIPTION
## Summary
- normalize request path in HtmlSessionExpiryFilter to prevent redirecting '/' to itself

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68a22c5376cc833384c549a2e5b96145