### PR TITLE
feat: event and break notifications with five-minute windows

### DIFF
--- a/docs/en/tasks/event-break-notifications.md
+++ b/docs/en/tasks/event-break-notifications.md
@@ -1,0 +1,10 @@
+# Tasks – Event and break notifications
+
+To support the requirement of notifying state changes for events and break slots five minutes before they start or end, implement the following tasks:
+
+- [ ] Set `notifications.upcoming.window` and `notifications.endingSoon.window` defaults to **PT5M**.
+- [ ] Create an `EventStateEvaluator` to emit `UPCOMING`, `STARTED`, `ENDING_SOON` and `FINISHED` notifications for the overall event.
+- [ ] Evaluate break slots (talks marked as `break`) and emit the same state notifications, reusing `TalkStateEvaluator` or introducing a dedicated evaluator.
+- [ ] Surface event and break notifications in the notification center alongside talk alerts.
+- [ ] Update documentation to describe event and break coverage and the new five‑minute windows.
+- [ ] Add integration tests that verify event and break notifications are enqueued at the expected times.

--- a/docs/notifications-global-ws.md
+++ b/docs/notifications-global-ws.md
@@ -19,12 +19,25 @@ Configuration is done via `application.properties`:
 - `notifications.global.enabled`
 - `notifications.global.buffer-size`
 - `notifications.global.dedupe-window`
+- `notifications.upcoming.window` (default `PT5M`)
+- `notifications.endingSoon.window` (default `PT5M`)
 
 The browser script `global-notifications-ws.js` connects automatically and forwards notifications to `window.EventFlowNotifications.accept` for toast display. It also stores messages locally so the notifications center page can render them without hitting the backend.
 
 ## Notification center
 
 Visitors can review the backlog of global notices at `/notifications/center`. The page is rendered entirely on the client using data from `localStorage` and offers filters for unread or recent messages as well as local actions to mark notifications as read or remove them.
