### PR TITLE
Disable Vert.x file caching to avoid permission warnings

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
@@ -1,0 +1,17 @@
+package com.scanales.eventflow;
+
+import io.quarkus.runtime.Quarkus;
+import io.quarkus.runtime.annotations.QuarkusMain;
+
+/**
+ * Custom entry point that disables Vert.x file caching before the application starts.
+ */
+@QuarkusMain
+public class VertxCacheFixMain {
+
+    public static void main(String... args) {
+        // Disable Vert.x file caching to avoid permission warnings on some filesystems
+        System.setProperty("vertx.disableFileCaching", "true");
+        Quarkus.run(args);
+    }
+}

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -49,3 +49,5 @@ metrics.trend.decimals=1
 # Session expiration handling
 app.auth.redirect-on-expire=true
 app.auth.redirect-grace-ms=30000
+
+quarkus.package.main-class=com.scanales.eventflow.VertxCacheFixMain


### PR DESCRIPTION
## Summary
- Add custom Quarkus main class to set `vertx.disableFileCaching` at startup
- Configure application to use the custom main class

## Testing
- `mvn -q -f quarkus-app/pom.xml test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a34f978f4c8333b4d2ee8bd1090e5d