### PR TITLE
fix: resolve talk event context

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -26,6 +26,11 @@ public class EventTalkResource {
   @Inject UsageMetricsService metrics;
 
   private String canonicalize(String rawId) {
+    int talkIdx = rawId.indexOf("-talk-");
+    if (talkIdx >= 0) {
+      int next = rawId.indexOf('-', talkIdx + 6);
+      return next >= 0 ? rawId.substring(0, next) : rawId;
+    }
     int idx = rawId.indexOf('-');
     return idx >= 0 ? rawId.substring(0, idx) : rawId;
   }
@@ -44,7 +49,7 @@ public class EventTalkResource {
     metrics.recordPageView("/event/" + eventId + "/talk", sessionId, ua);
     try {
       String canonicalTalkId = canonicalize(talkId);
-      Talk talk = eventService.findTalk(canonicalTalkId);
+      Talk talk = eventService.findTalk(eventId, canonicalTalkId);
       if (talk == null) {
         LOG.warnf("Talk %s not found", talkId);
         return Response.status(Response.Status.NOT_FOUND).build();

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -40,6 +40,11 @@ public class TalkResource {
   @Inject UsageMetricsService metrics;
 
   private String canonicalize(String rawId) {
+    int talkIdx = rawId.indexOf("-talk-");
+    if (talkIdx >= 0) {
+      int next = rawId.indexOf('-', talkIdx + 6);
+      return next >= 0 ? rawId.substring(0, next) : rawId;
+    }
     int idx = rawId.indexOf('-');
     return idx >= 0 ? rawId.substring(0, idx) : rawId;
   }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -153,6 +153,18 @@ public class EventService {
         .orElse(null);
   }
 
+  /** Returns the talk with the given id within the specified event or {@code null} if not found. */
+  public Talk findTalk(String eventId, String talkId) {
+    Event event = events.get(eventId);
+    if (event == null) {
+      return null;
+    }
+    return event.getAgenda().stream()
+        .filter(t -> t.getId().equals(talkId))
+        .findFirst()
+        .orElse(null);
+  }
+
   /** Returns the event that contains the given scenario or {@code null} if none. */
   public Event findEventByScenario(String scenarioId) {
     return events.values().stream()
@@ -194,7 +206,11 @@ public class EventService {
   public List<Talk> findTalkOccurrences(String talkId) {
     return events.values().stream()
         .flatMap(e -> e.getAgenda().stream().filter(t -> t.getId().equals(talkId)))
-        .sorted(java.util.Comparator.comparingInt(Talk::getDay).thenComparing(Talk::getStartTime))
+        .sorted(
+            java.util.Comparator.comparingInt(Talk::getDay)
+                .thenComparing(
+                    Talk::getStartTime,
+                    java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
         .toList();
   }
 
@@ -203,7 +219,11 @@ public class EventService {
     return events.values().stream()
         .flatMap(e -> e.getAgenda().stream())
         .filter(t -> scenarioId.equals(t.getLocation()))
-        .sorted(java.util.Comparator.comparingInt(Talk::getDay).thenComparing(Talk::getStartTime))
+        .sorted(
+            java.util.Comparator.comparingInt(Talk::getDay)
+                .thenComparing(
+                    Talk::getStartTime,
+                    java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
         .toList();
   }
 

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventTalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventTalkResourceTest.java
@@ -1,0 +1,55 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class EventTalkResourceTest {
+
+  @Inject EventService eventService;
+
+  @AfterEach
+  public void cleanup() {
+    eventService.deleteEvent("e1");
+    eventService.deleteEvent("e2");
+  }
+
+  @Test
+  public void talkUsesEventSpecificContext() {
+    Event e1 = new Event("e1", "Evento A", "desc");
+    e1.setScenarios(List.of(new Scenario("sc1", "Sala A")));
+    Talk t1 = new Talk("s1-talk-1", "Charla");
+    t1.setLocation("sc1");
+    t1.setStartTime(LocalTime.of(10, 0));
+    t1.setDurationMinutes(30);
+    e1.getAgenda().add(t1);
+    eventService.saveEvent(e1);
+
+    Event e2 = new Event("e2", "Evento B", "desc");
+    e2.setScenarios(List.of(new Scenario("sc2", "Sala B")));
+    Talk t2 = new Talk("s1-talk-1", "Charla");
+    t2.setLocation("sc2");
+    t2.setStartTime(LocalTime.of(11, 0));
+    t2.setDurationMinutes(45);
+    e2.getAgenda().add(t2);
+    eventService.saveEvent(e2);
+
+    given()
+        .when()
+        .get("/event/e2/talk/s1-talk-1")
+        .then()
+        .statusCode(200)
+        .body(containsString("/event/e2/scenario/sc2"));
+  }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -21,7 +21,7 @@ public class TalkResourceTest {
   @Inject EventService eventService;
 
   private static final String EVENT_ID = "e1";
-  private static final String TALK_ID = "t1";
+  private static final String TALK_ID = "s1-talk-1";
 
   @BeforeEach
   public void setup() {


### PR DESCRIPTION
## Summary
- retain `-talk-` segments when resolving talk identifiers so URLs map to the correct talks
- ensure event-scoped talk endpoint renders with the event that contains the talk
- exercise talk endpoints with `-talk-` IDs and slugs in tests

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d6c808c0833382c9ce2c0e3d579a