### PR TITLE
refactor: centralize user extraction for notifications

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationPollingResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationPollingResource.java
@@ -1,5 +1,6 @@
 package com.scanales.eventflow.notifications;
 
+import io.eventflow.notifications.rest.SecurityIdentityUser;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
@@ -24,11 +25,7 @@ public class NotificationPollingResource {
   @Path("/next")
   @Produces(MediaType.APPLICATION_JSON)
   public Response next(@QueryParam("since") long since, @QueryParam("limit") Integer limit) {
-    Object emailAttr = identity.getAttribute("email");
-    String user = emailAttr != null ? emailAttr.toString() : null;
-    if (user == null && identity.getPrincipal() != null) {
-      user = identity.getPrincipal().getName();
-    }
+    String user = SecurityIdentityUser.id(identity);
     if (user == null) {
       return Response.status(Response.Status.UNAUTHORIZED).build();
     }

--- a/quarkus-app/src/main/java/io/eventflow/notifications/rest/SecurityIdentityUser.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/rest/SecurityIdentityUser.java
@@ -10,7 +10,8 @@ public final class SecurityIdentityUser {
     if (identity == null || identity.isAnonymous()) {
       return null;
     }
-    String email = identity.getAttribute("email");
+    Object emailAttr = identity.getAttribute("email");
+    String email = emailAttr != null ? emailAttr.toString() : null;
     if (email == null && identity.getPrincipal() != null) {
       email = identity.getPrincipal().getName();
     }

--- a/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationPollingResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/notifications/NotificationPollingResourceTest.java
@@ -55,4 +55,14 @@ class NotificationPollingResourceTest {
         .header("Cache-Control", containsString("no-store"))
         .header("X-User-Scoped", is("true"));
   }
+
+  @Test
+  void unauthenticatedIsUnauthorized() {
+    given()
+        .queryParam("since", 0L)
+        .when()
+        .get("/api/notifications/next")
+        .then()
+        .statusCode(401);
+  }
 }


### PR DESCRIPTION
## Summary
- use `SecurityIdentityUser.id` in `NotificationPollingResource`
- harden `SecurityIdentityUser.id` to handle non-string attributes
- test unauthenticated access for polling endpoint

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b0915be37083339aed527568bec9c7