### PR TITLE
feat(home): add email link to event listings

### DIFF
--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -25,12 +25,13 @@
                         {#if e.descriptionSummary}
                         <p class="event-description">{e.descriptionSummary}</p>
                         {/if}
-                        {#if app:validUrl(e.website) || app:validUrl(e.twitter) || app:validUrl(e.linkedin) || app:validUrl(e.instagram) || app:validUrl(e.ticketsUrl)}
+                        {#if app:validUrl(e.website) || app:validUrl(e.twitter) || app:validUrl(e.linkedin) || app:validUrl(e.instagram) || app:validEmail(e.contactEmail) || app:validUrl(e.ticketsUrl)}
                         <div class="event-links">
                             {#if app:validUrl(e.website)}<a href="{e.website}" target="_blank" rel="noopener" class="btn">🌐 Sitio Web</a>{/if}
                             {#if app:validUrl(e.twitter)}<a href="{e.twitter}" target="_blank" rel="noopener" class="btn">🐦 Twitter</a>{/if}
                             {#if app:validUrl(e.linkedin)}<a href="{e.linkedin}" target="_blank" rel="noopener" class="btn">💼 LinkedIn</a>{/if}
                             {#if app:validUrl(e.instagram)}<a href="{e.instagram}" target="_blank" rel="noopener" class="btn">📸 Instagram</a>{/if}
+                            {#if app:validEmail(e.contactEmail)}<a href="mailto:{e.contactEmail}" target="_blank" rel="noopener" class="btn">📧 Email</a>{/if}
                             {#if app:validUrl(e.ticketsUrl)}<a href="{e.ticketsUrl}" target="_blank" rel="noopener" class="btn">🎟️ Entradas</a>{/if}
                         </div>
                         {/if}


### PR DESCRIPTION
## Summary
- show contact email link in home event cards for parity with event detail view

## Testing
- `mvn -f quarkus-app/pom.xml test`


------
https://chatgpt.com/codex/tasks/task_e_68a4694597f48333a0c28b34da2bde38