### PR TITLE
feat: allow attended param to stay on profile

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -136,7 +136,8 @@ public class ProfileResource {
   public Response addTalkRedirect(
       @PathParam("id") String id,
       @Context HttpHeaders headers,
-      @jakarta.ws.rs.QueryParam("visited") boolean visited) {
+      @jakarta.ws.rs.QueryParam("visited") boolean visited,
+      @jakarta.ws.rs.QueryParam("attended") boolean attended) {
     String email = getEmail();
     boolean added = userSchedule.addTalkForUser(email, id);
     if (added) {
@@ -146,7 +147,7 @@ public class ProfileResource {
           talk != null ? talk.getSpeakers() : java.util.List.of(),
           headers.getHeaderString("User-Agent"));
     }
-    if (visited) {
+    if (visited || attended) {
       userSchedule.updateTalk(email, id, true, null, null, null);
       return Response.seeOther(java.net.URI.create("/private/profile")).build();
     }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -137,4 +137,21 @@ public class ProfileResourceTest {
     assertNotNull(details);
     assertTrue(details.attended);
   }
+
+  @Test
+  @TestSecurity(user = "user@example.com")
+  public void attendedParamAddsTalkAndMarksAttended() {
+    assertFalse(userSchedule.getTalkDetailsForUser("user@example.com").containsKey("t8"));
+    given()
+        .redirects()
+        .follow(false)
+        .when()
+        .get("/private/profile/add/t8?attended=true")
+        .then()
+        .statusCode(303)
+        .header("Location", endsWith("/private/profile"));
+    var details = userSchedule.getTalkDetailsForUser("user@example.com").get("t8");
+    assertNotNull(details);
+    assertTrue(details.attended);
+  }
 }


### PR DESCRIPTION
## Summary
- redirect to profile when adding a talk with `attended=true`
- test attended param add flow

## Testing
- `mvn -f quarkus-app/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_68a7d6dd9d488333a46c4bb0358e03c9