### PR TITLE
fix: propagate speaker updates to event talks

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -174,6 +174,13 @@ public class SpeakerService {
       return;
     }
     for (Talk talk : sp.getTalks()) {
+      if (talk.getSpeakers() != null && !talk.getSpeakers().isEmpty()) {
+        List<Speaker> updatedSpeakers =
+            talk.getSpeakers().stream()
+                .map(s -> speakers.getOrDefault(s.getId(), s))
+                .collect(Collectors.toList());
+        talk.setSpeakers(updatedSpeakers);
+      }
       for (Talk evTalk : eventService.findTalkOccurrences(talk.getId())) {
         evTalk.setName(talk.getName());
         evTalk.setDescription(talk.getDescription());


### PR DESCRIPTION
## Summary
- ensure speaker updates refresh associated talks with canonical data

## Testing
- `mvn -q -f quarkus-app/pom.xml spotless:apply`
- `mvn -q -f quarkus-app/pom.xml enforcer:enforce`
- `./dev/deps-check.sh`
- `./dev/pr-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a63f1b8428833395dc9683f2bb6d42