### PR TITLE
Ensure notifications respect existing security and allow auth center

### DIFF
--- a/quarkus-app/src/main/java/io/eventflow/notifications/NotificationWebSocket.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/NotificationWebSocket.java
@@ -2,8 +2,6 @@ package io.eventflow.notifications;
 
 import com.scanales.eventflow.notifications.NotificationConfig;
 import com.scanales.eventflow.notifications.NotificationSocketService;
-import io.eventflow.notifications.rest.SecurityIdentityUser;
-import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
 import jakarta.websocket.CloseReason;
 import jakarta.websocket.OnClose;
@@ -19,7 +17,6 @@ public class NotificationWebSocket {
 
   private static final Logger LOG = Logger.getLogger(NotificationWebSocket.class);
 
-  @Inject SecurityIdentity identity;
   @Inject NotificationSocketService sessions;
   @Inject NotificationConfig config;
 
@@ -29,8 +26,11 @@ public class NotificationWebSocket {
       session.close(new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "disabled"));
       return;
     }
-    String user = SecurityIdentityUser.id(identity);
-    if (user == null) {
+    String user = null;
+    if (session.getUserPrincipal() != null) {
+      user = session.getUserPrincipal().getName();
+    }
+    if (user == null || user.isBlank()) {
       session.close(new CloseReason(CloseReason.CloseCodes.VIOLATED_POLICY, "unauthorized"));
       return;
     }

--- a/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationPageResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/rest/NotificationPageResource.java
@@ -5,6 +5,7 @@ import io.eventflow.notifications.api.NotificationListResponse;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -28,6 +29,7 @@ public class NotificationPageResource {
 
   @GET
   @Path("/center")
+  @Authenticated
   @Produces(MediaType.TEXT_HTML)
   public TemplateInstance center() {
     String user = userId();


### PR DESCRIPTION
## Summary
- Obtain WebSocket user from session principal and reject anonymous connections
- Require authentication for notification center page so logged-in users can access

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68b12161a61083339f74ce30c68508fa