### PR TITLE
Filtrar horarios de charlas por evento

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -55,7 +55,7 @@ public class EventTalkResource {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
       var event = eventService.getEvent(eventId);
-      var occurrences = eventService.findTalkOccurrences(canonicalTalkId);
+      var occurrences = eventService.findTalkOccurrences(eventId, canonicalTalkId);
       metrics.recordTalkView(canonicalTalkId, sessionId, ua);
       if (talk.getLocation() != null) {
         metrics.recordStageVisit(

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -214,6 +214,22 @@ public class EventService {
         .toList();
   }
 
+  /** Returns all instances of a talk within the specified event ordered by day and time. */
+  public List<Talk> findTalkOccurrences(String eventId, String talkId) {
+    Event event = events.get(eventId);
+    if (event == null) {
+      return java.util.List.of();
+    }
+    return event.getAgenda().stream()
+        .filter(t -> t.getId().equals(talkId))
+        .sorted(
+            java.util.Comparator.comparingInt(Talk::getDay)
+                .thenComparing(
+                    Talk::getStartTime,
+                    java.util.Comparator.nullsLast(java.util.Comparator.naturalOrder())))
+        .toList();
+  }
+
   /** Returns the list of talks scheduled in the given scenario ordered by day and time. */
   public List<Talk> findTalksForScenario(String scenarioId) {
     return events.values().stream()


### PR DESCRIPTION
## Resumen
- Añade método en EventService para buscar ocurrencias de una charla dentro de un evento específico
- Usa el nuevo método en EventTalkResource para mostrar solo los horarios correspondientes al evento en contexto

## Testing
- `./dev/pr-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a51d009e40833397b272e4fe1df7b3