### PR TITLE
Optimize utility helpers for admin checks and trend formatting

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/AdminUtils.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/AdminUtils.java
@@ -3,12 +3,17 @@ package com.scanales.eventflow.util;
 import io.quarkus.oidc.runtime.OidcJwtCallerPrincipal;
 import io.quarkus.security.identity.SecurityIdentity;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 /** Utility methods for admin checks. */
 public final class AdminUtils {
+
+  private static final List<String> ADMIN_LIST = initAdminList();
+  private static final Set<String> ADMIN_SET = new HashSet<>(ADMIN_LIST);
 
   private AdminUtils() {}
 
@@ -17,6 +22,10 @@ public final class AdminUtils {
    * The value is expected to be a comma separated list of email addresses.
    */
   public static List<String> getAdminList() {
+    return ADMIN_LIST;
+  }
+
+  private static List<String> initAdminList() {
     String raw = ConfigProvider.getConfig().getOptionalValue("ADMIN_LIST", String.class).orElse("");
     if (raw.isBlank()) {
       return List.of();
@@ -36,7 +45,7 @@ public final class AdminUtils {
     if (email == null) {
       email = identity.getPrincipal().getName();
     }
-    return email != null && getAdminList().contains(email);
+    return email != null && ADMIN_SET.contains(email);
   }
 
   /** Obtains a claim or attribute from the identity. */

--- a/quarkus-app/src/main/java/com/scanales/eventflow/util/TrendUtils.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/util/TrendUtils.java
@@ -6,6 +6,8 @@ import java.util.Locale;
 
 /** Utility methods to compute and format metric trends. */
 public final class TrendUtils {
+  private static final DecimalFormatSymbols US_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.US);
+
   private TrendUtils() {}
 
   /** Result of a trend calculation. */
@@ -42,9 +44,7 @@ public final class TrendUtils {
       formatted = "<0.1%";
       prefix = ""; // no sign for very small changes
     } else if (absPct < 10d) {
-      DecimalFormat df =
-          new DecimalFormat(
-              "#0." + "0".repeat(decimals), DecimalFormatSymbols.getInstance(Locale.US));
+      DecimalFormat df = new DecimalFormat("#0." + "0".repeat(decimals), US_SYMBOLS);
       formatted = df.format(absPct) + "%";
     } else {
       formatted = Math.round(absPct) + "%";


### PR DESCRIPTION
## Summary
- cache ADMIN_LIST and lookup set in AdminUtils
- reuse DecimalFormatSymbols in TrendUtils

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68a268c360bc83339e94cfe849f6bbd1