### PR TITLE
feat(notifications): runtime integration via scheduler + SSE

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -101,3 +101,26 @@ usuario devuelven `404`.
 - Navegación por teclado y foco visible.
 - Contraste AA en el contador y botones.
 
+## Iteración 4 – Integración runtime
+
+```
+Mis Charlas -> Evaluador -> Servicio Notif -> SSE/Poll -> UI
+```
+
+### Configuración
+- `notifications.scheduler.enabled`
+- `notifications.scheduler.interval`
+- `notifications.upcoming.window`
+- `notifications.endingSoon.window`
+- `notifications.sse.enabled`
+- `notifications.sse.heartbeat`
+- `notifications.poll.interval`
+- `notifications.poll.limit`
+- `notifications.stream.maxConnectionsPerUser`
+
+### Seguridad
+- Propiedad de usuario derivada de `SecurityIdentity`, sin aceptar `userId` externo.
+- Límite de 1 SSE activo por usuario y control de `limit` en polling.
+- Respuestas con `Cache-Control: no-store` y cabecera `X-User-Scoped: true`.
+- Ante `401` la UI cae a polling o redirige al inicio.
+

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationConfig.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationConfig.java
@@ -30,4 +30,33 @@ public class NotificationConfig {
 
   @ConfigProperty(name = "notifications.drop-on-queue-full", defaultValue = "false")
   public boolean dropOnQueueFull;
+
+  // Iteration 4 runtime integration
+
+  @ConfigProperty(name = "notifications.scheduler.enabled", defaultValue = "true")
+  public boolean schedulerEnabled;
+
+  @ConfigProperty(name = "notifications.scheduler.interval", defaultValue = "PT15S")
+  public Duration schedulerInterval;
+
+  @ConfigProperty(name = "notifications.upcoming.window", defaultValue = "PT15M")
+  public Duration upcomingWindow;
+
+  @ConfigProperty(name = "notifications.endingSoon.window", defaultValue = "PT10M")
+  public Duration endingSoonWindow;
+
+  @ConfigProperty(name = "notifications.sse.enabled", defaultValue = "true")
+  public boolean sseEnabled;
+
+  @ConfigProperty(name = "notifications.sse.heartbeat", defaultValue = "PT25S")
+  public Duration sseHeartbeat;
+
+  @ConfigProperty(name = "notifications.poll.interval", defaultValue = "PT15S")
+  public Duration pollInterval;
+
+  @ConfigProperty(name = "notifications.poll.limit", defaultValue = "20")
+  public int pollLimit;
+
+  @ConfigProperty(name = "notifications.stream.maxConnectionsPerUser", defaultValue = "1")
+  public int streamMaxConnectionsPerUser;
 }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationPollingResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationPollingResource.java
