### PR TITLE
fix: remove redundant talk link

### DIFF
--- a/quarkus-app/src/main/resources/templates/TalkResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/TalkResource/detail.html
@@ -126,10 +126,6 @@
           {#else}
             <span>Ubicación por confirmar</span>
           {/if}
-          {#if event && t.id}
-            <span class="sep">|</span>
-            <a href="/event/{event.id}/talk/{t.id}" class="btn btn-link">Ver charla</a>
-          {/if}
         </li>
     {/for}
     </ul>


### PR DESCRIPTION
## Summary
- remove self-referential "Ver charla" link from talk page

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_68a8e95bef548333accd541748ca2e8f