### PR TITLE
Fix session expiry filter to allow initial OAuth login

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionExpiryFilterTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionExpiryFilterTest.java
@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Test;
 public class SessionExpiryFilterTest {
 
   @Test
-  public void htmlRedirectsToRootWhenUnauthorized() {
+  public void htmlExpiredSessionRedirectsToRoot() {
     given()
         .redirects()
         .follow(false)
         .accept("text/html")
+        .cookie("q_session", "expired")
         .when()
         .get("/private/admin")
         .then()


### PR DESCRIPTION
## Summary
- Avoid redirecting unauthenticated users without a session cookie so OAuth login can start
- Adjust session expiry test to simulate an expired session cookie

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68a243766f388333b5f8fdedbd2ce3a1