### PR TITLE
fix: improve release tag scripts

### DIFF
--- a/scripts/tag-release.ps1
+++ b/scripts/tag-release.ps1
@@ -1,0 +1,31 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+$pomFile = Join-Path $repoRoot 'quarkus-app/pom.xml'
+$readmeFile = Join-Path $repoRoot 'README.md'
+
+[xml]$pom = Get-Content $pomFile
+$version = $pom.project.version
+if ([string]::IsNullOrWhiteSpace($version)) {
+    Write-Error "Could not determine version from $pomFile"
+    exit 1
+}
+
+$description = Get-Content $readmeFile | Where-Object { $_ -notmatch '^(#|\[|\s*$)' } | Select-Object -First 1
+if ([string]::IsNullOrWhiteSpace($description)) {
+    Write-Error "Could not determine description from $readmeFile"
+    exit 1
+}
+
+$tag = $version
+
+# Check if the tag already exists
+git rev-parse --verify --quiet "refs/tags/$tag" > $null 2>&1
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Tag $tag already exists"
+    exit 0
+}
+
+git tag -a $tag -m $description
+git push origin $tag

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+POM_FILE="$REPO_ROOT/quarkus-app/pom.xml"
+README_FILE="$REPO_ROOT/README.md"
+
+# Extract version from pom.xml
+VERSION=$(grep -m1 '<version>' "$POM_FILE" | sed -E 's/.*<version>([^<]+)<\/version>.*/\1/')
+if [[ -z "$VERSION" ]]; then
+  echo "Could not determine version from $POM_FILE" >&2
+  exit 1
+fi
+
+# Extract description from README.md
+DESCRIPTION=$(grep -m1 -vE '^(#|\[|$)' "$README_FILE" | sed -E 's/^\s+//;s/\s+$//')
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "Could not determine description from $README_FILE" >&2
+  exit 1
+fi
+
+TAG="$VERSION"
+
+# Check if the tag already exists
+if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null 2>&1; then
+  echo "Tag $TAG already exists"
+  exit 0
+fi
+
+git tag -a "$TAG" -m "$DESCRIPTION"
+git push origin "$TAG"


### PR DESCRIPTION
## Summary
- avoid git errors by checking for existing tags with `git rev-parse --verify --quiet`
- tag versions directly without `v` prefix in bash and PowerShell scripts

## Testing
- `pwsh ./scripts/tag-release.ps1` *(command not found: pwsh)*
- `cd quarkus-app && ./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade3603c7c8333892a2d4f787f640f