### PR TITLE
Add session refresh endpoint for notifications

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/SessionResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/SessionResource.java
@@ -1,13 +1,16 @@
 package com.scanales.eventflow.security;
 
+import io.quarkus.oidc.OidcSession;
 import io.quarkus.security.Authenticated;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import java.util.Map;
+import org.eclipse.microprofile.jwt.Claims;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 /** Simple endpoint to report session status. */
@@ -15,6 +18,7 @@ import org.eclipse.microprofile.jwt.JsonWebToken;
 public class SessionResource {
 
   @Inject SecurityIdentity identity;
+  @Inject OidcSession oidcSession;
 
   @GET
   @Authenticated
@@ -24,10 +28,29 @@ public class SessionResource {
     JsonWebToken jwt = null;
     if (identity.getPrincipal() instanceof JsonWebToken jw) {
       jwt = jw;
+    } else if (oidcSession != null) {
+      jwt = oidcSession.getIdToken();
     }
     if (jwt != null) {
-      exp = jwt.getExpirationTime();
+      Object claim = jwt.getClaim(Claims.exp.name());
+      if (claim instanceof Long l) {
+        exp = l;
+      } else if (claim instanceof Integer i) {
+        exp = i.longValue();
+      }
     }
     return Map.of("active", true, "exp", exp);
+  }
+
+  @POST
+  @Path("/refresh")
+  @Authenticated
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, Object> refresh() {
+    // Simply accessing the ID token ensures the session remains active
+    if (oidcSession != null) {
+      oidcSession.getIdToken();
+    }
+    return session();
   }
 }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -38,6 +38,7 @@ quarkus.jackson.serialization-inclusion=non-null
 quarkus.http.proxy.proxy-address-forwarding=true
 quarkus.http.proxy.allow-forwarded=true
 quarkus.http.auth.session.encryption-key=${SESSION_KEY}
+quarkus.http.auth.session.timeout=PT15M
 quarkus.http.auth.permission.private.paths=/private/*
 quarkus.http.auth.permission.private.policy=authenticated
 

--- a/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/security/SessionResourceTest.java
@@ -1,0 +1,24 @@
+package com.scanales.eventflow.security;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import org.junit.jupiter.api.Test;
+
+/** Tests for session refresh endpoint. */
+@QuarkusTest
+public class SessionResourceTest {
+
+  @Test
+  @TestSecurity(user = "user@example.com")
+  public void refreshKeepsSessionActive() {
+    given()
+        .when()
+        .post("/auth/session/refresh")
+        .then()
+        .statusCode(200)
+        .body("active", is(true));
+  }
+}


### PR DESCRIPTION
## Summary
- add session refresh endpoint and token lookup
- set short session timeout
- cover session refresh with test

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68b1149d9cec8333a8b711ba8acfc13a