### PR TITLE
fix(config): use writable Vert.x cache directory

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -19,6 +19,8 @@ quarkus.oidc.token.principal-claim=id_token
 %prod.smallrye.jwt.verify.algorithm=RS256
 # Application version
 quarkus.application.version=2.1.4
+# Store Vert.x cache on a writable volume
+quarkus.vertx.cache-directory=/work/data/vertx-cache
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings
 quarkus.log.category."io.quarkus.oidc".level=INFO

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -4,3 +4,4 @@ metrics.flush-interval=PT1H
 metrics.trend.min-baseline=20
 metrics.trend.decimals=1
 metrics.min-view-threshold=0
+quarkus.vertx.cache-directory=target/vertx-cache


### PR DESCRIPTION
## Summary
- store Vert.x cache under `/work/data/vertx-cache` using the correct `quarkus.vertx.cache-directory` property
- override test configuration to use a local cache directory

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c90d92d083338d99f3b8dba8475f