### PR TITLE
ci: ensure Maven cache path exists for static analysis workflow

### DIFF
--- a/.github/workflows/pr-static-analysis.yml
+++ b/.github/workflows/pr-static-analysis.yml
@@ -27,6 +27,9 @@ jobs:
           java-version: '21'
           cache: maven
 
+      - name: Ensure Maven cache path exists
+        run: mkdir -p ~/.m2/repository
+
       - name: Run static analysis (diff-aware)
         run: |
           mkdir -p reports


### PR DESCRIPTION
## Summary
- avoid cache warnings in static analysis workflow by creating Maven repository before saving cache

## Testing
- `mvn -f quarkus-app/pom.xml test`


------
https://chatgpt.com/codex/tasks/task_e_68a280e386cc8333ba64a0f1716296d2