### PR TITLE
fix: avoid notifications requests when unauthenticated

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -57,7 +57,8 @@
 {#include fragments/toasts.qute.html/}
 <script>
 window.addEventListener('DOMContentLoaded', () => {
-(function(){
+  if (!{app:isAuthenticated()}) return;
+  (function(){
   const useSSE = !!window.EventSource;
   let since = Date.now();
 


### PR DESCRIPTION
## Summary
- skip notifications SSE/polling when user is not authenticated to prevent unauthorized errors

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af3f929a688333a87ad661e9e35506