### PR TITLE
chore: disable workflow cancellations

### DIFF
--- a/.github/workflows/pr-architecture-rules.yml
+++ b/.github/workflows/pr-architecture-rules.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: qa-arch-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   arch-rules:

--- a/.github/workflows/pr-deps-hygiene.yml
+++ b/.github/workflows/pr-deps-hygiene.yml
@@ -9,7 +9,7 @@ permissions:
 
 concurrency:
   group: qa-deps-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   DEPS_GATING: ${{ vars.DEPS_GATING || 'warn' }}  # 'warn' | 'enforcing'

--- a/.github/workflows/pr-static-analysis.yml
+++ b/.github/workflows/pr-static-analysis.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: qa-static-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   static-analysis:


### PR DESCRIPTION
## Summary
- avoid canceling in-progress static analysis and dependency jobs
- ensure architecture checks also run to completion without cancellations

## Testing
- `actionlint .github/workflows/pr-static-analysis.yml .github/workflows/pr-architecture-rules.yml .github/workflows/pr-deps-hygiene.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a27588aec083339b2454c0dd53b846