### PR TITLE
Fix past events section on home page

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/model/Event.java
@@ -350,7 +350,7 @@ public class Event {
       return "Fecha por confirmar";
     }
     long diff =
-        java.time.temporal.ChronoUnit.DAYS.between(java.time.LocalDate.now(getZoneId()), date);
+        java.time.temporal.ChronoUnit.DAYS.between(java.time.LocalDate.now(), date);
     if (diff == 0) {
       return "Comienza hoy";
     }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -46,12 +46,14 @@ public class HomeResource {
       @jakarta.ws.rs.core.Context io.vertx.ext.web.RoutingContext context) {
     metrics.recordPageView("/", headers, context);
     var allEvents = eventService.listEvents();
+    LocalDate today = LocalDate.now();
     List<Event> upcoming =
         allEvents.stream()
             .filter(
                 e -> {
                   ZonedDateTime end = e.getEndDateTime();
-                  return end == null || !end.isBefore(ZonedDateTime.now(e.getZoneId()));
+                  LocalDate endDate = end == null ? null : end.toLocalDate();
+                  return endDate == null || !endDate.isBefore(today);
                 })
             .sorted(
                 Comparator.comparing(
@@ -62,14 +64,14 @@ public class HomeResource {
             .filter(
                 e -> {
                   ZonedDateTime end = e.getEndDateTime();
-                  return end != null && end.isBefore(ZonedDateTime.now(e.getZoneId()));
+                  LocalDate endDate = end == null ? null : end.toLocalDate();
+                  return endDate != null && endDate.isBefore(today);
                 })
             .sorted(
                 Comparator.comparing(
                         Event::getEndDateTime, Comparator.nullsLast(Comparator.naturalOrder()))
                     .reversed())
             .toList();
-    var today = LocalDate.now();
     var stats =
         Map.of(
             "status",


### PR DESCRIPTION
## Summary
- Classify home page events using the current date
- Base countdown label on system date instead of event timezone

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68ae4c18dcac8333acc1686cac257388