### PR TITLE
feat(home): add past events section

### DIFF
--- a/docs/ui/home-sections.md
+++ b/docs/ui/home-sections.md
@@ -1,0 +1,17 @@
+# Secciones de inicio
+
+La página de inicio ahora diferencia eventos en dos bloques:
+
+## Eventos disponibles
+- Ordenados del más próximo al más lejano.
+- Clasificación automática según la fecha/hora de término del evento.
+- Badge `En curso` cuando el evento ya comenzó pero aún no finaliza.
+- Microcopy de inicio: `Comienza hoy`, `Comienza en X días` o `Fecha por confirmar`.
+- Estado vacío: *"No hay eventos próximos por ahora. Vuelve pronto 👀"*
+
+## Eventos pasados
+- Ordenados del más reciente al más antiguo.
+- Badge `Finalizado` para todos los eventos listados.
+- Estado vacío: *"Aún no tenemos eventos anteriores."*
+
+> Capturas antes/después pendientes.

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -4,12 +4,12 @@
 {#main}
 <section class="home-section">
     <h1 class="page-title">Eventos disponibles</h1>
-    {#if events.isEmpty()}
-        <p class="section-subtitle no-events">No hay eventos disponibles.</p>
+    {#if upcoming.isEmpty()}
+        <p class="section-subtitle no-events">No hay eventos próximos por ahora. Vuelve pronto 👀</p>
     {#else}
         <div class="timeline">
             <div class="timeline-label">Hoy: {today.format('dd/MM/yyyy')}</div>
-            {#for e in events}
+            {#for e in upcoming}
             <div class="timeline-item">
                 <div class="timeline-marker"></div>
                 <article class="event-row">
@@ -22,6 +22,9 @@
                     </div>
                     <div class="event-main">
                         <h2 class="event-name"><a href="/event/{e.id}">{e.title}</a></h2>
+                        {#if e.isOngoing()}
+                        <span class="badge info">En curso</span>
+                        {/if}
                         {#if e.descriptionSummary}
                         <p class="event-description">{e.descriptionSummary}</p>
                         {/if}
@@ -40,14 +43,42 @@
                         {#if e.formattedDate}
                         <p class="event-date">{e.formattedDate}</p>
                         {/if}
-                        <p class="days-left">Faltan {e.daysUntil} días</p>
+                        <p class="days-left">{e.countdownLabel}</p>
                     </div>
                 </article>
             </div>
             {/for}
         </div>
     {/if}
-</section>
+    </section>
+
+    <section class="home-section">
+        <h1 class="page-title">Eventos pasados</h1>
+        {#if past.isEmpty()}
+            <p class="section-subtitle no-events">Aún no tenemos eventos anteriores.</p>
+        {#else}
+            <div class="event-grid">
+                {#for e in past}
+                <a href="/event/{e.id}" class="event-card">
+                    <div class="event-image">
+                        {#if app:validUrl(e.logoUrl)}
+                        <img src="{e.logoUrl}" alt="Logo de {e.title}">
+                        {#else}
+                        <div class="no-logo">Sin logo disponible</div>
+                        {/if}
+                    </div>
+                    <div class="event-content">
+                        <h3 class="event-name">{e.title}</h3>
+                        {#if e.formattedDate}
+                        <p class="event-date">{e.formattedDate}</p>
+                        {/if}
+                        <span class="badge past">Finalizado</span>
+                    </div>
+                </a>
+                {/for}
+            </div>
+        {/if}
+    </section>
 {/main}
 {/include}
 

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomePastEventsTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomePastEventsTest.java
@@ -1,0 +1,56 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.LocalDate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class HomePastEventsTest {
+
+  @Inject EventService eventService;
+
+  @BeforeEach
+  public void setup() {
+    Event past = new Event("past1", "Evento Pasado", "desc");
+    past.setDate(LocalDate.now().minusDays(1));
+    Event upcoming = new Event("up1", "Evento Futuro", "desc");
+    upcoming.setDate(LocalDate.now().plusDays(1));
+    eventService.saveEvent(past);
+    eventService.saveEvent(upcoming);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    eventService.listEvents().forEach(e -> eventService.deleteEvent(e.getId()));
+  }
+
+  @Test
+  public void homeShowsPastSection() {
+    String html =
+        given()
+            .when()
+            .get("/")
+            .then()
+            .statusCode(200)
+            .body(containsString("Eventos pasados"))
+            .extract()
+            .asString();
+
+    int pastIdx = html.indexOf("Eventos pasados");
+    int pastEventIdx = html.indexOf("Evento Pasado");
+    int upcomingIdx = html.indexOf("Eventos disponibles");
+    int upcomingEventIdx = html.indexOf("Evento Futuro");
+
+    org.junit.jupiter.api.Assertions.assertTrue(upcomingEventIdx > upcomingIdx);
+    org.junit.jupiter.api.Assertions.assertTrue(pastEventIdx > pastIdx);
+    org.junit.jupiter.api.Assertions.assertTrue(upcomingEventIdx < pastIdx);
+  }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HomeTimelineTest.java
@@ -42,8 +42,8 @@ public class HomeTimelineTest {
             .get("/")
             .then()
             .statusCode(200)
-            .body(containsString("Faltan 3 días"))
-            .body(containsString("Faltan 10 días"))
+            .body(containsString("Comienza en 3 días"))
+            .body(containsString("Comienza en 10 días"))
             .extract()
             .asString();
 


### PR DESCRIPTION
## Summary
- split events into upcoming and past in home resource
- show contextual countdown and ongoing badge for upcoming events
- add past events grid with finished badge

## Testing
- `mvn -q spotless:apply`
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_68ae311a232c83339835cb8616112bdd