### PR TITLE
feat(ui): add mobile foundations (tokens, fluid type, container)

### DIFF
--- a/docs/ui/mobile-upgrade.md
+++ b/docs/ui/mobile-upgrade.md
@@ -1,0 +1,5 @@
+# Mobile upgrade
+
+## Fundaciones
+
+Se añadieron variables de diseño (espaciados, colores, radios y sombras), una escala tipográfica fluida para móvil, un contenedor responsivo con `padding-inline` seguro y reglas globales que evitan desbordes horizontales.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/EventTalkResource.java
@@ -72,8 +72,7 @@ public class EventTalkResource {
           inSchedule = userSchedule.getTalksForUser(email).contains(canonicalTalkId);
         }
       }
-      return Response.ok(
-              TalkResource.Templates.detail(talk, event, occurrences, inSchedule))
+      return Response.ok(TalkResource.Templates.detail(talk, event, occurrences, inSchedule))
           .build();
     } catch (Exception e) {
       LOG.errorf(e, "Error rendering talk %s", talkId);

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1,16 +1,57 @@
-/* Color palette */
+/* Design tokens */
 :root {
+    /* Colors */
     --color-bg: #f9f9f9;
     --color-primary: #2196f3;
     --color-accent: #26c6da;
     --color-dark: #0d47a1;
     --color-text: #333;
     --color-light: #fff;
+
+    /* Spacing */
+    --space-xs: 0.25rem;
+    --space-sm: 0.5rem;
+    --space-md: 1rem;
+    --space-lg: 1.5rem;
+    --space-xl: 2rem;
+
+    /* Radius */
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+
+    /* Shadows */
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.1);
+    --shadow-md: 0 2px 4px rgba(0, 0, 0, 0.1);
+    --shadow-lg: 0 4px 8px rgba(0, 0, 0, 0.1);
+
+    /* Typography */
+    --font-size-base: clamp(1rem, 0.875rem + 0.5vw, 1.125rem);
+    --font-size-h1: clamp(1.75rem, 1.5rem + 1.5vw, 2.5rem);
+    --font-size-h2: clamp(1.5rem, 1.25rem + 1vw, 2rem);
+    --line-height-base: 1.5;
+    --line-height-heading: 1.2;
+
+    /* Layout */
+    --container-max: 64rem;
     --avatar-size: 80px;
 }
 
 html {
     scroll-behavior: smooth;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    overflow-wrap: anywhere;
+}
+
+html,
+body {
+    max-width: 100%;
+    overflow-x: hidden;
 }
 
 body {
@@ -20,6 +61,25 @@ body {
     margin: 0;
     opacity: 0;
     transition: opacity 0.3s ease;
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-base);
+}
+
+h1 {
+    font-size: var(--font-size-h1);
+    line-height: var(--line-height-heading);
+}
+
+h2 {
+    font-size: var(--font-size-h2);
+    line-height: var(--line-height-heading);
+}
+
+.container {
+    width: 100%;
+    max-width: var(--container-max);
+    margin-inline: auto;
+    padding-inline: var(--space-md);
 }
 
 body.loaded {

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -4,10 +4,10 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.scanales.eventflow.service.UserScheduleService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
-import com.scanales.eventflow.service.UserScheduleService;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/TalkResourceTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-  public class TalkResourceTest {
+public class TalkResourceTest {
 
   @Inject EventService eventService;
 
@@ -58,5 +58,4 @@ import org.junit.jupiter.api.Test;
         .statusCode(200)
         .body(containsString("Charla de prueba"));
   }
-
 }


### PR DESCRIPTION
## Summary
- add design tokens for spacing, radius, shadows and colors
- implement fluid typography, responsive container and overflow safeguards
- document mobile foundations

## Testing
- `mvn -q spotless:check`
- `mvn -B -ntp -DskipITs=false verify`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ebee6bc8333ba43170debb28e74