### PR TITLE
Redirect to profile after QR scan

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -89,6 +89,7 @@ public class EventTalkResource {
               inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
             }
             userSchedule.updateTalk(email, canonicalTalkId, true, null, null, null);
+            return Response.seeOther(java.net.URI.create("/profile")).build();
           }
           details = userSchedule.getTalkDetailsForUser(email).get(canonicalTalkId);
           if (details != null && details.ratedAt != null) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -116,6 +116,7 @@ public class TalkResource {
               inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
             }
             userSchedule.updateTalk(email, canonicalId, true, null, null, null);
+            return Response.seeOther(java.net.URI.create("/profile")).build();
           }
           details = userSchedule.getTalkDetailsForUser(email).get(canonicalId);
           if (details != null && details.ratedAt != null) {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -70,10 +70,31 @@ import org.junit.jupiter.api.Test;
     assertFalse(
         userSchedule.getTalkDetailsForUser("user@example.com").containsKey(TALK_ID));
     given()
+        .redirects()
+        .follow(false)
         .when()
         .get("/talk/" + TALK_ID + "?qr=1")
         .then()
-        .statusCode(200);
+        .statusCode(303)
+        .header("Location", containsString("/profile"));
+    var details = userSchedule.getTalkDetailsForUser("user@example.com").get(TALK_ID);
+    assertNotNull(details);
+    assertTrue(details.attended);
+  }
+
+  @Test
+  @TestSecurity(user = "user@example.com")
+  public void qrAddsTalkAndMarksAttendedFromEvent() {
+    assertFalse(
+        userSchedule.getTalkDetailsForUser("user@example.com").containsKey(TALK_ID));
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/event/" + EVENT_ID + "/talk/" + TALK_ID + "?qr=1")
+        .then()
+        .statusCode(303)
+        .header("Location", containsString("/profile"));
     var details = userSchedule.getTalkDetailsForUser("user@example.com").get(TALK_ID);
     assertNotNull(details);
     assertTrue(details.attended);


### PR DESCRIPTION
## Summary
- Redirect QR talk requests to profile page
- Auto-register scanned talks as attended
- Test QR flow for talk and event URLs

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68a607db06908333894ca5645cf11dc0