### PR TITLE
chore: format VertxCacheFixMain with Spotless

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
@@ -3,15 +3,13 @@ package com.scanales.eventflow;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.annotations.QuarkusMain;
 
-/**
- * Custom entry point that disables Vert.x file caching before the application starts.
- */
+/** Custom entry point that disables Vert.x file caching before the application starts. */
 @QuarkusMain
 public class VertxCacheFixMain {
 
-    public static void main(String... args) {
-        // Disable Vert.x file caching to avoid permission warnings on some filesystems
-        System.setProperty("vertx.disableFileCaching", "true");
-        Quarkus.run(args);
-    }
+  public static void main(String... args) {
+    // Disable Vert.x file caching to avoid permission warnings on some filesystems
+    System.setProperty("vertx.disableFileCaching", "true");
+    Quarkus.run(args);
+  }
 }


### PR DESCRIPTION
## Summary
- format VertxCacheFixMain to match Spotless rules

## Testing
- `mvn spotless:check`
- `mvn test` *(fails: terminated after extensive dependency downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68a3541d93308333bf58d2655785ce31