### PR TITLE
Reinstate async notification persistence

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/FileIO.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/FileIO.java
@@ -15,7 +15,8 @@ public final class FileIO {
     Path tmp = path.resolveSibling(path.getFileName() + ".tmp");
     Files.write(tmp, data, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     try (FileChannel ch = FileChannel.open(tmp, StandardOpenOption.WRITE)) {
-      ch.force(true);
+      // Flush file data without forcing metadata for better throughput
+      ch.force(false);
     }
     Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
   }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationRepository.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationRepository.java
@@ -78,6 +78,11 @@ public class NotificationRepository {
 
   /** Schedules persistence of the full list for a user. */
   public void replace(String userId, List<Notification> list) {
+    // Avoid expensive serialization when the writer queue is full.
+    if (queue.remainingCapacity() == 0) {
+      return;
+    }
+
     byte[] data;
     try {
       data = mapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(list);


### PR DESCRIPTION
## Summary
- Restore asynchronous in-memory notification service with file-based writer
- Skip serialization when writer queue is full and drop metadata flush for faster persistence

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b10bf94b288333928c739972add7b7