### PR TITLE
Handle expired sessions for notifications

### DIFF
--- a/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationPageResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationPageResource.java
@@ -35,7 +35,9 @@ public class NotificationPageResource {
     String user = userId();
     if (user == null) {
       throw new jakarta.ws.rs.WebApplicationException(
-          "user not found", jakarta.ws.rs.core.Response.Status.UNAUTHORIZED);
+          jakarta.ws.rs.core.Response.status(jakarta.ws.rs.core.Response.Status.UNAUTHORIZED)
+              .header("X-Session-Expired", "true")
+              .build());
     }
     var page = service.listPage(user, "all", null, 20);
     return Templates.center(NotificationListResponse.from(page));

--- a/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationResource.java
@@ -30,6 +30,12 @@ public class NotificationResource {
     return SecurityIdentityUser.id(identity);
   }
 
+  private Response unauthorized() {
+    return Response.status(Response.Status.UNAUTHORIZED)
+        .header("X-Session-Expired", "true")
+        .build();
+  }
+
   @GET
   public Response list(
       @QueryParam("filter") String filter,
@@ -37,7 +43,7 @@ public class NotificationResource {
       @QueryParam("limit") @DefaultValue("20") @Min(1) @Max(100) int limit) {
     String userId = userId();
     if (userId == null) {
-      return Response.status(Response.Status.UNAUTHORIZED).build();
+      return unauthorized();
     }
     var page = service.listPage(userId, filter, cursor, limit);
     return scoped(Response.ok(NotificationListResponse.from(page))).build();
@@ -48,7 +54,7 @@ public class NotificationResource {
   public Response markRead(@PathParam("id") String id) {
     String userId = userId();
     if (userId == null) {
-      return Response.status(Response.Status.UNAUTHORIZED).build();
+      return unauthorized();
     }
     boolean ok = service.markRead(userId, id);
     if (!ok) {
@@ -62,7 +68,7 @@ public class NotificationResource {
   public Response readAll() {
     String userId = userId();
     if (userId == null) {
-      return Response.status(Response.Status.UNAUTHORIZED).build();
+      return unauthorized();
     }
     service.markAllRead(userId);
     return scoped(Response.noContent()).build();
@@ -73,7 +79,7 @@ public class NotificationResource {
   public Response delete(@PathParam("id") String id) {
     String userId = userId();
     if (userId == null) {
-      return Response.status(Response.Status.UNAUTHORIZED).build();
+      return unauthorized();
     }
     boolean ok = service.delete(userId, id);
     if (!ok) {
@@ -87,7 +93,7 @@ public class NotificationResource {
   public Response bulkDelete(@Valid BulkDeleteRequest req) {
     String userId = userId();
     if (userId == null) {
-      return Response.status(Response.Status.UNAUTHORIZED).build();
+      return unauthorized();
     }
     if (req == null || req.ids == null || req.ids.isEmpty() || req.ids.size() > 100) {
       return Response.status(Response.Status.BAD_REQUEST).build();

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -72,7 +72,14 @@ window.addEventListener('DOMContentLoaded', () => {
       window.__metrics.count('ui.notifications.received');
     }
   }
-  const url = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/api/notifications/ws';
+  const token = sessionStorage.getItem('token') || localStorage.getItem('token');
+  let url =
+    (location.protocol === 'https:' ? 'wss://' : 'ws://') +
+    location.host +
+    '/api/notifications/ws';
+  if (token) {
+    url += '?access_token=' + encodeURIComponent(token);
+  }
   function connect(){
     const ws = new WebSocket(url);
     ws.onmessage = (ev) => {

--- a/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationResourceTest.java
@@ -67,4 +67,14 @@ public class NotificationResourceTest {
         .then()
         .statusCode(404);
   }
+
+  @Test
+  public void unauthorizedRequestsReturn401() {
+    given()
+        .when()
+        .get("/api/notifications")
+        .then()
+        .statusCode(401)
+        .header("X-Session-Expired", is("true"));
+  }
 }


### PR DESCRIPTION
## Summary
- Propagate `X-Session-Expired` header when the user is missing in notification endpoints
- Require the same header for the notifications page
- Pass stored access token when opening the notification WebSocket
- Test that unauthenticated notification requests return 401 with the header

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2a3ad448333a0341b9203a32ec9