### PR TITLE
feat: remove v prefix from release tags

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -31,9 +31,9 @@ After merging to `main`:
 
 ```bash
 git fetch origin && git checkout main && git pull
-git tag -a v2.2.0 -m "EventFlow 2.2.0"
-git push origin v2.2.0
+git tag -a 2.2.0 -m "EventFlow 2.2.0"
+git push origin 2.2.0
 
 # Optional GitHub Release
-gh release create v2.2.0 -F RELEASE_NOTES.md -t "EventFlow 2.2.0"
+gh release create 2.2.0 -F RELEASE_NOTES.md -t "EventFlow 2.2.0"
 ```

--- a/scripts/tag-release.ps1
+++ b/scripts/tag-release.ps1
@@ -1,0 +1,8 @@
+param(
+  [Parameter(Mandatory=$true)][string]$version
+)
+
+$tag = $version
+
+git tag -a $tag -m "EventFlow $version"
+git push origin $tag

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+TAG="$VERSION"
+
+git tag -a "$TAG" -m "EventFlow $VERSION"
+git push origin "$TAG"


### PR DESCRIPTION
## Summary
- drop `v` prefix from release tags in shell and PowerShell scripts
- document tagging without `v` prefix

## Testing
- `./scripts/tag-release.sh 9.9.9-test`
- `cd quarkus-app && ./mvnw -B -ntp test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade56bce1083338cc988289ecca30b