### PR TITLE
ci: trigger deploy on auto-merge

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -7,6 +7,9 @@ name: Build Native and Deploy
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_run:
+    workflows: ["PR Auto Merge"]
+    types: [completed]
 
 concurrency:
   group: main-deploy
@@ -17,10 +20,15 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
-      github.event.pull_request.merged == true)
+      github.event.pull_request.merged == true) ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0].merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_commit.id || github.sha }}
       - uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
## Summary
- run main deployment workflow when PRs are auto-merged
- checkout merged commit during workflow_run trigger

## Testing
- `mvn -f quarkus-app/pom.xml spotless:apply`
- `./dev/pr-check.sh` *(fails: process did not complete before timeout)*
- `mvn -f quarkus-app/pom.xml test` *(fails: process terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bce58d248333a848d37f35d791c8