### PR TITLE
fix: configure upload directory on writable volume

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -21,6 +21,8 @@ quarkus.oidc.token.principal-claim=id_token
 quarkus.application.version=2.1.4
 # Store Vert.x cache on a writable volume
 quarkus.vertx.cache-directory=/work/data/vertx-cache
+# Store HTTP file uploads on a writable volume
+quarkus.http.body.uploads-directory=/work/data/uploads
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings
 quarkus.log.category."io.quarkus.oidc".level=INFO


### PR DESCRIPTION
## Summary
- store HTTP file uploads under `/work/data/uploads` to avoid read-only filesystem errors

## Testing
- `mvn test -e`


------
https://chatgpt.com/codex/tasks/task_e_68a45d4c9bb08333bb4eae5c7d60d423