### PR TITLE
chore: apply Spotless formatting

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/VertxCacheFixMain.java
@@ -6,13 +6,13 @@ import io.quarkus.runtime.annotations.QuarkusMain;
 /**
  * Custom entry point that tunes Vert.x before Quarkus starts.
  *
- * <p>Some deployment environments mount the filesystem as read only. Vert.x
- * normally extracts classpath resources to a temporary directory, creating a
- * {@code vertx-cache} folder under {@code java.io.tmpdir}. When the filesystem is
- * not writable, this fails and the application cannot start.</p>
+ * <p>Some deployment environments mount the filesystem as read only. Vert.x normally extracts
+ * classpath resources to a temporary directory, creating a {@code vertx-cache} folder under {@code
+ * java.io.tmpdir}. When the filesystem is not writable, this fails and the application cannot
+ * start.
  *
- * <p>This main class disables Vert.x file caching <em>and</em> classpath resolving
- * so Vert.x no longer attempts to create the cache directory.</p>
+ * <p>This main class disables Vert.x file caching <em>and</em> classpath resolving so Vert.x no
+ * longer attempts to create the cache directory.
  */
 @QuarkusMain
 public class VertxCacheFixMain {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -72,8 +72,7 @@ public class EventTalkResource {
           inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
         }
       }
-      return Response.ok(
-              TalkResource.Templates.detail(talk, event, occurrences, inSchedule))
+      return Response.ok(TalkResource.Templates.detail(talk, event, occurrences, inSchedule))
           .build();
     } catch (Exception e) {
       LOG.errorf(e, "Error rendering talk %s", talkId);

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
@@ -48,8 +48,8 @@ public class ScenarioResource {
   }
 
   /**
-   * Nueva ruta: /event/{eventId}/scenario/{id}
-   * Permite mostrar el escenario en el contexto del evento de origen.
+   * Nueva ruta: /event/{eventId}/scenario/{id} Permite mostrar el escenario en el contexto del
+   * evento de origen.
    */
   @GET
   @Path("/event/{eventId}/scenario/{id}")

--- a/quarkus-app/src/test/java/com/scanales/eventflow/TestDataDir.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/TestDataDir.java
@@ -6,22 +6,22 @@ import java.nio.file.Path;
 import java.util.Map;
 
 public class TestDataDir implements QuarkusTestResourceLifecycleManager {
-    private Path tempDir;
+  private Path tempDir;
 
-    @Override
-    public Map<String, String> start() {
-        try {
-            tempDir = Files.createTempDirectory("eventflow-test");
-            String path = tempDir.toString();
-            System.setProperty("eventflow.data.dir", path);
-            return Map.of("eventflow.data.dir", path);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+  @Override
+  public Map<String, String> start() {
+    try {
+      tempDir = Files.createTempDirectory("eventflow-test");
+      String path = tempDir.toString();
+      System.setProperty("eventflow.data.dir", path);
+      return Map.of("eventflow.data.dir", path);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    @Override
-    public void stop() {
-        // no cleanup required
-    }
+  @Override
+  public void stop() {
+    // no cleanup required
+  }
 }


### PR DESCRIPTION
## Summary
- format Java sources with Spotless to resolve build failure

## Testing
- `mvn com.diffplug.spotless:spotless-maven-plugin:2.46.1:check`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68a530af6a6083338dd8c6ce1f05457a