### PR TITLE
Add event-aware scenario page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventScenarioResource.java
@@ -1,0 +1,46 @@
+package com.scanales.eventflow.public_;
+
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.UsageMetricsService;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.PermitAll;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/event")
+public class EventScenarioResource {
+
+  @Inject EventService eventService;
+  @Inject UsageMetricsService metrics;
+
+  @GET
+  @Path("{eventId}/scenario/{id}")
+  @PermitAll
+  @Produces(MediaType.TEXT_HTML)
+  public TemplateInstance detailWithEvent(
+      @PathParam("eventId") String eventId,
+      @PathParam("id") String id,
+      @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
+      @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
+    metrics.recordPageView("/event/" + eventId + "/scenario", headers, context);
+    var event = eventService.getEvent(eventId);
+    if (event == null) {
+      return ScenarioResource.Templates.detail(null, null, java.util.List.of());
+    }
+    var scenario =
+        event.getScenarios().stream().filter(s -> s.getId().equals(id)).findFirst().orElse(null);
+    var talks =
+        event.getAgenda().stream()
+            .filter(t -> id.equals(t.getLocation()))
+            .sorted(
+                java.util.Comparator.comparingInt(com.scanales.eventflow.model.Talk::getDay)
+                    .thenComparing(com.scanales.eventflow.model.Talk::getStartTime))
+            .toList();
+    metrics.recordStageVisit(id, event.getTimezone(), headers, context);
+    return ScenarioResource.Templates.detail(scenario, event, talks);
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/ScenarioResource.java
@@ -46,35 +46,4 @@ public class ScenarioResource {
     metrics.recordStageVisit(id, event != null ? event.getTimezone() : null, headers, context);
     return Templates.detail(s, event, talks);
   }
-
-  /**
-   * Nueva ruta: /event/{eventId}/scenario/{id} Permite mostrar el escenario en el contexto del
-   * evento de origen.
-   */
-  @GET
-  @Path("/event/{eventId}/scenario/{id}")
-  @PermitAll
-  @Produces(MediaType.TEXT_HTML)
-  public TemplateInstance detailWithEvent(
-      @PathParam("eventId") String eventId,
-      @PathParam("id") String id,
-      @jakarta.ws.rs.core.Context jakarta.ws.rs.core.HttpHeaders headers,
-      @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
-    metrics.recordPageView("/event/" + eventId + "/scenario", headers, context);
-    var event = eventService.getEvent(eventId);
-    if (event == null) {
-      return Templates.detail(null, null, java.util.List.of());
-    }
-    var scenario =
-        event.getScenarios().stream().filter(s -> s.getId().equals(id)).findFirst().orElse(null);
-    var talks =
-        event.getAgenda().stream()
-            .filter(t -> id.equals(t.getLocation()))
-            .sorted(
-                java.util.Comparator.comparingInt(com.scanales.eventflow.model.Talk::getDay)
-                    .thenComparing(com.scanales.eventflow.model.Talk::getStartTime))
-            .toList();
-    metrics.recordStageVisit(id, event.getTimezone(), headers, context);
-    return Templates.detail(scenario, event, talks);
-  }
 }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventScenarioResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/EventScenarioResourceTest.java
@@ -1,0 +1,45 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Scenario;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class EventScenarioResourceTest {
+
+  @Inject EventService eventService;
+
+  @AfterEach
+  public void cleanup() {
+    eventService.deleteEvent("e1");
+  }
+
+  @Test
+  public void scenarioUsesEventSpecificContext() {
+    Event e1 = new Event("e1", "Evento A", "desc");
+    e1.setScenarios(List.of(new Scenario("sc1", "Sala A")));
+    Talk t1 = new Talk("t1", "Charla");
+    t1.setLocation("sc1");
+    t1.setStartTime(LocalTime.of(10, 0));
+    t1.setDurationMinutes(30);
+    e1.getAgenda().add(t1);
+    eventService.saveEvent(e1);
+
+    given()
+        .when()
+        .get("/event/e1/scenario/sc1")
+        .then()
+        .statusCode(200)
+        .body(containsString("Sala A"));
+  }
+}


### PR DESCRIPTION
## Summary
- expose `/event/{eventId}/scenario/{id}` to show stage talks within an event
- cover event-aware scenario page with test

## Testing
- `mvn -f quarkus-app/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_68ad0ef903d88333a600d47ae23faa4f