@@ -1,0 +1,61 @@
+package com.scanales.eventflow.notifications;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+@Path("/api/notifications")
+public class NotificationPollingResource {
+
+  @Inject SecurityIdentity identity;
+  @Inject NotificationService notifications;
+  @Inject NotificationConfig config;
+
+  @GET
+  @Path("/next")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response next(@QueryParam("since") long since, @QueryParam("limit") Integer limit) {
+    String user = identity.getAttribute("email");
+    if (user == null && identity.getPrincipal() != null) {
+      user = identity.getPrincipal().getName();
+    }
+    int lim = limit == null ? config.pollLimit : Math.min(limit, config.pollLimit);
+    List<Notification> list = notifications.listForUser(user, 1000, false);
+    List<Notification> filtered =
+        list.stream()
+            .filter(n -> n.createdAt > since)
+            .sorted((a, b) -> Long.compare(a.createdAt, b.createdAt))
+            .limit(lim)
+            .toList();
+    long nextSince =
+        filtered.stream().mapToLong(n -> n.createdAt).max().orElse(since);
+    List<io.eventflow.notifications.api.NotificationDTO> items =
+        filtered.stream().map(this::toDTO).toList();
+    Map<String, Object> body =
+        Map.of("items", items, "serverTime", System.currentTimeMillis(), "nextSince", nextSince);
+    return Response.ok(body)
+        .header("Cache-Control", "no-store")
+        .header("X-User-Scoped", "true")
+        .build();
+  }
+
+  private io.eventflow.notifications.api.NotificationDTO toDTO(Notification n) {
+    io.eventflow.notifications.api.NotificationDTO dto =
+        new io.eventflow.notifications.api.NotificationDTO();
+    dto.id = n.id;
+    dto.talkId = n.talkId;
+    dto.eventId = n.eventId;
+    dto.type = n.type != null ? n.type.name() : null;
+    dto.title = n.title;
+    dto.message = n.message;
+    dto.createdAt = n.createdAt;
+    return dto;
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationStreamResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationStreamResource.java
@@ -1,0 +1,34 @@
+package com.scanales.eventflow.notifications;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.mutiny.Multi;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.jboss.resteasy.reactive.RestStreamElementType;
+
+@Path("/api/notifications")
+public class NotificationStreamResource {
+
+  @Inject SecurityIdentity identity;
+  @Inject NotificationStreamService streamService;
+  @Inject NotificationConfig config;
+
+  @GET
+  @Path("/stream")
+  @Produces(MediaType.SERVER_SENT_EVENTS)
+  @RestStreamElementType(MediaType.APPLICATION_JSON)
+  public Multi<io.eventflow.notifications.api.NotificationDTO> stream() {
+    if (!config.sseEnabled) {
+      throw new NotFoundException();
+    }
+    String user = identity.getAttribute("email");
+    if (user == null && identity.getPrincipal() != null) {
+      user = identity.getPrincipal().getName();
+    }
+    return streamService.subscribe(user);
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationStreamService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationStreamService.java
@@ -1,0 +1,96 @@
+package com.scanales.eventflow.notifications;
+
+import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.infrastructure.Infrastructure;
+import io.smallrye.mutiny.subscription.MultiEmitter;
+import io.smallrye.mutiny.subscription.MultiEmitterFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jboss.logging.Logger;
+
+/** Simple in-memory stream manager for notification SSE connections. */
+@ApplicationScoped
+public class NotificationStreamService {
+
+  private static final Logger LOG = Logger.getLogger(NotificationStreamService.class);
+
+  @Inject NotificationConfig config;
+
+  private final Map<String, MultiEmitter<io.eventflow.notifications.api.NotificationDTO>> emitters =
+      new ConcurrentHashMap<>();
+
+  private final Map<String, AtomicInteger> connections = new ConcurrentHashMap<>();
+
+  /**
+   * Subscribe the given user to the notification stream.
+   *
+   * @throws WebApplicationException with status 429 if the user already has an active connection.
+   */
+  public Multi<io.eventflow.notifications.api.NotificationDTO> subscribe(String userId) {
+    AtomicInteger count = connections.computeIfAbsent(userId, k -> new AtomicInteger());
+    if (count.incrementAndGet() > config.streamMaxConnectionsPerUser) {
+      count.decrementAndGet();
+      throw new WebApplicationException(
+          Response.status(Response.Status.TOO_MANY_REQUESTS).entity("max connections").build());
+    }
+
+    Multi<io.eventflow.notifications.api.NotificationDTO> events =
+        Multi.createFrom()
+            .<io.eventflow.notifications.api.NotificationDTO>emitter(
+                emitter -> {
+                  emitters.put(userId, emitter);
+                  emitter.onTermination(() -> {
+                    emitters.remove(userId);
+                    count.decrementAndGet();
+                  });
+                },
+                MultiEmitterFactory.BackPressureStrategy.BUFFER);
+
+    Multi<io.eventflow.notifications.api.NotificationDTO> heartbeat =
+        Multi.createFrom()
+            .ticks()
+            .every(config.sseHeartbeat)
+            .onOverflow().drop()
+            .map(
+                t -> {
+                  io.eventflow.notifications.api.NotificationDTO hb =
+                      new io.eventflow.notifications.api.NotificationDTO();
+                  hb.type = "HEARTBEAT";
+                  hb.createdAt = System.currentTimeMillis();
+                  return hb;
+                });
+
+    return Multi.createBy().merging().streams(events, heartbeat).runSubscriptionOn(Infrastructure.getDefaultExecutor());
+  }
+
+  /** Broadcasts a notification to active subscribers. */
+  public void broadcast(Notification n) {
+    io.eventflow.notifications.api.NotificationDTO dto = toDTO(n);
+    MultiEmitter<io.eventflow.notifications.api.NotificationDTO> emitter = emitters.get(n.userId);
+    if (emitter != null) {
+      try {
+        emitter.emit(dto);
+      } catch (Exception e) {
+        LOG.debug("emit failed", e);
+      }
+    }
+  }
+
+  private io.eventflow.notifications.api.NotificationDTO toDTO(Notification n) {
+    io.eventflow.notifications.api.NotificationDTO dto =
+        new io.eventflow.notifications.api.NotificationDTO();
+    dto.id = n.id;
+    dto.talkId = n.talkId;
+    dto.eventId = n.eventId;
+    dto.type = n.type != null ? n.type.name() : null;
+    dto.title = n.title;
+    dto.message = n.message;
+    dto.createdAt = n.createdAt;
+    return dto;
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/TalkStateEvaluator.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/TalkStateEvaluator.java
@@ -1,0 +1,83 @@
+package com.scanales.eventflow.notifications;
+
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.model.TalkInfo;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.UserScheduleService;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+import org.jboss.logging.Logger;
+
+/** Periodically evaluates registered talks to emit runtime notifications. */
+@ApplicationScoped
+public class TalkStateEvaluator {
+
+  private static final Logger LOG = Logger.getLogger(TalkStateEvaluator.class);
+
+  @Inject UserScheduleService schedules;
+  @Inject EventService events;
+  @Inject NotificationService notifications;
+  @Inject NotificationConfig config;
+
+  @Scheduled(every = "{notifications.scheduler.interval}")
+  void evaluate() {
+    if (!config.schedulerEnabled) return;
+    long nowMs = System.currentTimeMillis();
+    Set<String> users = schedules.listUsers();
+    for (String user : users) {
+      for (String talkId : schedules.getTalksForUser(user)) {
+        try {
+          evaluateTalk(user, talkId, nowMs);
+        } catch (Exception e) {
+          LOG.debugf(e, "evaluator error user=%s talk=%s", user, talkId);
+        }
+      }
+    }
+  }
+
+  private void evaluateTalk(String user, String talkId, long nowMs) {
+    TalkInfo info = events.findTalkInfo(talkId);
+    if (info == null) return;
+    Talk talk = info.talk();
+    if (talk.getStartTime() == null || talk.getEndTime() == null) return;
+    ZoneId zone =
+        info.event() != null && info.event().getTimezone() != null
+            ? ZoneId.of(info.event().getTimezone())
+            : ZoneId.of("America/Santiago");
+    ZonedDateTime now = ZonedDateTime.ofInstant(Instant.ofEpochMilli(nowMs), zone);
+    ZonedDateTime start = now.with(talk.getStartTime());
+    ZonedDateTime end = now.with(talk.getEndTime());
+    if (end.isBefore(start)) {
+      end = start.plus(1, ChronoUnit.HOURS);
+    }
+    if (now.isBefore(start) && start.minus(config.upcomingWindow).isBefore(now)) {
+      enqueue(user, talkId, info, NotificationType.UPCOMING, "Charla pronto");
+    } else if (!now.isBefore(start) && now.isBefore(end)) {
+      if (end.minus(config.endingSoonWindow).isBefore(now)) {
+        enqueue(user, talkId, info, NotificationType.ENDING_SOON, "Termina pronto");
+      } else {
+        enqueue(user, talkId, info, NotificationType.STARTED, "Ha comenzado");
+      }
+    } else if (!now.isBefore(end)) {
+      enqueue(user, talkId, info, NotificationType.FINISHED, "Finalizó");
+    }
+  }
+
+  private void enqueue(
+      String user, String talkId, TalkInfo info, NotificationType type, String message) {
+    Notification n = new Notification();
+    n.userId = user;
+    n.talkId = talkId;
+    n.eventId = info.event() != null ? info.event().getId() : null;
+    n.type = type;
+    n.title = info.talk().getName();
+    n.message = message;
+    notifications.enqueue(n);
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -209,6 +209,12 @@ public class UserScheduleService {
     return new Summary(talks.size(), attendedCount, ratedCount);
   }
 
+  /** Returns all user ids with schedules (testing/evaluator use). */
+  public Set<String> listUsers() {
+    recordRead();
+    return schedules.keySet();
+  }
+
   /** Reloads schedules from persistent storage. */
   public void reload() {
     schedules.clear();

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -55,3 +55,14 @@ app.auth.redirect-on-expire=true
 app.auth.redirect-grace-ms=30000
 
 quarkus.package.main-class=com.scanales.eventflow.VertxCacheFixMain
+
+# Notifications runtime integration
+notifications.scheduler.enabled=true
+notifications.scheduler.interval=PT15S
+notifications.upcoming.window=PT15M
+notifications.endingSoon.window=PT10M
+notifications.sse.enabled=true
+notifications.sse.heartbeat=PT25S
+notifications.poll.interval=PT15S
+notifications.poll.limit=20
+notifications.stream.maxConnectionsPerUser=1

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{#insert title}EventFlow{/}</title>
     <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/css/notifications.css">
     <script src="/js/app.js" defer></script>
+    <script src="/js/notifications.js" defer></script>
 </head>
 <body>
 <a href="#main-content" class="skip-link">Ir al contenido principal</a>
@@ -51,5 +53,62 @@
         <p>&copy; {app:currentYear()} EventFlow &ndash; v{app:version()}</p>
     </div>
 </footer>
+
+{#include ../fragments/toasts.qute.html/}
+<script>
+window.addEventListener('DOMContentLoaded', () => {
+(function(){
+  const useSSE = !!window.EventSource;
+  let since = Date.now();
+
+  function onDTO(dto){
+    since = Math.max(since, dto.createdAt || Date.now());
+    if (window.EventFlowNotifications && typeof window.EventFlowNotifications.accept === 'function') {
+      window.EventFlowNotifications.accept(dto);
+    }
+    if (window.__metrics && window.__metrics.count) {
+      window.__metrics.count('ui.notifications.received');
+    }
+  }
+
+  function startSSE(){
+    try {
+      const es = new EventSource('/api/notifications/stream', { withCredentials: true });
+      es.onmessage = (ev) => {
+        const dto = JSON.parse(ev.data);
+        if (dto && dto.type !== 'HEARTBEAT') onDTO(dto);
+      };
+      es.onopen = () => { if(window.__metrics) window.__metrics.count('ui.notifications.sse.connected'); };
+      es.onerror = () => { es.close(); if(window.__metrics) window.__metrics.count('ui.notifications.sse.fallback_polling'); startPolling(); };
+    } catch(e) { startPolling(); }
+  }
+
+  function startPolling(){
+    if(window.__metrics) window.__metrics.count('ui.notifications.fallback_polling');
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/notifications/next?since=${since}&limit=20`, { cache: 'no-store' });
+        if (res.status === 401) return;
+        const data = await res.json();
+        (data.items || []).forEach(onDTO);
+      } catch(_) {}
+      setTimeout(poll, 15000);
+    };
+    poll();
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden) {
+      fetch(`/api/notifications/next?since=${since}&limit=20`, { cache: 'no-store' })
+        .then(r => r.ok ? r.json() : null)
+        .then(d => (d?.items || []).forEach(onDTO))
+        .catch(()=>{});
+    }
+  });
+
+  useSSE ? startSSE() : startPolling();
+})();
+});
+</script>
 </body>
 </html>

--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationPollingResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationPollingResourceTest.java
@@ -1,0 +1,53 @@
+package com.scanales.eventflow.notifications;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import com.scanales.eventflow.notifications.Notification;
+import com.scanales.eventflow.notifications.NotificationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class NotificationPollingResourceTest {
+
+  @Inject NotificationService service;
+  @Inject NotificationConfig config;
+
+  @BeforeEach
+  void setup() {
+    service.reset();
+    config.pollLimit = 20;
+    Notification n1 = new Notification();
+    n1.userId = "u1";
+    n1.talkId = "t1";
+    n1.type = NotificationType.STARTED;
+    n1.title = "n1";
+    service.enqueue(n1);
+    Notification n2 = new Notification();
+    n2.userId = "u1";
+    n2.talkId = "t2";
+    n2.type = NotificationType.STARTED;
+    n2.title = "n2";
+    service.enqueue(n2);
+  }
+
+  @Test
+  @TestSecurity(user = "u1")
+  void sinceAndLimit() {
+    long since = 0L;
+    given()
+        .queryParam("since", since)
+        .queryParam("limit", 1)
+        .when()
+        .get("/api/notifications/next")
+        .then()
+        .statusCode(200)
+        .body("items.size()", is(1))
+        .header("Cache-Control", containsString("no-store"))
+        .header("X-User-Scoped", is("true"));
+  }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationStreamServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationStreamServiceTest.java
@@ -1,0 +1,41 @@
+package com.scanales.eventflow.notifications;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.eventflow.notifications.api.NotificationDTO;
+import io.smallrye.mutiny.helpers.test.AssertSubscriber;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.WebApplicationException;
+import com.scanales.eventflow.notifications.Notification;
+import com.scanales.eventflow.notifications.NotificationType;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class NotificationStreamServiceTest {
+
+  @Inject NotificationStreamService service;
+  @Inject NotificationConfig config;
+
+  @Test
+  void emitsToCorrectUserAndLimitsConnections() {
+    config.streamMaxConnectionsPerUser = 1;
+    AssertSubscriber<NotificationDTO> sub1 = AssertSubscriber.create(1);
+    service.subscribe("u1").subscribe().with(sub1);
+    assertThrows(WebApplicationException.class, () -> service.subscribe("u1"));
+    AssertSubscriber<NotificationDTO> sub2 = AssertSubscriber.create(1);
+    service.subscribe("u2").subscribe().with(sub2);
+    Notification n = new Notification();
+    n.userId = "u1";
+    n.talkId = "t1";
+    n.eventId = "e1";
+    n.type = NotificationType.STARTED;
+    n.title = "t";
+    service.broadcast(n);
+    sub1.awaitItems(1);
+    sub1.assertItems(d -> d.talkId.equals("t1"));
+    sub2.assertSubscribed().assertHasNotReceivedAnyItem();
+    sub1.cancel();
+    sub2.cancel();
+  }
+}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/TalkStateEvaluatorTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/TalkStateEvaluatorTest.java
@@ -1,0 +1,63 @@
+package com.scanales.eventflow.notifications;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import com.scanales.eventflow.service.UserScheduleService;
+import com.scanales.eventflow.notifications.Notification;
+import com.scanales.eventflow.notifications.NotificationType;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class TalkStateEvaluatorTest {
+
+  @Inject TalkStateEvaluator evaluator;
+  @Inject NotificationService notifications;
+  @Inject EventService events;
+  @Inject UserScheduleService schedules;
+
+  @BeforeEach
+  void setup() {
+    notifications.reset();
+    Event e = new Event("e1", "E", "d");
+    e.setTimezone("UTC");
+    LocalTime now = LocalTime.now();
+    Talk t1 = new Talk("t1", "t1");
+    t1.setStartTime(now.plusMinutes(10));
+    t1.setDurationMinutes(30);
+    Talk t2 = new Talk("t2", "t2");
+    t2.setStartTime(now.minusMinutes(1));
+    t2.setDurationMinutes(20);
+    Talk t3 = new Talk("t3", "t3");
+    t3.setStartTime(now.minusMinutes(30));
+    t3.setDurationMinutes(35);
+    Talk t4 = new Talk("t4", "t4");
+    t4.setStartTime(now.minusMinutes(30));
+    t4.setDurationMinutes(20);
+    e.getAgenda().addAll(List.of(t1, t2, t3, t4));
+    events.saveEvent(e);
+    String user = "user@example.com";
+    schedules.addTalkForUser(user, "t1");
+    schedules.addTalkForUser(user, "t2");
+    schedules.addTalkForUser(user, "t3");
+    schedules.addTalkForUser(user, "t4");
+  }
+
+  @Test
+  void emitsStates() {
+    evaluator.evaluate();
+    List<Notification> list = notifications.listForUser("user@example.com", 10, false);
+    assertEquals(4, list.size());
+    assertTrue(list.stream().anyMatch(n -> n.type == NotificationType.UPCOMING));
+    assertTrue(list.stream().anyMatch(n -> n.type == NotificationType.STARTED));
+    assertTrue(list.stream().anyMatch(n -> n.type == NotificationType.ENDING_SOON));
+    assertTrue(list.stream().anyMatch(n -> n.type == NotificationType.FINISHED));
+  }
+}


### PR DESCRIPTION
## Summary
- evaluate talk states on a periodic scheduler to enqueue notifications
- stream notifications to the UI via SSE with polling fallback and heartbeat
- add polling endpoint, runtime config and frontend bootstrap

## Testing
- `./mvnw -q spotless:apply` *(failed: Network is unreachable)*
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aef556b85c8333930207d738ef94f4