### PR TITLE
fix: resolve talk event context

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -44,7 +44,7 @@ public class EventTalkResource {
     metrics.recordPageView("/event/" + eventId + "/talk", sessionId, ua);
     try {
       String canonicalTalkId = canonicalize(talkId);
-      Talk talk = eventService.findTalk(canonicalTalkId);
+      Talk talk = eventService.findTalk(eventId, canonicalTalkId);
       if (talk == null) {
         LOG.warnf("Talk %s not found", talkId);
         return Response.status(Response.Status.NOT_FOUND).build();

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -153,6 +153,18 @@ public class EventService {
         .orElse(null);
   }
 
+  /** Returns the talk with the given id within the specified event or {@code null} if not found. */
+  public Talk findTalk(String eventId, String talkId) {
+    Event event = events.get(eventId);
+    if (event == null) {
+      return null;
+    }
+    return event.getAgenda().stream()
+        .filter(t -> t.getId().equals(talkId))
+        .findFirst()
+        .orElse(null);
+  }
+
   /** Returns the event that contains the given scenario or {@code null} if none. */
   public Event findEventByScenario(String scenarioId) {
     return events.values().stream()

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventTalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventTalkResourceTest.java
@@ -1,0 +1,55 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class EventTalkResourceTest {
+
+  @Inject EventService eventService;
+
+  @AfterEach
+  public void cleanup() {
+    eventService.deleteEvent("e1");
+    eventService.deleteEvent("e2");
+  }
+
+  @Test
+  public void talkUsesEventSpecificContext() {
+    Event e1 = new Event("e1", "Evento A", "desc");
+    e1.setScenarios(List.of(new Scenario("sc1", "Sala A")));
+    Talk t1 = new Talk("t1", "Charla");
+    t1.setLocation("sc1");
+    t1.setStartTime(LocalTime.of(10, 0));
+    t1.setDurationMinutes(30);
+    e1.getAgenda().add(t1);
+    eventService.saveEvent(e1);
+
+    Event e2 = new Event("e2", "Evento B", "desc");
+    e2.setScenarios(List.of(new Scenario("sc2", "Sala B")));
+    Talk t2 = new Talk("t1", "Charla");
+    t2.setLocation("sc2");
+    t2.setStartTime(LocalTime.of(11, 0));
+    t2.setDurationMinutes(45);
+    e2.getAgenda().add(t2);
+    eventService.saveEvent(e2);
+
+    given()
+        .when()
+        .get("/event/e2/talk/t1")
+        .then()
+        .statusCode(200)
+        .body(containsString("/event/e2/scenario/sc2"));
+  }
+}


### PR DESCRIPTION
## Summary
- ensure talk lookups use the event where it's scheduled
- verify navigating to a talk within an event uses that event's context

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d6c808c0833382c9ce2c0e3d579a