### PR TITLE
fix: include credentials in fetch wrapper

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -1,6 +1,7 @@
 (function(){
   const origFetch = window.fetch;
-  window.fetch = async function(input, init) {
+  window.fetch = async function(input, init = {}) {
+    if (!init.credentials) { init.credentials = 'include'; }
     const res = await origFetch(input, init);
     if (res.status === 401 && res.headers.get('X-Session-Expired') === 'true') {
       try { sessionStorage.clear(); localStorage.clear(); } catch (e) {}


### PR DESCRIPTION
## Summary
- include credentials by default in custom fetch wrapper to avoid unauthorized requests

## Testing
- `mvn -f quarkus-app/pom.xml spotless:apply`
- `mvn -f quarkus-app/pom.xml enforcer:enforce`
- `./dev/deps-check.sh`
- `./dev/pr-check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68afb87605dc8333aff3f9f39f76e8bc