### PR TITLE
fix: attach auth token to fetch requests

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -2,6 +2,11 @@
   const origFetch = window.fetch;
   window.fetch = async function(input, init = {}) {
     if (!init.credentials) { init.credentials = 'include'; }
+    init.headers = new Headers(init.headers || {});
+    if (!init.headers.has('Authorization')) {
+      const token = sessionStorage.getItem('token') || localStorage.getItem('token');
+      if (token) { init.headers.set('Authorization', `Bearer ${token}`); }
+    }
     const res = await origFetch(input, init);
     if (res.status === 401 && res.headers.get('X-Session-Expired') === 'true') {
       try { sessionStorage.clear(); localStorage.clear(); } catch (e) {}


### PR DESCRIPTION
## Summary
- automatically set Authorization header on fetch when a token is stored in session or local storage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afbe8171d883339555023139706b87