### PR TITLE
Fix escaping of pipe character in enforce_severity

### DIFF
--- a/scripts/enforce_severity.py
+++ b/scripts/enforce_severity.py
@@ -70,7 +70,7 @@ if summary_path:
             order = {"High": 0, "Medium": 1, "Low": 2}
             for r in sorted(new_results, key=lambda x: order[x["severity"]])[:3]:
                 loc = f"{r['file']}:{r['line']}" if r.get("file") else ""
-                msg = r.get("message", "").replace("|", "\|")
+                msg = r.get("message", "").replace("|", r"\|")
                 f.write(
                     f"| {r['severity']} | {r.get('ruleId','')} | {loc} | {msg} |\n"
                 )


### PR DESCRIPTION
## Summary
- escape pipe character correctly in markdown table generation

## Testing
- `python -m pyflakes scripts/enforce_severity.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f3794f8c8333b42a8ae3fb1d5596