### PR TITLE
Handle missing user in notification endpoints

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationPollingResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationPollingResource.java
@@ -24,9 +24,13 @@ public class NotificationPollingResource {
   @Path("/next")
   @Produces(MediaType.APPLICATION_JSON)
   public Response next(@QueryParam("since") long since, @QueryParam("limit") Integer limit) {
-    String user = identity.getAttribute("email");
+    Object emailAttr = identity.getAttribute("email");
+    String user = emailAttr != null ? emailAttr.toString() : null;
     if (user == null && identity.getPrincipal() != null) {
       user = identity.getPrincipal().getName();
+    }
+    if (user == null) {
+      return Response.status(Response.Status.UNAUTHORIZED).build();
     }
     int lim = limit == null ? config.pollLimit : Math.min(limit, config.pollLimit);
     List<Notification> list = notifications.listForUser(user, 1000, false);

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationStreamResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationStreamResource.java
@@ -9,8 +9,10 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.jboss.resteasy.reactive.RestStreamElementType;
 
 @Path("/api/notifications")
@@ -30,9 +32,13 @@ public class NotificationStreamResource {
     if (!config.sseEnabled) {
       throw new NotFoundException();
     }
-    String user = identity.getAttribute("email");
+    Object emailAttr = identity.getAttribute("email");
+    String user = emailAttr != null ? emailAttr.toString() : null;
     if (user == null && identity.getPrincipal() != null) {
       user = identity.getPrincipal().getName();
+    }
+    if (user == null) {
+      throw new WebApplicationException("user not found", Response.Status.UNAUTHORIZED);
     }
     response.putHeader("Cache-Control", "no-store");
     response.putHeader("X-User-Scoped", "true");


### PR DESCRIPTION
## Summary
- prevent 500s when user identity is missing by returning 401 in polling
- validate user identity before starting SSE stream

## Testing
- `mvn test -e`

------
https://chatgpt.com/codex/tasks/task_e_68af48a4c6dc8333a63ffce6700ecaa5