### PR TITLE
Register JavaTimeModule for persistence

### DIFF
--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -11,13 +11,13 @@ Under the hood, this demo uses:
 
 To compile and run this demo you will need:
 
-- JDK 17+
+- JDK 21
 - GraalVM
 
-### Configuring GraalVM and JDK 17+
+### Configuring GraalVM and JDK 21
 
 Make sure that both the `GRAALVM_HOME` and `JAVA_HOME` environment variables have
-been set, and that a JDK 17+ `java` command is on the path.
+been set, and that a JDK 21 `java` command is on the path.
 
 See the [Building a Native Executable guide](https://quarkus.io/guides/building-native-image-guide)
 for help setting up your environment.

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -111,6 +111,10 @@
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/PersistenceService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.model.Speaker;
 import jakarta.annotation.PostConstruct;
@@ -66,7 +67,9 @@ public class PersistenceService {
         objectMapper
             .copy()
             .enable(SerializationFeature.INDENT_OUTPUT)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .registerModule(new JavaTimeModule());
     try {
       Files.createDirectories(dataDir);
       LOG.infov("Using data directory {0}", dataDir.toAbsolutePath());

--- a/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminCapacityResource/index.html
@@ -5,7 +5,7 @@
 <section>
     <h1 class="page-title">Control de capacidad</h1>
     <ul class="card">
-        <li>Modo actual: {status.mode == 'ADMITTING' ? 'Admitiendo' : 'Conteniendo nuevos logins'}</li>
+        <li>Modo actual: {#if status.mode == 'ADMITTING'}Admitiendo{#else}Conteniendo nuevos logins{/if}</li>
         <li>Usuarios activos en memoria: {status.activeUsers}</li>
         <li>% de memoria usada: {status.memoryPercent}%</li>
         <li>% de disco libre: {status.diskFreePercent}%</li>

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -22,8 +22,7 @@ Evento
       <div class="event-info">
         <h1 class="page-title">{event.title}</h1>
         {#if event.formattedDate}
-        <p class="event-datetime">{event.formattedDate} | {event.startTimeStr} – {event.endTimeStr} hrs{#if
-          event.timezone} ({event.timezone}){/if}.</p>
+        <p class="event-datetime">{event.formattedDate} | {event.startTimeStr} – {event.endTimeStr} hrs{#if event.timezone} ({event.timezone}){/if}.</p>
         {/if}
         {#if event.description}
         <p class="event-description">{event.description}</p>


### PR DESCRIPTION
## Summary
- ensure PersistenceService can serialize java.time types by registering Jackson's JavaTimeModule and disabling timestamp output
- declare jackson-datatype-jsr310 dependency
- document Java 21 requirement and clean up Qute templates

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68afc7881d808333a4fc02892ba2ba4c