### PR TITLE
Redirect QR scans to private profile

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -99,7 +99,7 @@ public class EventTalkResource {
               inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
             }
             userSchedule.updateTalk(email, canonicalTalkId, true, null, null, null);
-            return Response.seeOther(java.net.URI.create("/profile")).build();
+            return Response.seeOther(java.net.URI.create("/private/profile")).build();
           }
           details = userSchedule.getTalkDetailsForUser(email).get(canonicalTalkId);
           if (details != null && details.ratedAt != null) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/TalkResource.java
@@ -126,7 +126,7 @@ public class TalkResource {
               inSchedule = userSchedule.getTalksForUser(email).contains(canonicalId);
             }
             userSchedule.updateTalk(email, canonicalId, true, null, null, null);
-            return Response.seeOther(java.net.URI.create("/profile")).build();
+            return Response.seeOther(java.net.URI.create("/private/profile")).build();
           }
           details = userSchedule.getTalkDetailsForUser(email).get(canonicalId);
           if (details != null && details.ratedAt != null) {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -90,7 +90,7 @@ import org.junit.jupiter.api.Test;
         .get("/talk/" + TALK_ID + "?qr=1")
         .then()
         .statusCode(303)
-        .header("Location", containsString("/profile"));
+        .header("Location", containsString("/private/profile"));
     var details = userSchedule.getTalkDetailsForUser("user@example.com").get(TALK_ID);
     assertNotNull(details);
     assertTrue(details.attended);
@@ -108,7 +108,7 @@ import org.junit.jupiter.api.Test;
         .get("/event/" + EVENT_ID + "/talk/" + TALK_ID + "?qr=1")
         .then()
         .statusCode(303)
-        .header("Location", containsString("/profile"));
+        .header("Location", containsString("/private/profile"));
     var details = userSchedule.getTalkDetailsForUser("user@example.com").get(TALK_ID);
     assertNotNull(details);
     assertTrue(details.attended);


### PR DESCRIPTION
## Summary
- Redirect QR-based talk views to `/private/profile` after adding and marking a talk as attended
- Update tests to expect the new profile route

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae34fdf08333af76e73e50d447cd