### PR TITLE
Match past events style with upcoming events

### DIFF
--- a/docs/ui/home-sections.md
+++ b/docs/ui/home-sections.md
@@ -12,6 +12,7 @@ La página de inicio ahora diferencia eventos en dos bloques:
 ## Eventos pasados
 - Ordenados del más reciente al más antiguo.
 - Badge `Finalizado` para todos los eventos listados.
+- Se muestran con una apariencia equivalente a los eventos disponibles, pero en escala de grises para indicar que ya finalizaron.
 - Estado vacío: *"Aún no tenemos eventos anteriores."*
 
 > Capturas antes/después pendientes.

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1009,60 +1009,7 @@ p.note {
     }
 }
 
-/* Grid of event cards on the home page */
-.event-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 1.5rem;
-    padding: 0;
-    margin-top: 2rem;
-}
-
-.event-card {
-    background-color: var(--color-light);
-    border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-    transition: transform 0.2s ease;
-    animation: fadeInUp 0.3s ease;
-    text-decoration: none;
-    color: var(--color-dark);
-}
-
-.event-card:hover {
-    transform: translateY(-4px);
-}
-
-.event-image {
-    background-color: var(--color-accent);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 120px;
-    padding: 1rem;
-}
-
-.event-image img {
-    max-width: 120px;
-    max-height: 100%;
-    object-fit: contain;
-}
-
-.no-logo {
-    color: var(--color-light);
-    font-size: 0.9rem;
-    text-align: center;
-}
-
-.event-content {
-    padding: 1rem;
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-}
-
+/* Shared event text styles */
 .event-name {
     font-size: 1.25rem;
     margin: 0 0 0.5rem;
@@ -1085,43 +1032,17 @@ p.note {
     margin: 0 0 0.25rem;
 }
 
-.event-time {
-    font-size: 0.85rem;
-    color: #555;
-    margin: 0 0 0.5rem;
+/* Past events grayscale styling */
+.timeline.past-events::before {
+    background-color: #9e9e9e;
 }
 
-.event-time-info {
-    font-size: 0.85rem;
-    color: #555;
-    margin: 0.5rem 0;
+.timeline-item.past::before {
+    background-color: #9e9e9e;
 }
 
-
-.event-excerpt {
-    font-size: 0.9rem;
-    color: #555;
-    margin: 0 0 1rem;
-}
-
-.event-more {
-    margin-top: auto;
-    font-weight: bold;
-    color: var(--color-primary);
-}
-
-@media (min-width: 600px) {
-    .event-card {
-        flex-direction: row;
-        align-items: center;
-    }
-    .event-image {
-        width: 120px;
-        height: 120px;
-    }
-    .event-content {
-        text-align: left;
-    }
+.event-row.past {
+    filter: grayscale(100%);
 }
 
 /* Event detail header */

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -57,24 +57,32 @@
         {#if past.isEmpty()}
             <p class="section-subtitle no-events">Aún no tenemos eventos anteriores.</p>
         {#else}
-            <div class="event-grid">
+            <div class="timeline past-events">
                 {#for e in past}
-                <a href="/event/{e.id}" class="event-card">
-                    <div class="event-image">
-                        {#if app:validUrl(e.logoUrl)}
-                        <img src="{e.logoUrl}" alt="Logo de {e.title}">
-                        {#else}
-                        <div class="no-logo">Sin logo disponible</div>
-                        {/if}
-                    </div>
-                    <div class="event-content">
-                        <h3 class="event-name">{e.title}</h3>
-                        {#if e.formattedDate}
-                        <p class="event-date">{e.formattedDate}</p>
-                        {/if}
-                        <span class="badge past">Finalizado</span>
-                    </div>
-                </a>
+                <div class="timeline-item past">
+                    <div class="timeline-marker"></div>
+                    <article class="event-row past">
+                        <div class="event-logo">
+                            {#if app:validUrl(e.logoUrl)}
+                            <img src="{e.logoUrl}" alt="Logo de {e.title}">
+                            {#else}
+                            <div class="no-logo">Sin logo disponible</div>
+                            {/if}
+                        </div>
+                        <div class="event-main">
+                            <h2 class="event-name"><a href="/event/{e.id}">{e.title}</a></h2>
+                            {#if e.descriptionSummary}
+                            <p class="event-description">{e.descriptionSummary}</p>
+                            {/if}
+                            <span class="badge past">Finalizado</span>
+                        </div>
+                        <div class="event-countdown">
+                            {#if e.formattedDate}
+                            <p class="event-date">{e.formattedDate}</p>
+                            {/if}
+                        </div>
+                    </article>
+                </div>
                 {/for}
             </div>
         {/if}


### PR DESCRIPTION
## Summary
- Render past events using the same layout as available events
- Add grayscale styling and timeline cues for past events
- Document the new grayscale appearance for past events

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5df26b748333b5157e660892f6b4