+
+### Event and break notifications
+
+State changes for events and break slots are published five minutes before they begin or end. The `category` field distinguishes the source and notifications are deduplicated by `(category, id, type, slotEdge)` in the event's time zone.
+
+Example payloads:
+
+```json
+{"id":"01","type":"UPCOMING","category":"event","eventId":"e1","title":"El evento comienza pronto","message":"Conf"}
+{"id":"02","type":"STARTED","category":"break","eventId":"e1","talkId":"b1","title":"Break en curso","message":"Coffee break"}
+```
 
 ## Admin broadcast
 

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/BreakStateEvaluator.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/BreakStateEvaluator.java
@@ -1,0 +1,79 @@
+package io.eventflow.notifications.global;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.*;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/** Evaluates break slots to emit global notifications. */
+@ApplicationScoped
+public class BreakStateEvaluator {
+
+  @ConfigProperty(name = "notifications.upcoming.window", defaultValue = "PT5M")
+  Duration upcomingWin;
+
+  @ConfigProperty(name = "notifications.endingSoon.window", defaultValue = "PT5M")
+  Duration endingWin;
+
+  @Inject GlobalNotificationService global;
+  @Inject EventService events;
+  @Inject Clock clock;
+
+  @Scheduled(every = "{notifications.scheduler.interval}")
+  void tick() {
+    if (!GlobalNotificationConfig.enabled) return;
+    ZonedDateTime now = ZonedDateTime.now(clock);
+    for (Event ev : events.listEvents()) {
+      ZoneId tz = ev.getZoneId();
+      for (Talk t : ev.getAgenda()) {
+        if (!t.isBreak() || t.getStartTime() == null) continue;
+        if (ev.getDate() == null) continue;
+        ZonedDateTime start = ZonedDateTime.of(
+            ev.getDate().plusDays(t.getDay() - 1), t.getStartTime(), tz);
+        ZonedDateTime end = start.plusMinutes(t.getDurationMinutes());
+        ZonedDateTime nowTz = now.withZoneSameInstant(tz);
+        if (inWindow(nowTz, start.minus(upcomingWin), start)) {
+          enqueue(ev, t, "UPCOMING", start);
+        }
+        if (!nowTz.isBefore(start) && nowTz.isBefore(end)) {
+          enqueue(ev, t, "STARTED", start);
+        }
+        if (inWindow(nowTz, end.minus(endingWin), end)) {
+          enqueue(ev, t, "ENDING_SOON", end);
+        }
+        if (!nowTz.isBefore(end)) {
+          enqueue(ev, t, "FINISHED", end);
+        }
+      }
+    }
+  }
+
+  private boolean inWindow(ZonedDateTime now, ZonedDateTime from, ZonedDateTime to) {
+    return !now.isBefore(from) && now.isBefore(to);
+  }
+
+  private void enqueue(Event ev, Talk t, String type, ZonedDateTime edge) {
+    String dedupeKey = String.format(
+        "global:break:%s:%s:%d", t.getId(), type, edge.toEpochSecond());
+    GlobalNotification n = new GlobalNotification();
+    n.type = type;
+    n.category = "break";
+    n.eventId = ev.getId();
+    n.talkId = t.getId();
+    n.title = switch (type) {
+      case "UPCOMING" -> "Break comienza pronto";
+      case "STARTED" -> "Break en curso";
+      case "ENDING_SOON" -> "Break por finalizar";
+      case "FINISHED" -> "Break finalizado";
+      default -> "Break";
+    };
+    n.message = t.getName();
+    n.createdAt = Instant.now(clock).toEpochMilli();
+    n.dedupeKey = dedupeKey;
+    global.enqueue(n);
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/ClockProducer.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/ClockProducer.java
@@ -1,0 +1,14 @@
+package io.eventflow.notifications.global;
+
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import java.time.Clock;
+
+/** Provides a default system clock for injection. */
+@Singleton
+public class ClockProducer {
+  @Produces
+  public Clock clock() {
+    return Clock.systemUTC();
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/EventStateEvaluator.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/EventStateEvaluator.java
@@ -1,0 +1,77 @@
+package io.eventflow.notifications.global;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.scheduler.Scheduled;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.*;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/** Evaluates event state transitions to emit global notifications. */
+@ApplicationScoped
+public class EventStateEvaluator {
+
+  @ConfigProperty(name = "notifications.upcoming.window", defaultValue = "PT5M")
+  Duration upcomingWin;
+
+  @ConfigProperty(name = "notifications.endingSoon.window", defaultValue = "PT5M")
+  Duration endingWin;
+
+  @Inject GlobalNotificationService global;
+  @Inject EventService events;
+  @Inject Clock clock;
+
+  @Scheduled(every = "{notifications.scheduler.interval}")
+  void tick() {
+    if (!GlobalNotificationConfig.enabled) return;
+    ZonedDateTime now = ZonedDateTime.now(clock);
+    for (Event ev : events.listEvents()) {
+      ZonedDateTime start = ev.getStartDateTime();
+      ZonedDateTime end = ev.getEndDateTime();
+      if (start == null || end == null) continue;
+      ZoneId tz = ev.getZoneId();
+      ZonedDateTime nowTz = now.withZoneSameInstant(tz);
+      // UPCOMING
+      if (inWindow(nowTz, start.minus(upcomingWin), start)) {
+        enqueue(ev, "UPCOMING", start);
+      }
+      // STARTED
+      if (!nowTz.isBefore(start) && nowTz.isBefore(end)) {
+        enqueue(ev, "STARTED", start);
+      }
+      // ENDING_SOON
+      if (inWindow(nowTz, end.minus(endingWin), end)) {
+        enqueue(ev, "ENDING_SOON", end);
+      }
+      // FINISHED
+      if (!nowTz.isBefore(end)) {
+        enqueue(ev, "FINISHED", end);
+      }
+    }
+  }
+
+  private boolean inWindow(ZonedDateTime now, ZonedDateTime from, ZonedDateTime to) {
+    return !now.isBefore(from) && now.isBefore(to);
+  }
+
+  private void enqueue(Event ev, String type, ZonedDateTime edge) {
+    String dedupeKey = String.format(
+        "global:event:%s:%s:%d", ev.getId(), type, edge.toEpochSecond());
+    GlobalNotification n = new GlobalNotification();
+    n.type = type;
+    n.category = "event";
+    n.eventId = ev.getId();
+    n.title = switch (type) {
+      case "UPCOMING" -> "El evento comienza pronto";
+      case "STARTED" -> "El evento está en curso";
+      case "ENDING_SOON" -> "El evento está por finalizar";
+      case "FINISHED" -> "El evento ha finalizado";
+      default -> "Evento";
+    };
+    n.message = ev.getTitle();
+    n.createdAt = Instant.now(clock).toEpochMilli();
+    n.dedupeKey = dedupeKey;
+    global.enqueue(n);
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotification.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotification.java
@@ -6,7 +6,9 @@ package io.eventflow.notifications.global;
 public class GlobalNotification {
   public String id; // ULID/UUID
   public String type; // e.g. AGENDA_UPDATED
+  public String category; // "event" | "break" | "talk" | "announcement"
   public String eventId; // optional
+  public String talkId; // optional (required for category=break)
   public String title;
   public String message;
   public long createdAt; // epoch millis

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -20,13 +20,14 @@
     items.sort((a,b)=>(b.createdAt||0)-(a.createdAt||0)).forEach(n=>{
       const div = document.createElement('div');
       div.className = 'card notif';
+      const label = n.category==='event' ? 'Evento' : n.category==='break' ? 'Break' : n.category==='talk' ? 'Charla' : null;
       div.innerHTML = `
         <label class="row">
           <input type="checkbox" class="sel" data-id="${n.id}">
           <div class="col grow">
             <div class="title">${(n.title||'Aviso')}</div>
             <div class="msg">${(n.message||'')}</div>
-            <div class="meta">${new Date(n.createdAt||Date.now()).toLocaleString()}</div>
+            <div class="meta">${label?`<span class="chip">${label}</span>`:''} ${new Date(n.createdAt||Date.now()).toLocaleString()}</div>
           </div>
           <div class="col">
             <button class="btn-link" data-act="read" data-id="${n.id}">${n.readAt?'Leída':'Marcar leída'}</button>

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -65,8 +65,8 @@ quarkus.package.main-class=com.scanales.eventflow.VertxCacheFixMain
 # Notifications runtime integration
 notifications.scheduler.enabled=true
 notifications.scheduler.interval=PT15S
-notifications.upcoming.window=PT15M
-notifications.endingSoon.window=PT10M
+notifications.upcoming.window=PT5M
+notifications.endingSoon.window=PT5M
 notifications.ws.enabled=false
 notifications.stream.maxConnectionsPerUser=1
 

--- a/quarkus-app/src/test/java/io/eventflow/notifications/global/EventAndBreakEvaluatorTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/global/EventAndBreakEvaluatorTest.java
@@ -1,0 +1,110 @@
+package io.eventflow.notifications.global;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.time.*;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class EventAndBreakEvaluatorTest {
+
+  @Inject EventService events;
+  @Inject EventStateEvaluator eventEval;
+  @Inject BreakStateEvaluator breakEval;
+  @Inject GlobalNotificationService global;
+  @Inject Clock clock;
+
+  @Singleton
+  @Alternative
+  @Priority(1)
+  public static class TestClock extends Clock {
+    private Instant instant = Instant.now();
+    private ZoneId zone = ZoneOffset.UTC;
+    public void set(Instant i){ this.instant = i; }
+    @Override public ZoneId getZone(){ return zone; }
+    @Override public Clock withZone(ZoneId zone){ this.zone = zone; return this; }
+    @Override public Instant instant(){ return instant; }
+  }
+
+  private TestClock tc(){ return (TestClock) clock; }
+
+  @BeforeEach
+  void setup(){
+    events.reset();
+    for (GlobalNotification g : global.latest(1000)) { global.removeById(g.id); }
+  }
+
+  @Test
+  void eventLifecycle() {
+    Event e = new Event("e1","Ev","d");
+    e.setDate(LocalDate.of(2023,1,1));
+    e.setTimezone("UTC");
+    Talk t1 = new Talk("t1","t1"); t1.setStartTime(LocalTime.of(10,0)); t1.setDurationMinutes(60);
+    Talk t2 = new Talk("t2","t2"); t2.setStartTime(LocalTime.of(11,0)); t2.setDurationMinutes(60);
+    e.getAgenda().addAll(List.of(t1,t2));
+    events.saveEvent(e);
+
+    tc().set(Instant.parse("2023-01-01T09:55:00Z"));
+    eventEval.tick();
+    assertEquals(1, count("event","UPCOMING"));
+    eventEval.tick();
+    assertEquals(1, count("event","UPCOMING"));
+
+    tc().set(Instant.parse("2023-01-01T10:00:00Z"));
+    eventEval.tick();
+    assertEquals(1, count("event","STARTED"));
+
+    tc().set(Instant.parse("2023-01-01T11:55:00Z"));
+    eventEval.tick();
+    assertEquals(1, count("event","ENDING_SOON"));
+
+    tc().set(Instant.parse("2023-01-01T12:00:00Z"));
+    eventEval.tick();
+    assertEquals(1, count("event","FINISHED"));
+  }
+
+  @Test
+  void breakLifecycle() {
+    Event e = new Event("e1","Ev","d");
+    e.setDate(LocalDate.of(2023,1,1));
+    e.setTimezone("UTC");
+    Talk b = new Talk("b1","Coffee");
+    b.setStartTime(LocalTime.of(15,0));
+    b.setDurationMinutes(15);
+    b.setBreak(true);
+    e.getAgenda().add(b);
+    events.saveEvent(e);
+
+    tc().set(Instant.parse("2023-01-01T14:55:00Z"));
+    breakEval.tick();
+    assertEquals(1, count("break","UPCOMING"));
+
+    tc().set(Instant.parse("2023-01-01T15:00:00Z"));
+    breakEval.tick();
+    assertEquals(1, count("break","STARTED"));
+
+    tc().set(Instant.parse("2023-01-01T15:10:00Z"));
+    breakEval.tick();
+    assertEquals(1, count("break","ENDING_SOON"));
+
+    tc().set(Instant.parse("2023-01-01T15:15:00Z"));
+    breakEval.tick();
+    assertEquals(1, count("break","FINISHED"));
+  }
+
+  private long count(String category, String type){
+    return global.latest(1000).stream()
+        .filter(n -> type.equals(n.type) && category.equals(n.category))
+        .count();
+  }
+}

--- a/quarkus-app/src/test/resources/application.properties
+++ b/quarkus-app/src/test/resources/application.properties
@@ -4,3 +4,5 @@ metrics.flush-interval=PT1H
 metrics.trend.min-baseline=20
 metrics.trend.decimals=1
 metrics.min-view-threshold=0
+notifications.upcoming.window=PT5M
+notifications.endingSoon.window=PT5M


### PR DESCRIPTION
## Summary
- add event and break state evaluators pushing global notifications
- show event/break categories in notification center and docs
- integration tests for notification timelines

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b32443773c8333832b494c431560ce