### PR TITLE
Disable Vert.x classpath resolver to avoid tmp cache

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
@@ -3,13 +3,25 @@ package com.scanales.eventflow;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.annotations.QuarkusMain;
 
-/** Custom entry point that disables Vert.x file caching before the application starts. */
+/**
+ * Custom entry point that tunes Vert.x before Quarkus starts.
+ *
+ * <p>Some deployment environments mount the filesystem as read only. Vert.x
+ * normally extracts classpath resources to a temporary directory, creating a
+ * {@code vertx-cache} folder under {@code java.io.tmpdir}. When the filesystem is
+ * not writable, this fails and the application cannot start.</p>
+ *
+ * <p>This main class disables Vert.x file caching <em>and</em> classpath resolving
+ * so Vert.x no longer attempts to create the cache directory.</p>
+ */
 @QuarkusMain
 public class VertxCacheFixMain {
 
   public static void main(String... args) {
-    // Disable Vert.x file caching to avoid permission warnings on some filesystems
+    // Disable caching of extracted resources
     System.setProperty("vertx.disableFileCaching", "true");
+    // Avoid extracting classpath resources entirely so no cache directory is needed
+    System.setProperty("vertx.disableFileCPResolving", "true");
     Quarkus.run(args);
   }
 }


### PR DESCRIPTION
## Summary
- disable Vert.x file caching and classpath resolving to prevent writing to `/tmp`

## Testing
- `mvn test` *(fails: There are test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a3af6f34bc833383435c685a79f09c