### PR TITLE
Allow anonymous access to login page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 @Priority(Priorities.AUTHORIZATION)
 public class HtmlSessionExpiryFilter implements ContainerRequestFilter {
 
-  private static final Set<String> PUBLIC_PATHS = Set.of("/", "/health", "/metrics");
+  private static final Set<String> PUBLIC_PATHS = Set.of("/", "/login", "/health", "/metrics");
   private static final Pattern STATIC_PATTERN = Pattern.compile("^/(css|js|images|static|img)/.*");
 
   @Inject SecurityIdentity identity;

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/LoginPageTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/LoginPageTest.java
@@ -1,0 +1,24 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class LoginPageTest {
+
+  @Test
+  public void loginAccessibleWithoutAuth() {
+    given()
+        .redirects()
+        .follow(false)
+        .accept("text/html")
+        .when()
+        .get("/login")
+        .then()
+        .statusCode(200)
+        .body(containsString("Login"));
+  }
+}


### PR DESCRIPTION
## Summary
- allow unauthenticated visits to /login by whitelisting it in the session-expiry filter
- add regression test ensuring login page is served to anonymous users

## Testing
- `./dev/pr-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a23227ed988333b6c4931a8c39a4b8