### PR TITLE
fix: avoid false error after backup download

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -79,16 +79,18 @@ function bannerParallax() {
 let loadingTimeout;
 let loadingTarget = 'el contenido';
 
-function showLoading(target = 'el contenido') {
+function showLoading(target = 'el contenido', enableTimeout = true) {
     loadingTarget = target;
     document.body.classList.remove('loaded');
     const loader = document.getElementById('loading');
     if (loader) loader.classList.remove('hidden');
     clearTimeout(loadingTimeout);
-    loadingTimeout = setTimeout(() => {
-        hideLoading();
-        showNotification('error', `No se pudo cargar ${loadingTarget}`);
-    }, 5000);
+    if (enableTimeout) {
+        loadingTimeout = setTimeout(() => {
+            hideLoading();
+            showNotification('error', `No se pudo cargar ${loadingTarget}`);
+        }, 5000);
+    }
 }
 
 function hideLoading() {
@@ -183,4 +185,4 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 window.addEventListener('resize', adjustLayout);
 window.addEventListener('scroll', bannerParallax);
-window.addEventListener('beforeunload', () => showLoading('la página'));
+window.addEventListener('beforeunload', () => showLoading('la página', false));


### PR DESCRIPTION
## Summary
- allow showLoading to skip error timeout
- avoid false "No se pudo cargar la página" message when downloading backups

## Testing
- `mvn test` *(fails: Tests run: 49, Failures: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a46bdd02348333a3cbf9473784c646