### PR TITLE
Refactor logging filters and metrics utilities to reduce duplication

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -41,9 +41,7 @@ public class HomeResource {
   public TemplateInstance home(
       @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
-    String ua = headers.getHeaderString("User-Agent");
-    String sessionId = context.session() != null ? context.session().id() : null;
-    metrics.recordPageView("/", sessionId, ua);
+    metrics.recordPageView("/", headers, context);
     var events =
         eventService.listEvents().stream()
             .sorted(

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
@@ -36,16 +36,15 @@ public class ScenarioResource {
       @PathParam("id") String id,
       @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
-    String ua = headers.getHeaderString("User-Agent");
-    String sessionId = context.session() != null ? context.session().id() : null;
-    metrics.recordPageView("/scenario", sessionId, ua);
+    metrics.recordPageView("/scenario", headers, context);
     Scenario s = eventService.findScenario(id);
     if (s == null) {
       return Templates.detail(null, null, java.util.List.of());
     }
     var event = eventService.findEventByScenario(id);
     var talks = eventService.findTalksForScenario(id);
-    metrics.recordStageVisit(id, event != null ? event.getTimezone() : null, sessionId, ua);
+    metrics.recordStageVisit(
+        id, event != null ? event.getTimezone() : null, headers, context);
     return Templates.detail(s, event, talks);
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -2,10 +2,12 @@ package com.scanales.eventflow.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scanales.eventflow.model.Speaker;
+import io.vertx.ext.web.RoutingContext;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.HttpHeaders;
 import java.io.IOException;
 import java.nio.file.*;
 import java.time.Duration;
@@ -185,6 +187,12 @@ public class UsageMetricsService {
     recordPageView(route, null, ua);
   }
 
+  public void recordPageView(String route, HttpHeaders headers, RoutingContext context) {
+    String ua = headers.getHeaderString("User-Agent");
+    String sessionId = context.session() != null ? context.session().id() : null;
+    recordPageView(route, sessionId, ua);
+  }
+
   public void recordPageView(String route, String sessionId, String ua) {
     if (isBot(ua)) {
       incrementDiscard("bot");
@@ -306,6 +314,13 @@ public class UsageMetricsService {
       }
     }
     increment("stage_visit:" + stageId + ":" + today);
+  }
+
+  public void recordStageVisit(
+      String stageId, String timezone, HttpHeaders headers, RoutingContext context) {
+    String ua = headers.getHeaderString("User-Agent");
+    String sessionId = context.session() != null ? context.session().id() : null;
+    recordStageVisit(stageId, timezone, sessionId, ua);
   }
 
   public void recordCta(String name, String timezone) {

--- a/quarkus-app/src/main/java/com/scanales/oauth/logging/AbstractLoggingFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/oauth/logging/AbstractLoggingFilter.java
@@ -1,0 +1,22 @@
+package com.scanales.oauth.logging;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import java.io.IOException;
+import org.jboss.logging.Logger;
+
+/**
+ * Base logging filter with a per-class logger and a single entry point
+ * delegating to subclasses.
+ */
+public abstract class AbstractLoggingFilter implements ContainerRequestFilter {
+
+  protected final Logger log = Logger.getLogger(getClass());
+
+  @Override
+  public final void filter(ContainerRequestContext requestContext) throws IOException {
+    handle(requestContext);
+  }
+
+  protected abstract void handle(ContainerRequestContext requestContext) throws IOException;
+}

--- a/quarkus-app/src/main/java/com/scanales/oauth/logging/OidcCallbackLoggingFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/oauth/logging/OidcCallbackLoggingFilter.java
@@ -3,28 +3,24 @@ package com.scanales.oauth.logging;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
-import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.util.stream.Collectors;
-import org.jboss.logging.Logger;
 
 /** Logs all parameters received on the OIDC callback endpoint. */
 @Provider
 @Priority(Priorities.AUTHENTICATION)
-public class OidcCallbackLoggingFilter implements ContainerRequestFilter {
-
-  private static final Logger LOG = Logger.getLogger(OidcCallbackLoggingFilter.class);
+public class OidcCallbackLoggingFilter extends AbstractLoggingFilter {
 
   @Override
-  public void filter(ContainerRequestContext requestContext) throws IOException {
+  protected void handle(ContainerRequestContext requestContext) throws IOException {
     String path = requestContext.getUriInfo().getPath();
     if (path.startsWith("q/oauth2/callback") || path.startsWith("q/oidc/callback")) {
       String params =
           requestContext.getUriInfo().getQueryParameters().entrySet().stream()
               .map(e -> e.getKey() + "=" + String.join(",", e.getValue()))
               .collect(Collectors.joining(", "));
-      LOG.infov("OAuth callback parameters: {0}", params);
+      log.infov("OAuth callback parameters: {0}", params);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Extract common logger handling into `AbstractLoggingFilter` and update existing OAuth filters
- Add metrics helper methods and simplify resource page-view recording
- Deduplicate SARIF processing in `scripts/enforce_severity.py`

## Testing
- `./dev/pr-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a26c83ef788333a94f8330199424a2