### PR TITLE
feat(qr-feedback): add QR evaluation flow

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/LoginCallbackResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/LoginCallbackResource.java
@@ -1,0 +1,22 @@
+package com.scanales.eventflow.private_;
+
+import io.quarkus.security.Authenticated;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+
+/** Redirects authenticated users back to a requested page after login. */
+@Path("/private/login-callback")
+public class LoginCallbackResource {
+
+  @GET
+  @Authenticated
+  public Response callback(@QueryParam("redirect") String redirect) {
+    if (redirect == null || redirect.isBlank()) {
+      redirect = "/";
+    }
+    return Response.seeOther(URI.create(redirect)).build();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -153,14 +153,18 @@ public class ProfileResource {
   @Produces(MediaType.APPLICATION_JSON)
   public Response updateTalk(@PathParam("id") String id, @Valid UpdateRequest req) {
     String email = getEmail();
-    boolean ok = userSchedule.updateTalk(email, id, req.attended, req.rating, req.motivations);
+    boolean ok =
+        userSchedule.updateTalk(email, id, req.attended, req.rating, req.motivations, req.comment);
     String status = ok ? "updated" : "missing";
     return Response.ok(java.util.Map.of("status", status)).build();
   }
 
   @RegisterForReflection
   public record UpdateRequest(
-      Boolean attended, @Min(1) @Max(5) Integer rating, java.util.Set<String> motivations) {}
+      Boolean attended,
+      @Min(1) @Max(5) Integer rating,
+      java.util.Set<String> motivations,
+      @jakarta.validation.constraints.Size(max = 200) String comment) {}
 
   @POST
   @Path("add/{id}")

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/LoginPage.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/LoginPage.java
@@ -13,13 +13,13 @@ public class LoginPage {
 
   @CheckedTemplate
   static class Templates {
-    static native TemplateInstance login();
+    static native TemplateInstance login(String redirect);
   }
 
   @GET
   @PermitAll
   @Produces(MediaType.TEXT_HTML)
-  public TemplateInstance login() {
-    return Templates.login();
+  public TemplateInstance login(@jakarta.ws.rs.QueryParam("redirect") String redirect) {
+    return Templates.login(redirect);
   }
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -28,7 +28,10 @@ public class TalkResource {
         Talk talk,
         com.scanales.eventflow.model.Event event,
         java.util.List<Talk> occurrences,
-        boolean inSchedule);
+        boolean inSchedule,
+        com.scanales.eventflow.service.UserScheduleService.TalkDetails details,
+        boolean fromQr,
+        boolean canEdit);
   }
 
   @Inject EventService eventService;
@@ -55,6 +58,7 @@ public class TalkResource {
   @Produces(MediaType.TEXT_HTML)
   public Response detail(
       @PathParam("id") String id,
+      @jakarta.ws.rs.QueryParam("qr") String qr,
       @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
     String ua = headers.getHeaderString("User-Agent");
@@ -85,7 +89,16 @@ public class TalkResource {
         LOG.warnf("Talk %s missing data: %s", canonicalId, String.join(", ", missing));
       }
 
+      boolean fromQr = qr != null;
+      if (fromQr && (identity == null || identity.isAnonymous())) {
+        String target = "/talk/" + id + "?qr=1";
+        String enc = java.net.URLEncoder.encode(target, java.nio.charset.StandardCharsets.UTF_8);
+        return Response.seeOther(java.net.URI.create("/login?redirect=" + enc)).build();
+      }
+
       boolean inSchedule = false;
+      UserScheduleService.TalkDetails details = null;
+      boolean canEdit = false;
       if (identity != null && !identity.isAnonymous()) {
         String email = identity.getAttribute("email");
         if (email == null) {
@@ -94,9 +107,21 @@ public class TalkResource {
         }
         if (email != null) {
           inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
+          details = userSchedule.getTalkDetailsForUser(email).get(canonicalId);
+          if (details != null && details.ratedAt != null) {
+            canEdit =
+                details
+                    .ratedAt
+                    .plus(java.time.Duration.ofHours(24))
+                    .isAfter(java.time.Instant.now());
+          } else {
+            canEdit = true;
+          }
         }
       }
-      return Response.ok(Templates.detail(talk, event, occurrences, inSchedule)).build();
+      return Response.ok(
+              Templates.detail(talk, event, occurrences, inSchedule, details, fromQr, canEdit))
+          .build();
     } catch (Exception e) {
       LOG.errorf(e, "Error rendering talk %s", id);
       return Response.serverError().build();

--- a/quarkus-app/src/main/resources/templates/LoginPage/login.html
+++ b/quarkus-app/src/main/resources/templates/LoginPage/login.html
@@ -3,7 +3,11 @@
 {#main}
 <h1>Login</h1>
 <p>
+    {#if redirect}
+    <a href="/private/login-callback?redirect={redirect}"><img alt="Sign in with Google" src="https://developers.google.com/identity/images/btn_google_signin_dark_normal_web.png"></a>
+    {#else}
     <a href="/private/profile"><img alt="Sign in with Google" src="https://developers.google.com/identity/images/btn_google_signin_dark_normal_web.png"></a>
+    {/if}
 </p>
 <p><a href="/">Volver al inicio</a></p>
 {/main}

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -110,6 +110,90 @@
   })();
   </script>
   {/if}
+  {#if fromQr}
+    {#if details}
+      {#if canEdit}
+      <div id="feedback">
+        <h2 class="card-title">Evalúa esta charla</h2>
+        <label for="rating-select">Calificación:</label>
+        <select id="rating-select">
+          <option value="">★</option>
+          <option value="1" {#if details.rating == 1}selected{/if}>1</option>
+          <option value="2" {#if details.rating == 2}selected{/if}>2</option>
+          <option value="3" {#if details.rating == 3}selected{/if}>3</option>
+          <option value="4" {#if details.rating == 4}selected{/if}>4</option>
+          <option value="5" {#if details.rating == 5}selected{/if}>5</option>
+        </select>
+        <label for="comment-box">Comentario (opcional):</label>
+        <textarea id="comment-box" maxlength="200">{details.comment ?: ''}</textarea>
+        <button id="save-feedback" class="btn">Enviar</button>
+      </div>
+      <script>
+      (function(){
+        const talkId = '{talk.id}';
+        if (!{details.attended}) {
+          fetch('/private/profile/update/' + talkId, {
+            method:'POST',
+            headers:{'Content-Type':'application/json','Accept':'application/json'},
+            body: JSON.stringify({ attended: true })
+          });
+        }
+        document.getElementById('save-feedback').addEventListener('click', async () => {
+          const rating = document.getElementById('rating-select').value;
+          const comment = document.getElementById('comment-box').value;
+          if (!rating) {
+            showNotification('info', 'Seleccione una calificación');
+            return;
+          }
+          try {
+            const res = await fetch('/private/profile/update/' + talkId, {
+              method:'POST',
+              headers:{'Content-Type':'application/json','Accept':'application/json'},
+              body: JSON.stringify({ rating: parseInt(rating), comment })
+            });
+            if (res.ok) {
+              showNotification('success', 'Gracias por tu evaluación');
+            } else {
+              showNotification('error', 'No se pudo guardar');
+            }
+          } catch(e){
+            showNotification('error', 'No se pudo guardar');
+          }
+        });
+      })();
+      </script>
+      {#else}
+      <p>Gracias por tu evaluación.</p>
+      {/if}
+    {#else}
+      <p>Aún no has registrado esta charla.</p>
+      <button id="register-eval" class="btn">Registrar charla y evaluar</button>
+      <script>
+      (function(){
+        const btn = document.getElementById('register-eval');
+        btn.addEventListener('click', async () => {
+          btn.disabled = true;
+          try {
+            const res = await fetch('/private/profile/add/{talk.id}', {
+              method:'POST',
+              headers:{'Accept':'application/json','Content-Type':'application/json'},
+              body:'{}'
+            });
+            if (res.ok) {
+              window.location.href = window.location.pathname + '?qr=1';
+            } else {
+              showNotification('error','No se pudo registrar');
+              btn.disabled = false;
+            }
+          } catch(e){
+            showNotification('error','No se pudo registrar');
+            btn.disabled = false;
+          }
+        });
+      })();
+      </script>
+    {/if}
+  {/if}
   {#if !occurrences.isEmpty()}
   <div class="card">
     <h2 class="card-title"><span class="icon">⏰</span>Horarios</h2>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UserScheduleServiceTest.java
@@ -47,12 +47,15 @@ public class UserScheduleServiceTest {
       String user = "user@example.com";
 
       assertTrue(svc.addTalkForUser(user, "t1"));
-      assertTrue(svc.updateTalk(user, "t1", true, 5, Set.of("⭐ Relevante para mi trabajo")));
+      assertTrue(
+          svc.updateTalk(user, "t1", true, 5, Set.of("⭐ Relevante para mi trabajo"), "buena"));
 
       UserScheduleService.TalkDetails details = svc.getTalkDetailsForUser(user).get("t1");
       assertNotNull(details);
       assertTrue(details.attended);
       assertEquals(5, details.rating);
+      assertEquals("buena", details.comment);
+      assertNotNull(details.ratedAt);
       assertTrue(details.motivations.contains("⭐ Relevante para mi trabajo"));
 
       UserScheduleService.Summary summary = svc.getSummaryForUser(user);


### PR DESCRIPTION
## Summary
- add rating comment and timestamp to talk attendance
- redirect unauthenticated QR visitors to login then back to talk
- show evaluation form on talk page with auto attendance mark

## Testing
- `mvn -f quarkus-app/pom.xml spotless:apply`
- `./dev/pr-check.sh`
- `mvn -f quarkus-app/pom.xml test`


------
https://chatgpt.com/codex/tasks/task_e_68a5aee91a1c8333988525563df4ab4a