### PR TITLE
fix: maintain nav-logo color

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -237,12 +237,13 @@ button:focus-visible {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.nav-logo {
+a.nav-logo,
+a.nav-logo:visited {
     color: #fff;
     text-decoration: none;
 }
 
-.nav-logo:hover {
+a.nav-logo:hover {
     color: #fff;
     text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- ensure `.nav-logo` link remains white even when visited by using specific anchor selectors

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3222db5c8333b3aba7f11a3e0a27