### PR TITLE
Support talk URLs with slugs

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -4,8 +4,6 @@ import com.scanales.eventflow.model.Talk;
 import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.UsageMetricsService;
 import com.scanales.eventflow.service.UserScheduleService;
-import io.quarkus.qute.CheckedTemplate;
-import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.annotation.security.PermitAll;
 import jakarta.inject.Inject;
@@ -17,26 +15,14 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
-@Path("")
-public class TalkResource {
+@Path("/event")
+public class EventTalkResource {
 
-  private static final Logger LOG = Logger.getLogger(TalkResource.class);
-
-  @CheckedTemplate
-  static class Templates {
-    static native TemplateInstance detail(
-        Talk talk,
-        com.scanales.eventflow.model.Event event,
-        java.util.List<Talk> occurrences,
-        boolean inSchedule);
-  }
+  private static final Logger LOG = Logger.getLogger(EventTalkResource.class);
 
   @Inject EventService eventService;
-
   @Inject SecurityIdentity identity;
-
   @Inject UserScheduleService userSchedule;
-
   @Inject UsageMetricsService metrics;
 
   private String canonicalize(String rawId) {
@@ -45,41 +31,31 @@ public class TalkResource {
   }
 
   @GET
-  @Path("/talk/{id}")
+  @Path("{eventId}/talk/{talkId}")
   @PermitAll
   @Produces(MediaType.TEXT_HTML)
-  public Response detail(
-      @PathParam("id") String id,
+  public Response detailWithEvent(
+      @PathParam("eventId") String eventId,
+      @PathParam("talkId") String talkId,
       @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
     String ua = headers.getHeaderString("User-Agent");
     String sessionId = context.session() != null ? context.session().id() : null;
-    metrics.recordPageView("/talk", sessionId, ua);
+    metrics.recordPageView("/event/" + eventId + "/talk", sessionId, ua);
     try {
-      String canonicalId = canonicalize(id);
-      Talk talk = eventService.findTalk(canonicalId);
+      String canonicalTalkId = canonicalize(talkId);
+      Talk talk = eventService.findTalk(canonicalTalkId);
       if (talk == null) {
-        LOG.warnf("Talk %s not found", id);
+        LOG.warnf("Talk %s not found", talkId);
         return Response.status(Response.Status.NOT_FOUND).build();
       }
-      var event = eventService.findEventByTalk(canonicalId);
-      var occurrences = eventService.findTalkOccurrences(canonicalId);
-      metrics.recordTalkView(canonicalId, sessionId, ua);
+      var event = eventService.getEvent(eventId);
+      var occurrences = eventService.findTalkOccurrences(canonicalTalkId);
+      metrics.recordTalkView(canonicalTalkId, sessionId, ua);
       if (talk.getLocation() != null) {
         metrics.recordStageVisit(
             talk.getLocation(), event != null ? event.getTimezone() : null, sessionId, ua);
       }
-
-      java.util.List<String> missing = new java.util.ArrayList<>();
-      if (talk.getLocation() == null) missing.add("location");
-      if (talk.getName() == null) missing.add("name");
-      if (talk.getStartTime() == null) missing.add("startTime");
-      if (event == null) missing.add("event");
-      if (talk.getSpeakers() == null || talk.getSpeakers().isEmpty()) missing.add("speaker");
-      if (!missing.isEmpty()) {
-        LOG.warnf("Talk %s missing data: %s", canonicalId, String.join(", ", missing));
-      }
-
       boolean inSchedule = false;
       if (identity != null && !identity.isAnonymous()) {
         String email = identity.getAttribute("email");
@@ -88,12 +64,14 @@ public class TalkResource {
           email = principal != null ? principal.getName() : null;
         }
         if (email != null) {
-          inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
+          inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
         }
       }
-      return Response.ok(Templates.detail(talk, event, occurrences, inSchedule)).build();
+      return Response.ok(
+              TalkResource.Templates.detail(talk, event, occurrences, inSchedule))
+          .build();
     } catch (Exception e) {
-      LOG.errorf(e, "Error rendering talk %s", id);
+      LOG.errorf(e, "Error rendering talk %s", talkId);
       return Response.serverError().build();
     }
   }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -48,4 +48,14 @@ public class TalkResourceTest {
         .statusCode(200)
         .body(containsString("Charla de prueba"));
   }
+
+  @Test
+  public void talkUrlWithSlugIsResolved() {
+    given()
+        .when()
+        .get("/event/" + EVENT_ID + "/talk/" + TALK_ID + "-extra")
+        .then()
+        .statusCode(200)
+        .body(containsString("Charla de prueba"));
+  }
 }


### PR DESCRIPTION
## Summary
- Normalize talk IDs to strip trailing slugs before lookup
- Add dedicated /event/{eventId}/talk/{talkId} endpoint resolving slugs
- Test talk URLs with extra slug segments

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab1a11b88333b495f9f40c00badf