### PR TITLE
fix: use writable data directory for uploads and cache

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -20,9 +20,9 @@ quarkus.oidc.token.principal-claim=id_token
 # Application version
 quarkus.application.version=2.1.4
 # Store Vert.x cache on a writable volume
-quarkus.vertx.cache-directory=/work/data/vertx-cache
+quarkus.vertx.cache-directory=${eventflow.data.dir:./data}/vertx-cache
 # Store HTTP file uploads on a writable volume
-quarkus.http.body.uploads-directory=/work/data/uploads
+quarkus.http.body.uploads-directory=${eventflow.data.dir:./data}/uploads
 # Logging configuration
 # Reduce log volume to avoid WRITE_FAILURE warnings
 quarkus.log.category."io.quarkus.oidc".level=INFO


### PR DESCRIPTION
## Summary
- point Quarkus cache and upload directories to the configured data directory so tests run on writable paths

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68a46cf5f4888333ac56f44d2b426879