### PR TITLE
feat: register talks without qr parameter

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -133,7 +133,10 @@ public class ProfileResource {
   @GET
   @Path("add/{id}")
   @Authenticated
-  public Response addTalkRedirect(@PathParam("id") String id, @Context HttpHeaders headers) {
+  public Response addTalkRedirect(
+      @PathParam("id") String id,
+      @Context HttpHeaders headers,
+      @jakarta.ws.rs.QueryParam("visited") boolean visited) {
     String email = getEmail();
     boolean added = userSchedule.addTalkForUser(email, id);
     if (added) {
@@ -142,6 +145,10 @@ public class ProfileResource {
           id,
           talk != null ? talk.getSpeakers() : java.util.List.of(),
           headers.getHeaderString("User-Agent"));
+    }
+    if (visited) {
+      userSchedule.updateTalk(email, id, true, null, null, null);
+      return Response.seeOther(java.net.URI.create("/private/profile")).build();
     }
     return Response.status(Response.Status.SEE_OTHER).header("Location", "/talk/" + id).build();
   }

--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -110,63 +110,6 @@
   })();
   </script>
   {/if}
-  {#if fromQr}
-    {#if details}
-      {#if canEdit}
-      <div id="feedback">
-        <h2 class="card-title">Evalúa esta charla</h2>
-        <label for="rating-select">Calificación:</label>
-        <select id="rating-select">
-          <option value="">★</option>
-          <option value="1" {#if details.rating == 1}selected{/if}>1</option>
-          <option value="2" {#if details.rating == 2}selected{/if}>2</option>
-          <option value="3" {#if details.rating == 3}selected{/if}>3</option>
-          <option value="4" {#if details.rating == 4}selected{/if}>4</option>
-          <option value="5" {#if details.rating == 5}selected{/if}>5</option>
-        </select>
-        <label for="comment-box">Comentario (opcional):</label>
-        <textarea id="comment-box" maxlength="200">{details.comment ?: ''}</textarea>
-        <button id="save-feedback" class="btn">Enviar</button>
-      </div>
-      <script>
-      (function(){
-        const talkId = '{talk.id}';
-        if (!{details.attended}) {
-          fetch('/private/profile/update/' + talkId, {
-            method:'POST',
-            headers:{'Content-Type':'application/json','Accept':'application/json'},
-            body: JSON.stringify({ attended: true })
-          });
-        }
-        document.getElementById('save-feedback').addEventListener('click', async () => {
-          const rating = document.getElementById('rating-select').value;
-          const comment = document.getElementById('comment-box').value;
-          if (!rating) {
-            showNotification('info', 'Seleccione una calificación');
-            return;
-          }
-          try {
-            const res = await fetch('/private/profile/update/' + talkId, {
-              method:'POST',
-              headers:{'Content-Type':'application/json','Accept':'application/json'},
-              body: JSON.stringify({ rating: parseInt(rating), comment })
-            });
-            if (res.ok) {
-              showNotification('success', 'Gracias por tu evaluación');
-            } else {
-              showNotification('error', 'No se pudo guardar');
-            }
-          } catch(e){
-            showNotification('error', 'No se pudo guardar');
-          }
-        });
-      })();
-      </script>
-      {#else}
-      <p>Gracias por tu evaluación.</p>
-      {/if}
-    {/if}
-  {/if}
   {#if !occurrences.isEmpty()}
   <div class="card">
     <h2 class="card-title"><span class="icon">⏰</span>Horarios</h2>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -2,13 +2,18 @@ package com.scanales.eventflow.private_;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import com.scanales.eventflow.service.UserScheduleService;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 public class ProfileResourceTest {
+
+  @Inject UserScheduleService userSchedule;
 
   @Test
   @TestSecurity(user = "user@example.com")
@@ -114,5 +119,22 @@ public class ProfileResourceTest {
         .post("/private/profile/update/t6")
         .then()
         .statusCode(400);
+  }
+
+  @Test
+  @TestSecurity(user = "user@example.com")
+  public void visitedParamAddsTalkAndMarksAttended() {
+    assertFalse(userSchedule.getTalkDetailsForUser("user@example.com").containsKey("t7"));
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/private/profile/add/t7?visited=true")
+        .then()
+        .statusCode(303)
+        .header("Location", endsWith("/private/profile"));
+    var details = userSchedule.getTalkDetailsForUser("user@example.com").get("t7");
+    assertNotNull(details);
+    assertTrue(details.attended);
   }
 }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -2,16 +2,12 @@ package com.scanales.eventflow.public_;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Speaker;
 import com.scanales.eventflow.model.Talk;
 import com.scanales.eventflow.service.EventService;
-import com.scanales.eventflow.service.UserScheduleService;
 import io.quarkus.test.junit.QuarkusTest;
-import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
 import java.time.LocalTime;
 import java.util.List;
@@ -23,7 +19,6 @@ import org.junit.jupiter.api.Test;
   public class TalkResourceTest {
 
   @Inject EventService eventService;
-  @Inject UserScheduleService userSchedule;
 
   private static final String EVENT_ID = "e1";
   private static final String TALK_ID = "s1-talk-1";
@@ -42,7 +37,6 @@ import org.junit.jupiter.api.Test;
   @AfterEach
   public void cleanup() {
     eventService.deleteEvent(EVENT_ID);
-    userSchedule.removeTalkForUser("user@example.com", TALK_ID);
   }
 
   @Test
@@ -65,52 +59,4 @@ import org.junit.jupiter.api.Test;
         .body(containsString("Charla de prueba"));
   }
 
-  @Test
-  public void qrRedirectsAnonymousToLogin() {
-    given()
-        .redirects()
-        .follow(false)
-        .when()
-        .get("/talk/" + TALK_ID + "?qr=1")
-        .then()
-        .statusCode(303)
-        .header("Location", containsString("/login?redirect="))
-        .header("Location", not(containsString("qr=1")));
-  }
-
-  @Test
-  @TestSecurity(user = "user@example.com")
-  public void qrAddsTalkAndMarksAttended() {
-    assertFalse(
-        userSchedule.getTalkDetailsForUser("user@example.com").containsKey(TALK_ID));
-    given()
-        .redirects()
-        .follow(false)
-        .when()
-        .get("/talk/" + TALK_ID + "?qr=1")
-        .then()
-        .statusCode(303)
-        .header("Location", containsString("/private/profile"));
-    var details = userSchedule.getTalkDetailsForUser("user@example.com").get(TALK_ID);
-    assertNotNull(details);
-    assertTrue(details.attended);
-  }
-
-  @Test
-  @TestSecurity(user = "user@example.com")
-  public void qrAddsTalkAndMarksAttendedFromEvent() {
-    assertFalse(
-        userSchedule.getTalkDetailsForUser("user@example.com").containsKey(TALK_ID));
-    given()
-        .redirects()
-        .follow(false)
-        .when()
-        .get("/event/" + EVENT_ID + "/talk/" + TALK_ID + "?qr=1")
-        .then()
-        .statusCode(303)
-        .header("Location", containsString("/private/profile"));
-    var details = userSchedule.getTalkDetailsForUser("user@example.com").get(TALK_ID);
-    assertNotNull(details);
-    assertTrue(details.attended);
-  }
 }


### PR DESCRIPTION
## Summary
- add `visited` flag to `/private/profile/add/{id}` to mark attendance and redirect to profile
- remove QR parameter logic from public talk endpoints
- update tests for new flow

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68a7bce7c4f08333949c7f8e3a1649f2