### PR TITLE
feat: add notification bell with unread badge

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -154,3 +154,38 @@
   clip: rect(0, 0, 0, 0);
   border: 0;
 }
+
+/* Bell in navigation bar */
+.notifications-bell {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  text-decoration: none;
+  color: inherit;
+}
+
+.notifications-bell:focus {
+  outline: 2px solid #000;
+  outline-offset: 2px;
+}
+
+.notifications-bell .icon {
+  font-size: 1.25rem;
+}
+
+.notifications-bell .badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: #d00;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0 4px;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  min-width: 1.2em;
+  text-align: center;
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -101,8 +101,37 @@
   }
   const container=document.getElementById('ef-toast-container');
   const manager=container?new ToastQueueManager(container):null;
+  const badge=document.querySelector('[data-notifications-badge]');
+  const sr=document.querySelector('[data-notifications-sr]');
+  let unread=0;
+
+  function renderBadge(){
+    if(!badge)return;
+    if(unread>0){
+      badge.textContent=String(unread);
+      badge.hidden=false;
+      if(sr) sr.textContent=unread===1?`1 notificación nueva`:`${unread} notificaciones nuevas`;
+    }else{
+      badge.hidden=true;
+      if(sr) sr.textContent='';
+    }
+  }
+
+  async function fetchUnread(){
+    try{
+      const res=await fetch('/api/notifications?limit=1',{cache:'no-store',credentials:'include'});
+      if(res.ok){
+        const data=await res.json();
+        unread=data.unreadCount||0;
+        renderBadge();
+      }
+    }catch(_){}
+  }
+  if(badge){window.addEventListener('DOMContentLoaded',fetchUnread);}
+
   window.EventFlowNotifications={
     accept(dto){
+      unread++;renderBadge();
       if(!manager)return;
       const vm={
         id:dto.id||uid(),

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -20,6 +20,11 @@
             {#if app:isAdmin()}
                 <a href="/private/admin" data-nav-link>Admin</a>
             {/if}
+            <a href="/notifications/center" class="notifications-bell" aria-label="Notificaciones" aria-controls="notifications-center" data-nav-link>
+                <span class="icon" aria-hidden="true">🔔</span>
+                <span class="badge" data-notifications-badge aria-hidden="true" hidden></span>
+                <span class="sr-only" data-notifications-sr aria-live="polite"></span>
+            </a>
             <div class="user-menu" data-user-menu>
                 <button id="userMenuBtn" class="user-menu-btn" data-user-menu-btn aria-label="Usuario" aria-expanded="false" aria-controls="userDropdown">
                     {#if app:userAvatar()}


### PR DESCRIPTION
## Summary
- add notifications bell linking to notifications center
- style bell and badge with accessible focus
- load unread count and update badge in real time

## Testing
- `mvn -q -Dtest=NotificationResourceTest#listReturnsOnlyOwnNotifications test`


------
https://chatgpt.com/codex/tasks/task_e_68afc19d8bf4833393425b63ec4909d7