### PR TITLE
Fix PVC permissions by setting fsGroup

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -113,6 +113,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
+        fsGroup: 1001
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
## Summary
- set `fsGroup` to allow eventflow to write to persistent volume

## Testing
- `mvn test` *(fails: Tests run: 49, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a4532b1bf0833383748c34568a0199