### PR TITLE
fix: preserve event context in talk and scenario routing

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
@@ -13,7 +13,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-@Path("/scenario")
+@Path("/")
 public class ScenarioResource {
 
   @CheckedTemplate
@@ -29,7 +29,7 @@ public class ScenarioResource {
   @Inject UsageMetricsService metrics;
 
   @GET
-  @Path("{id}")
+  @Path("/scenario/{id}")
   @PermitAll
   @Produces(MediaType.TEXT_HTML)
   public TemplateInstance detail(
@@ -45,5 +45,36 @@ public class ScenarioResource {
     var talks = eventService.findTalksForScenario(id);
     metrics.recordStageVisit(id, event != null ? event.getTimezone() : null, headers, context);
     return Templates.detail(s, event, talks);
+  }
+
+  /**
+   * Nueva ruta: /event/{eventId}/scenario/{id}
+   * Permite mostrar el escenario en el contexto del evento de origen.
+   */
+  @GET
+  @Path("/event/{eventId}/scenario/{id}")
+  @PermitAll
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance detailWithEvent(
+      @PathParam("eventId") String eventId,
+      @PathParam("id") String id,
+      @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
+      @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
+    metrics.recordPageView("/event/" + eventId + "/scenario", headers, context);
+    var event = eventService.getEvent(eventId);
+    if (event == null) {
+      return Templates.detail(null, null, java.util.List.of());
+    }
+    var scenario =
+        event.getScenarios().stream().filter(s -> s.getId().equals(id)).findFirst().orElse(null);
+    var talks =
+        event.getAgenda().stream()
+            .filter(t -> id.equals(t.getLocation()))
+            .sorted(
+                java.util.Comparator.comparingInt(com.scanales.eventflow.model.Talk::getDay)
+                    .thenComparing(com.scanales.eventflow.model.Talk::getStartTime))
+            .toList();
+    metrics.recordStageVisit(id, event.getTimezone(), headers, context);
+    return Templates.detail(scenario, event, talks);
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -17,7 +17,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
-@Path("/talk")
+@Path("/")
 public class TalkResource {
 
   private static final Logger LOG = Logger.getLogger(TalkResource.class);
@@ -40,7 +40,7 @@ public class TalkResource {
   @Inject UsageMetricsService metrics;
 
   @GET
-  @Path("{id}")
+  @Path("/talk/{id}")
   @PermitAll
   @Produces(MediaType.TEXT_HTML)
   public Response detail(

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -63,7 +63,7 @@ Evento
       <article class="scenario-card">
         <h3>{s.name}</h3>
         {#if s.location}<p class="scenario-location">{s.location}</p>{/if}
-        <a href="/scenario/{s.id}" class="btn">Ver charlas</a>
+        <a href="/event/{event.id}/scenario/{s.id}" class="btn">Ver charlas</a>
       </article>
       {/for}
     </div>
@@ -103,7 +103,7 @@ Evento
                 {#if t.break}
                 <span class="agenda-title-text">{t.name}</span>
                 {#else}
-                <a href="/talk/{t.id}" class="agenda-title-text">{t.name}</a>
+                <a href="/event/{event.id}/talk/{t.id}" class="agenda-title-text">{t.name}</a>
                 {/if}
               </td>
               <td class="agenda-speakers">
@@ -121,7 +121,7 @@ Evento
                 </span>
                 {/if}
               </td>
-              <td class="agenda-location"><a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a></td>
+              <td class="agenda-location"><a href="/event/{event.id}/scenario/{t.location}">{event.getScenarioName(t.location)}</a></td>
             </tr>
             {/for}
           </tbody>
@@ -149,7 +149,7 @@ Evento
                   {#if t.break}
                   {t.name}
                   {#else}
-                  <a href="/talk/{t.id}">{t.name}</a>
+                  <a href="/event/{event.id}/talk/{t.id}">{t.name}</a>
                   {#if !t.speakers.isEmpty()}
                   <div class="agenda-slot-speakers">
                     {#for s in t.speakers}

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -25,7 +25,7 @@
         <div class="talk-row" data-talk-id="{t.id}" data-attended="{info.get(t.id).attended}" data-rated="{info.get(t.id).rating??}">
           <span class="attendance-icon">{#if info.get(t.id).attended}✅{#else}❌{/if}</span>
           <span class="talk-time">{t.startTimeStr} - {t.endTimeStr}</span>
-          <span class="talk-title"><a href="/talk/{t.id}">{t.name}</a></span>
+          <span class="talk-title"><a href="/event/{g.event.id}/talk/{t.id}">{t.name}</a></span>
           <div class="speaker-avatars">
             {#for s in t.speakers}
               <a href="/speaker/{s.id}" title="{s.name}">

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -6,7 +6,7 @@
 {#if talk}
 <a href="/">Inicio</a>
 {#if event}<span class="sep">/</span><a href="/event/{event.id}">{event.title}</a>{/if}
-{#if talk.location && event}<span class="sep">/</span><a href="/scenario/{talk.location}">{event.getScenarioName(talk.location)}</a>{/if}
+{#if talk.location && event}<span class="sep">/</span><a href="/event/{event.id}/scenario/{talk.location}">{event.getScenarioName(talk.location)}</a>{/if}
 <span class="sep">/</span><span>Charla: {talk.name ?: talk.id}</span>
 {/if}
 {/breadcrumbs}
@@ -119,7 +119,7 @@
           <span class="icon">⏰</span>Día {t.day} - {t.startTimeStr} ({t.durationMinutes} min) -
           {#if t.location}
             {#if event}
-              <a href="/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
+              <a href="/event/{event.id}/scenario/{t.location}">{event.getScenarioName(t.location)}</a>
             {#else}
               <span>{t.location}</span>
             {/if}
@@ -136,7 +136,7 @@
   </div>
   {/if}
   <div class="action-group">
-    {#if talk.location}<a href="/scenario/{talk.location}" class="btn btn-secondary">Volver al escenario</a>{/if}
+    {#if talk.location && event}<a href="/event/{event.id}/scenario/{talk.location}" class="btn btn-secondary">Volver al escenario</a>{/if}
     {#if event}<a href="/event/{event.id}" class="btn">Volver al evento</a>{/if}
   </div>
 </section>


### PR DESCRIPTION
## Summary
- ensure event-scoped talk and scenario endpoints are registered at root paths to prevent 404s

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68a48343faec833388593f6d4958c58d