### PR TITLE
ci: run main deploy on merges and refine quality workflows

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -4,15 +4,13 @@ name: Build Native and Deploy
 'on':
   push:
     branches: [main]
-    paths:
-      - 'quarkus-app/**'
-      - 'deployment/**'
   pull_request:
     types: [closed]
     branches: [main]
-    paths:
-      - 'quarkus-app/**'
-      - 'deployment/**'
+
+concurrency:
+  group: main-deploy
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/.github/workflows/pr-quality-suite.yml
+++ b/.github/workflows/pr-quality-suite.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: qa-suite-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   paths:

--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: qa-tests-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   COV_LINES_MIN: "70"        # umbral líneas (%)
@@ -25,6 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Prepare reports directory
+        run: mkdir -p reports
+
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
@@ -34,6 +37,8 @@ jobs:
 
       # 1) Ejecuta tests y genera jacoco.xml (ajusta el perfil 'coverage' en tu POM)
       - name: Build & Test (JaCoCo)
+        id: build
+        continue-on-error: true
         run: |
           cd quarkus-app
           mvn -B -ntp -DskipITs=false verify -Pcoverage
@@ -46,6 +51,7 @@ jobs:
 
       # 2) Archivos cambiados del PR
       - name: Collect changed files (diff)
+        if: always()
         id: diff
         env:
           GH_TOKEN: ${{ github.token }}
@@ -56,6 +62,7 @@ jobs:
 
       # 3) Cobertura en el diff (parsea jacoco.xml y mapea files->clases)
       - name: Enforce coverage on diff
+        if: steps.build.outcome == 'success'
         id: cov
         run: |
           python3 - << 'PY'
@@ -139,7 +146,7 @@ jobs:
 
       # 4) (Opcional) Mutación acotada con PIT
       - name: Run PIT (scoped)
-        if: ${{ env.RUN_PIT != 'off' && steps.diff.outputs.count != '0' }}
+        if: ${{ steps.build.outcome == 'success' && env.RUN_PIT != 'off' && steps.diff.outputs.count != '0' }}
         run: |
           PKGS=$(awk -F'src/(main|core)/java/' '/\.java$/{print $2}' reports/changed-files.txt \
                 | sed -E 's#/[^/]+\.java$##' | tr '/' '.' | sort -u)
@@ -164,3 +171,7 @@ jobs:
         with:
           name: pr-tests-coverage
           path: reports
+
+      - name: Fail build
+        if: steps.build.outcome != 'success'
+        run: exit 1


### PR DESCRIPTION
## Summary
- trigger deploy workflow on every merge to main and prevent overlapping runs
- keep PR quality checks from cancelling in-progress runs
- ensure test/coverage workflow always produces a report before failing

## Testing
- `mvn -B -ntp -f quarkus-app/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_68a25660cc0c83338e6c2200b93bd2b9