### PR TITLE
fix: disable Vert.x file cache for read-only rootfs

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             failureThreshold: 3
           env:
             - name: JAVA_TOOL_OPTIONS
-              value: "-XX:+UseContainerSupport -Deventflow.data.dir=/work/data"
+              value: "-XX:+UseContainerSupport -Deventflow.data.dir=/work/data -Dvertx.disableFileCaching=true -Dvertx.disableFileCPResolving=true"
             - name: OIDC_CLIENT_ID
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- disable Vert.x file caching and classpath resolving via `JAVA_TOOL_OPTIONS` so the app no longer writes to `/tmp`

## Testing
- `./quarkus-app/mvnw -q -f quarkus-app/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b4a1ad748333bcf101c3f559ca85