### PR TITLE
docs: add user stories for core features

### DIFF
--- a/docs/features/admin-area.md
+++ b/docs/features/admin-area.md
@@ -1,0 +1,13 @@
+# Historia de usuario — "Panel de control seguro para organizadores"
+
+Soy Laura, parte del equipo organizador. Ingreso con mi correo autorizado y la app me muestra la sección Admin. Desde allí creo eventos, escenarios y charlas con formularios claros y validaciones en vivo.
+
+Puedo editar detalles, cargar imágenes y programar horarios sin miedo a romper nada: solo los administradores listados pueden entrar aquí.
+
+Me siento en control:
+
+- Todo está agrupado por evento y charla.
+- Los cambios se guardan de inmediato.
+- Nadie sin permiso puede ver esta sección.
+
+Resultado: organizo el programa completo sin depender de herramientas externas.

--- a/docs/features/event-discovery-registration.md
+++ b/docs/features/event-discovery-registration.md
@@ -1,0 +1,13 @@
+# Historia de usuario — "Explorar y registrar charlas a mi ritmo"
+
+Soy Javier. Desde mi laptop entro a EventFlow y veo de un vistazo las pistas y charlas disponibles. Marco como favoritas las que me interesan y mi agenda personal se actualiza al instante.
+
+Mientras navego puedo filtrar por tema, horario o ponente, y cada charla tiene su tarjeta con descripción, sala y un botón para sumarla o quitarla de mi lista. En móvil la vista se adapta y puedo reorganizar mi día con un pulgar.
+
+Me siento dueño de mi agenda:
+
+- Veo toda la oferta sin perderme en menús.
+- Registro o quito charlas con un toque.
+- Mi plan se sincroniza en todos mis dispositivos.
+
+Resultado: armo mi plan en minutos y sé exactamente dónde estar y cuándo.

--- a/docs/features/google-sign-in.md
+++ b/docs/features/google-sign-in.md
@@ -1,0 +1,13 @@
+# Historia de usuario — "Entrar con mi cuenta Google en segundos"
+
+Soy María. Llego al sitio de EventFlow y en vez de crear otra contraseña, presiono "Continuar con Google". Autorizo y listo: ya estoy dentro con mi nombre y foto.
+
+Puedo revisar mis charlas guardadas o crear nuevas sin pasos extra. Si cierro sesión, sé que la próxima vez bastará un toque para volver.
+
+Me siento sin fricción:
+
+- No recuerdo contraseñas.
+- Uso la misma identidad en todos mis dispositivos.
+- Puedo revocar el acceso desde Google cuando quiera.
+
+Resultado: inicio rápido y seguro que me deja tiempo para lo importante.

--- a/docs/features/import-events.md
+++ b/docs/features/import-events.md
@@ -1,0 +1,13 @@
+# Historia de usuario — "Carga masiva sin dolores"
+
+Soy Rodrigo, coordinador de logística. Tengo todas las charlas en un archivo JSON. En el panel admin voy a "Importar", subo el archivo y en segundos las sesiones aparecen en la plataforma.
+
+Si el archivo tiene un ID duplicado, la app me avisa qué línea revisar. Si hay un error en el formato, obtengo un mensaje claro para corregirlo.
+
+Me siento eficiente:
+
+- No tecleo dato por dato.
+- Los errores se detectan antes de publicar.
+- Puedo repetir la importación cuantas veces necesite.
+
+Resultado: migro mi agenda completa de una sola vez y la app queda lista para los asistentes.

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -1,0 +1,17 @@
+# Historia de usuario — "Notificaciones que me acompañan sin estorbar"
+
+Soy Carolina. Entro a EventFlow desde el celular, reviso “Eventos disponibles” y registro mis charlas favoritas. Arriba, junto al menú, veo una campanita sin número: no tengo nada pendiente… por ahora.
+
+Un rato antes de mi primera charla, aparece un aviso sutil abajo de la pantalla: “Comienza en 10 min”. Es un toast liviano: no tapa lo que estoy haciendo. Si toco el aviso, voy directo al detalle de la charla; si no, desaparece solo a los pocos segundos. Como registré varias, recibo 2 o 3 avisos seguidos y uso “Cerrar todas” para limpiar la cola de una.
+
+Durante el día, la app me avisa cuando una charla “está en curso”, cuando “está por finalizar” y al final “ha finalizado”. Todo sin bloquearme. Si pierdo señal un momento, al volver, las notificaciones se ponen al día solas.
+
+Cuando quiero ver todo con calma, toco la campana (ahora con numerito). Entro al Centro de Notificaciones, donde puedo filtrar Todas / No leídas / Últimas 24 h, marcar como leídas o eliminar varias a la vez. Todo está ordenado en tarjetas compactas, los textos no se cortan raro, y los botones son cómodos de pulsar.
+
+Me siento acompañada, no perseguida:
+
+- Solo recibo avisos de mis charlas registradas.
+- Si llegan muchas, puedo cerrarlas de golpe o gestionarlas luego en la campana.
+- En móvil se ve limpio, legible y accesible (buen contraste, foco visible, sin scroll lateral).
+
+Resultado: llego a tiempo, no me pierdo nada y la app nunca se interpone en mi camino.

--- a/docs/features/supply-chain-security.md
+++ b/docs/features/supply-chain-security.md
@@ -1,0 +1,13 @@
+# Historia de usuario — "Confianza de extremo a extremo"
+
+Soy Elena, encargada de DevOps. Cada vez que publicamos una versión, EventFlow genera SBOMs y firma las imágenes del contenedor. La pipeline escanea dependencias y me alerta si aparece una vulnerabilidad.
+
+Desde un panel puedo ver los reportes y compartirlos con auditorías externas. Sé exactamente qué librería usamos y qué versión.
+
+Me siento tranquila:
+
+- El código y las imágenes tienen trazabilidad.
+- Los problemas se detectan antes de llegar a producción.
+- Puedo probar que seguimos buenas prácticas de seguridad.
+
+Resultado: entregamos una aplicación confiable sin sorpresas.

--- a/docs/product-user-experience.md
+++ b/docs/product-user-experience.md
@@ -1,0 +1,12 @@
+# Product User Experience — Why EventFlow is for me?
+
+EventFlow me ayuda a planificar y disfrutar eventos sin fricciones. Estas historias muestran cómo se vive cada funcionalidad:
+
+- [Explorar y registrar charlas a mi ritmo](features/event-discovery-registration.md)
+- [Entrar con mi cuenta Google en segundos](features/google-sign-in.md)
+- [Panel de control seguro para organizadores](features/admin-area.md)
+- [Carga masiva sin dolores](features/import-events.md)
+- [Notificaciones que me acompañan sin estorbar](features/notifications.md)
+- [Confianza de extremo a extremo](features/supply-chain-security.md)
+
+Cada experiencia está pensada para que la aplicación se adapte a mí, no al revés.


### PR DESCRIPTION
## Summary
- add product user experience index with feature links
- document user stories for notifications, event planning, Google sign-in, admin area, imports and supply chain security

## Testing
- `mvn -f quarkus-app/pom.xml -q test`

------
https://chatgpt.com/codex/tasks/task_e_68afba5b63888333b01c8be36882a4f5