### PR TITLE
Fix QR talk links to auto-register after login

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -63,8 +63,18 @@ public class EventTalkResource {
             talk.getLocation(), event != null ? event.getTimezone() : null, sessionId, ua);
       }
       boolean fromQr = qr != null;
+      if (context.session() != null) {
+        String pending = context.session().get("qr-talk");
+        if (canonicalTalkId.equals(pending)) {
+          fromQr = true;
+          context.session().remove("qr-talk");
+        }
+      }
       if (fromQr && (identity == null || identity.isAnonymous())) {
-        String target = "/event/" + eventId + "/talk/" + talkId + "?qr=1";
+        if (context.session() != null) {
+          context.session().put("qr-talk", canonicalTalkId);
+        }
+        String target = "/event/" + eventId + "/talk/" + talkId;
         String enc = java.net.URLEncoder.encode(target, java.nio.charset.StandardCharsets.UTF_8);
         return Response.seeOther(java.net.URI.create("/login?redirect=" + enc)).build();
       }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -90,8 +90,18 @@ public class TalkResource {
       }
 
       boolean fromQr = qr != null;
+      if (context.session() != null) {
+        String pending = context.session().get("qr-talk");
+        if (canonicalId.equals(pending)) {
+          fromQr = true;
+          context.session().remove("qr-talk");
+        }
+      }
       if (fromQr && (identity == null || identity.isAnonymous())) {
-        String target = "/talk/" + id + "?qr=1";
+        if (context.session() != null) {
+          context.session().put("qr-talk", canonicalId);
+        }
+        String target = "/talk/" + id;
         String enc = java.net.URLEncoder.encode(target, java.nio.charset.StandardCharsets.UTF_8);
         return Response.seeOther(java.net.URI.create("/login?redirect=" + enc)).build();
       }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.public_;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.scanales.eventflow.model.Event;
@@ -62,6 +63,19 @@ import org.junit.jupiter.api.Test;
         .then()
         .statusCode(200)
         .body(containsString("Charla de prueba"));
+  }
+
+  @Test
+  public void qrRedirectsAnonymousToLogin() {
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/talk/" + TALK_ID + "?qr=1")
+        .then()
+        .statusCode(303)
+        .header("Location", containsString("/login?redirect="))
+        .header("Location", not(containsString("qr=1")));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Preserve QR scan intent in session to auto-register and mark talks as attended after login
- Redirect authenticated users to profile without relying on `qr` parameter
- Add regression test for anonymous QR link login redirect

## Testing
- `./quarkus-app/mvnw -q -f quarkus-app/pom.xml test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fb1514d083339445225977e25585