### PR TITLE
fix(ui): preserve avatar ratio and compact list rows on mobile

### DIFF
--- a/docs/ui/mobile-upgrade.md
+++ b/docs/ui/mobile-upgrade.md
@@ -3,3 +3,9 @@
 ## Fundaciones
 
 Se añadieron variables de diseño (espaciados, colores, radios y sombras), una escala tipográfica fluida para móvil, un contenedor responsivo con `padding-inline` seguro y reglas globales que evitan desbordes horizontales.
+
+## Listas
+
+Comparaciones antes y después para las filas de listas en múltiples tamaños de pantalla.
+
+> Las capturas se omiten porque el repositorio no admite archivos binarios.

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -212,9 +212,13 @@ button:focus-visible {
 }
 
 .avatar {
-    width: 32px;
-    height: 32px;
+    width: 48px;
+    height: 48px;
+    aspect-ratio: 1;
+    object-fit: cover;
+    object-position: center;
     border-radius: 50%;
+    display: inline-block;
 }
 
 .avatar.placeholder {
@@ -228,7 +232,7 @@ button:focus-visible {
 
 .speaker-avatars {
     display: inline-flex;
-    gap: 0.25rem;
+    gap: var(--space-xs);
     vertical-align: middle;
 }
 
@@ -1162,15 +1166,65 @@ footer {
     .talk-card .rating-select { width: auto; }
 }
 /* Compact talk row for agenda view */
-.talk-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem 0.5rem; border-bottom: 1px solid #ddd; }
-.talk-row .talk-time { width: 80px; flex-shrink: 0; font-size: 0.9rem; }
-.talk-row .talk-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.talk-row .talk-actions { display: flex; align-items: center; gap: 0.25rem; margin-left: auto; }
-.talk-row .motivation-list { display: flex; flex-wrap: wrap; gap: 0.25rem; }
-.talk-row .motivation-badge { background: #e0e0e0; color: #333; cursor: pointer; }
-.talk-row .motivation-select { width: auto; }
-.talk-row .rating-select { width: auto; }
-.talk-row .attendance-icon { margin-right: 0.25rem; }
+.talk-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    border-bottom: 1px solid #ddd;
+}
+.talk-row .talk-time {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-size: 0.9rem;
+}
+.talk-row .talk-info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    min-width: 0;
+}
+.talk-row .talk-title {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+.talk-row .talk-title a {
+    color: inherit;
+    text-decoration: none;
+}
+.talk-row .talk-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+}
+.talk-row .talk-actions > * {
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.talk-row .motivation-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+}
+.talk-row .motivation-badge {
+    background: #e0e0e0;
+    color: #333;
+    cursor: pointer;
+}
+.talk-row .motivation-select,
+.talk-row .rating-select {
+    width: auto;
+}
+.talk-row .attendance-icon {
+    margin-right: 0.25rem;
+}
 @media (min-width: 600px) {
     .talk-row .motivation-select,
     .talk-row .rating-select { width: auto; }

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -23,21 +23,25 @@
       <div class="talks-day">
         {#for t in d.talks}
         <div class="talk-row" data-talk-id="{t.id}" data-attended="{info.get(t.id).attended}" data-rated="{info.get(t.id).rating??}">
-          <span class="attendance-icon">{#if info.get(t.id).attended}✅{#else}❌{/if}</span>
-          <span class="talk-time">{t.startTimeStr} - {t.endTimeStr}</span>
-          <span class="talk-title"><a href="/event/{g.event.id}/talk/{t.id}">{t.name}</a></span>
-          <div class="speaker-avatars">
-            {#for s in t.speakers}
-              <a href="/speaker/{s.id}" title="{s.name}">
-                {#if app:validUrl(s.photoUrl)}
-                  <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
-                {#else}
-                  <span class="avatar placeholder">👤</span>
-                {/if}
-              </a>
-            {/for}
+          <div class="talk-time">
+            <span class="attendance-icon">{#if info.get(t.id).attended}✅{#else}❌{/if}</span>
+            <span>{t.startTimeStr} - {t.endTimeStr}</span>
           </div>
-          <span class="badge talk-state {app:talkStateClass(t, g.event)}">{app:talkState(t, g.event)}</span>
+          <div class="talk-info">
+            <span class="talk-title"><a href="/event/{g.event.id}/talk/{t.id}">{t.name}</a></span>
+            <div class="speaker-avatars">
+              {#for s in t.speakers}
+                <a href="/speaker/{s.id}" title="{s.name}">
+                  {#if app:validUrl(s.photoUrl)}
+                    <img src="{s.photoUrl}" alt="{s.name}" class="avatar">
+                  {#else}
+                    <span class="avatar placeholder">👤</span>
+                  {/if}
+                </a>
+              {/for}
+            </div>
+            <span class="badge talk-state {app:talkStateClass(t, g.event)}">{app:talkState(t, g.event)}</span>
+          </div>
           <div class="talk-actions">
             <div class="motivation-list">
               {#for m in info.get(t.id).motivations}


### PR DESCRIPTION
## Summary
- ensure square avatars with consistent sizing
- use grid-based layout for compact talk rows on mobile
- document mobile list updates without binary screenshots

## Testing
- `mvn -f quarkus-app/pom.xml spotless:apply --no-transfer-progress`
- `mvn -f quarkus-app/pom.xml test --no-transfer-progress`


------
https://chatgpt.com/codex/tasks/task_e_68ad921db524833397a8eea44bba6edf