### PR TITLE
Stabilize notification tests by resetting services

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/EventService.java
@@ -96,6 +96,12 @@ public class EventService {
     }
   }
 
+  /** Clears all stored events (testing only). */
+  public void reset() {
+    events.clear();
+    persistence.saveEvents(new ConcurrentHashMap<>(events));
+  }
+
   /**
    * Checks whether the given talk overlaps with an existing one in the same event, day and
    * scenario.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/SpeakerService.java
@@ -89,6 +89,12 @@ public class SpeakerService {
     persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
   }
 
+  /** Clears all stored speakers (testing only). */
+  public void reset() {
+    speakers.clear();
+    persistence.saveSpeakers(new ConcurrentHashMap<>(speakers));
+  }
+
   public void saveTalk(String speakerId, Talk talk) {
     Speaker sp = speakers.get(speakerId);
     if (sp == null || talk == null || talk.getId() == null) {

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UserScheduleService.java
@@ -221,6 +221,13 @@ public class UserScheduleService {
     init();
   }
 
+  /** Clears all schedules and historical data (testing only). */
+  public void reset() {
+    schedules.clear();
+    historical.clear();
+    persistence.saveUserSchedules(activeYear, schedules);
+  }
+
   /** Result codes for loading historical data. */
   public enum LoadStatus {
     LOADED,

--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationPollingResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationPollingResourceTest.java
@@ -20,6 +20,11 @@ class NotificationPollingResourceTest {
   @BeforeEach
   void setup() {
     service.reset();
+    config.enabled = true;
+    config.userCap = 100;
+    config.globalCap = 1000;
+    config.maxQueueSize = 10000;
+    config.dedupeWindow = java.time.Duration.ofMinutes(30);
     config.pollLimit = 20;
     Notification n1 = new Notification();
     n1.userId = "u1";

--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationServiceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationServiceTest.java
@@ -13,6 +13,7 @@ public class NotificationServiceTest {
 
   @Test
   public void dedupePreventsDuplicates() {
+    notifications.reset();
     config.enabled = true;
     config.maxQueueSize = 10000;
     config.dropOnQueueFull = false;
@@ -33,6 +34,7 @@ public class NotificationServiceTest {
 
   @Test
   public void queueFullReturnsVolatile() {
+    notifications.reset();
     config.enabled = true;
     config.maxQueueSize = 0;
     config.dropOnQueueFull = false;

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
@@ -32,6 +32,8 @@ public class AdminMetricsExportTest {
 
   @BeforeEach
   void setUp() {
+    eventService.reset();
+    speakerService.reset();
     try {
       Method m = UsageMetricsService.class.getDeclaredMethod("reset");
       m.setAccessible(true);

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -29,6 +29,7 @@ public class ProfileResourceTest {
     config.maxQueueSize = 10000;
     config.dedupeWindow = java.time.Duration.ofMinutes(30);
     notifications.reset();
+    userSchedule.reset();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add reset hooks for event, speaker and schedule services
- configure notification tests with explicit limits and relaxed evaluator expectations
- ensure admin metrics export starts from clean data

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_68af0c2df0608333b1f73f7207aee96f