### PR TITLE
Auto register talk from QR

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -80,12 +80,15 @@ public class EventTalkResource {
         }
         if (email != null) {
           inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
-          if (fromQr && !inSchedule) {
-            boolean added = userSchedule.addTalkForUser(email, canonicalTalkId);
-            if (added) {
-              metrics.recordTalkRegister(canonicalTalkId, talk.getSpeakers(), ua);
+          if (fromQr) {
+            if (!inSchedule) {
+              boolean added = userSchedule.addTalkForUser(email, canonicalTalkId);
+              if (added) {
+                metrics.recordTalkRegister(canonicalTalkId, talk.getSpeakers(), ua);
+              }
+              inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
             }
-            inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
+            userSchedule.updateTalk(email, canonicalTalkId, true, null, null, null);
           }
           details = userSchedule.getTalkDetailsForUser(email).get(canonicalTalkId);
           if (details != null && details.ratedAt != null) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -107,12 +107,15 @@ public class TalkResource {
         }
         if (email != null) {
           inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
-          if (fromQr && !inSchedule) {
-            boolean added = userSchedule.addTalkForUser(email, canonicalId);
-            if (added) {
-              metrics.recordTalkRegister(canonicalId, talk.getSpeakers(), ua);
+          if (fromQr) {
+            if (!inSchedule) {
+              boolean added = userSchedule.addTalkForUser(email, canonicalId);
+              if (added) {
+                metrics.recordTalkRegister(canonicalId, talk.getSpeakers(), ua);
+              }
+              inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
             }
-            inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
+            userSchedule.updateTalk(email, canonicalId, true, null, null, null);
           }
           details = userSchedule.getTalkDetailsForUser(email).get(canonicalId);
           if (details != null && details.ratedAt != null) {


### PR DESCRIPTION
## Summary
- Auto-add talk to user profile when using QR link and mark attendance
- Test QR flow registers and marks talk as attended

## Testing
- `mvn -Dtest=TalkResourceTest test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fc53f2808333b32dbd4f0d2de255