### PR TITLE
Use temp data dir for tests

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/TestDataDir.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/TestDataDir.java
@@ -1,0 +1,27 @@
+package com.scanales.eventflow;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+public class TestDataDir implements QuarkusTestResourceLifecycleManager {
+    private Path tempDir;
+
+    @Override
+    public Map<String, String> start() {
+        try {
+            tempDir = Files.createTempDirectory("eventflow-test");
+            String path = tempDir.toString();
+            System.setProperty("eventflow.data.dir", path);
+            return Map.of("eventflow.data.dir", path);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        // no cleanup required
+    }
+}

--- a/quarkus-app/src/test/resources/META-INF/services/io.quarkus.test.common.QuarkusTestResourceLifecycleManager
+++ b/quarkus-app/src/test/resources/META-INF/services/io.quarkus.test.common.QuarkusTestResourceLifecycleManager
@@ -1,0 +1,1 @@
+com.scanales.eventflow.TestDataDir

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -4,4 +4,3 @@ metrics.flush-interval=PT1H
 metrics.trend.min-baseline=20
 metrics.trend.decimals=1
 metrics.min-view-threshold=0
-quarkus.vertx.cache-directory=target/vertx-cache


### PR DESCRIPTION
## Summary
- Ensure tests write data under a temporary directory by adding a global `QuarkusTestResource`
- Keep test `application.properties` minimal for faster builds

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68a470b459a883339c964beba1526bda