### PR TITLE
Fix Mutiny emitter API usage in notification stream service

### DIFF
--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationStreamServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationStreamServiceTest.java
@@ -21,10 +21,10 @@ class NotificationStreamServiceTest {
   void emitsToCorrectUserAndLimitsConnections() {
     config.streamMaxConnectionsPerUser = 1;
     AssertSubscriber<NotificationDTO> sub1 = AssertSubscriber.create(1);
-    service.subscribe("u1").subscribe().with(sub1);
+    service.subscribe("u1").subscribe().withSubscriber(sub1);
     assertThrows(WebApplicationException.class, () -> service.subscribe("u1"));
     AssertSubscriber<NotificationDTO> sub2 = AssertSubscriber.create(1);
-    service.subscribe("u2").subscribe().with(sub2);
+    service.subscribe("u2").subscribe().withSubscriber(sub2);
     Notification n = new Notification();
     n.userId = "u1";
     n.talkId = "t1";
@@ -33,7 +33,8 @@ class NotificationStreamServiceTest {
     n.title = "t";
     service.broadcast(n);
     sub1.awaitItems(1);
-    sub1.assertItems(d -> d.talkId.equals("t1"));
+    NotificationDTO received = sub1.getItems().get(0);
+    assertEquals("t1", received.talkId);
     sub2.assertSubscribed().assertHasNotReceivedAnyItem();
     sub1.cancel();
     sub2.cancel();


### PR DESCRIPTION
## Summary
- replace removed `MultiEmitterFactory` with `BackPressureStrategy`
- adjust `NotificationStreamService` emitter typing for Mutiny 2
- update unit test to new Mutiny subscribe API

## Testing
- `python tests/test_enforce_severity.py`
- `mvn -ntp verify` *(fails: Tests run: 66, Failures: 20, Errors: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68af02a92c948333b30daa6693aa75c1