### PR TITLE
fix: include credentials in notifications polling

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -88,7 +88,10 @@ window.addEventListener('DOMContentLoaded', () => {
     if(window.__metrics) window.__metrics.count('ui.notifications.fallback_polling');
     const poll = async () => {
       try {
-        const res = await fetch(`/api/notifications/next?since=$\{since}&limit=20`, { cache: 'no-store' });
+        const res = await fetch(`/api/notifications/next?since=$\{since}&limit=20`, {
+          cache: 'no-store',
+          credentials: 'include'
+        });
         if (res.status === 401) return;
         const data = await res.json();
         (data.items || []).forEach(onDTO);
@@ -100,8 +103,11 @@ window.addEventListener('DOMContentLoaded', () => {
 
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) {
-      fetch(`/api/notifications/next?since=$\{since}&limit=20`, { cache: 'no-store' })
-        .then(r => r.ok ? r.json() : null)
+      fetch(`/api/notifications/next?since=$\{since}&limit=20`, {
+        cache: 'no-store',
+        credentials: 'include'
+      })
+        .then(r => (r.ok ? r.json() : null))
         .then(d => (d?.items || []).forEach(onDTO))
         .catch(()=>{});
     }


### PR DESCRIPTION
## Summary
- include credentials with notification polling requests

## Testing
- `mvn -f quarkus-app/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_68af5d26fd388333a82aa203c142f33f