### PR TITLE
fix: handle missing user for notifications center

### DIFF
--- a/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationPageResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationPageResource.java
@@ -32,7 +32,12 @@ public class NotificationPageResource {
   @Path("/center")
   @Produces(MediaType.TEXT_HTML)
   public TemplateInstance center() {
-    var page = service.listPage(userId(), "all", null, 20);
+    String user = userId();
+    if (user == null) {
+      throw new jakarta.ws.rs.WebApplicationException(
+          "user not found", jakarta.ws.rs.core.Response.Status.UNAUTHORIZED);
+    }
+    var page = service.listPage(user, "all", null, 20);
     return Templates.center(NotificationListResponse.from(page));
   }
 }

--- a/quarkus-app/src/main/java/io/eventflow/notifications/rest/SecurityIdentityUser.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/rest/SecurityIdentityUser.java
@@ -7,6 +7,9 @@ public final class SecurityIdentityUser {
   private SecurityIdentityUser() {}
 
   public static String id(SecurityIdentity identity) {
+    if (identity == null || identity.isAnonymous()) {
+      return null;
+    }
     String email = identity.getAttribute("email");
     if (email == null && identity.getPrincipal() != null) {
       email = identity.getPrincipal().getName();

--- a/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationPageResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationPageResourceTest.java
@@ -1,0 +1,50 @@
+package io.eventflow.notifications.rest;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import com.scanales.eventflow.notifications.NotificationConfig;
+import com.scanales.eventflow.notifications.NotificationService;
+import com.scanales.eventflow.notifications.NotificationType;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the notifications center page. */
+@QuarkusTest
+public class NotificationPageResourceTest {
+
+  @Inject NotificationService service;
+  @Inject NotificationConfig config;
+
+  @BeforeEach
+  void setup() {
+    config.enabled = true;
+    service.reset();
+    // enqueue a sample notification for the authenticated user
+    var n = new com.scanales.eventflow.notifications.Notification();
+    n.userId = "u1";
+    n.talkId = "t1";
+    n.type = NotificationType.STARTED;
+    n.title = "hello";
+    service.enqueue(n);
+  }
+
+  @Test
+  public void centerRequiresAuth() {
+    given().when().get("/notifications/center").then().statusCode(401);
+  }
+
+  @Test
+  @TestSecurity(user = "u1")
+  public void centerRendersForUser() {
+    given()
+        .when()
+        .get("/notifications/center")
+        .then()
+        .statusCode(200)
+        .body(containsString("Notificaciones"));
+  }
+}


### PR DESCRIPTION
## Summary
- avoid 500 when visiting notifications center without user id
- treat anonymous SecurityIdentity as missing user
- add tests for notifications center page

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68b036a24130833387493f0cd08a5498