### PR TITLE
Protect notifications API path

### DIFF
--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -33,7 +33,7 @@ quarkus.log.console.enable=true
 quarkus.jackson.fail-on-unknown-properties=true
 quarkus.jackson.serialization-inclusion=non-null
 
-quarkus.http.auth.permission.protected.paths=/private/*
+quarkus.http.auth.permission.protected.paths=/private/*,/api/notifications/*
 quarkus.http.auth.permission.protected.policy=authenticated
 
 # Comma separated list of admin emails


### PR DESCRIPTION
## Summary
- require authentication for `/api/notifications/*` endpoints so cookies are sent and 401 errors avoided

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68af998ccb1c833381c97c495ed2d96c