### PR TITLE
feat: manage global listeners lifecycle

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -167,7 +167,7 @@ function restoreScroll() {
     sessionStorage.removeItem('scrollPos');
 }
 
-window.addEventListener('DOMContentLoaded', () => {
+function onDomContentLoaded() {
     setupMenu();
     setupUserMenu();
     setupAgendaToggle();
@@ -182,7 +182,60 @@ window.addEventListener('DOMContentLoaded', () => {
         hideLoading();
         showNotification('info', 'No hay eventos disponibles');
     }
-});
-window.addEventListener('resize', adjustLayout);
-window.addEventListener('scroll', bannerParallax);
-window.addEventListener('beforeunload', () => showLoading('la página', false));
+}
+
+let domContentLoadedHandler;
+let resizeHandler;
+let scrollHandler;
+let beforeUnloadHandler;
+let unloadHandler;
+
+function initListeners() {
+    domContentLoadedHandler = onDomContentLoaded;
+    window.addEventListener('DOMContentLoaded', domContentLoadedHandler);
+
+    resizeHandler = adjustLayout;
+    window.addEventListener('resize', resizeHandler);
+
+    scrollHandler = bannerParallax;
+    window.addEventListener('scroll', scrollHandler);
+
+    beforeUnloadHandler = () => showLoading('la página', false);
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+
+    unloadHandler = () => removeListeners();
+    window.addEventListener('unload', unloadHandler);
+}
+
+function removeListeners() {
+    if (domContentLoadedHandler) {
+        window.removeEventListener('DOMContentLoaded', domContentLoadedHandler);
+        domContentLoadedHandler = null;
+    }
+    if (resizeHandler) {
+        window.removeEventListener('resize', resizeHandler);
+        resizeHandler = null;
+    }
+    if (scrollHandler) {
+        window.removeEventListener('scroll', scrollHandler);
+        scrollHandler = null;
+    }
+    if (beforeUnloadHandler) {
+        window.removeEventListener('beforeunload', beforeUnloadHandler);
+        beforeUnloadHandler = null;
+    }
+    if (unloadHandler) {
+        window.removeEventListener('unload', unloadHandler);
+        unloadHandler = null;
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.initListeners = initListeners;
+    window.removeListeners = removeListeners;
+    initListeners();
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initListeners, removeListeners };
+}


### PR DESCRIPTION
## Summary
- encapsulate global event listeners in `initListeners` and `removeListeners`
- export listener lifecycle helpers for SPA use without syntax errors

## Testing
- `cd quarkus-app && ./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c07a681c8333ada6c6f04c804e35