### PR TITLE
Avoid repeated reload on session expiry

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -89,7 +89,10 @@ window.addEventListener('DOMContentLoaded', () => {
         es.close();
         try {
           const check = await fetch('/api/notifications/stream', { credentials: 'include' });
-          if (check.status === 401) { location.assign('/?session=expired'); return; }
+          if (check.status === 401 && !location.search.includes('session=expired')) {
+            location.assign('/?session=expired');
+            return;
+          }
         } catch(_){}
         if(window.__metrics) window.__metrics.count('ui.notifications.sse.fallback_polling');
         startPolling();
@@ -105,7 +108,10 @@ window.addEventListener('DOMContentLoaded', () => {
           cache: 'no-store',
           credentials: 'include'
         });
-        if (res.status === 401) { location.assign('/?session=expired'); return; }
+        if (res.status === 401 && !location.search.includes('session=expired')) {
+          location.assign('/?session=expired');
+          return;
+        }
         const data = await res.json();
         (data.items || []).forEach(onDTO);
       } catch(_) {}
@@ -121,7 +127,10 @@ window.addEventListener('DOMContentLoaded', () => {
         credentials: 'include'
       })
         .then(r => {
-          if (r.status === 401) { location.assign('/?session=expired'); return null; }
+          if (r.status === 401 && !location.search.includes('session=expired')) {
+            location.assign('/?session=expired');
+            return null;
+          }
           return r.ok ? r.json() : null;
         })
         .then(d => (d?.items || []).forEach(onDTO))


### PR DESCRIPTION
## Summary
- prevent redirect loop when notification requests return 401

## Testing
- `pytest tests/test_enforce_severity.py -q`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b080e602508333af6b603e8813b88c