### PR TITLE
refactor(notifications): remove profile test controls and legacy endpoint

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -3,9 +3,6 @@ package com.scanales.eventflow.private_;
 import com.scanales.eventflow.model.Talk;
 import com.scanales.eventflow.model.TalkInfo;
 import com.scanales.eventflow.service.EventService;
-import com.scanales.eventflow.notifications.NotificationService;
-import com.scanales.eventflow.notifications.Notification;
-import com.scanales.eventflow.notifications.NotificationType;
 import com.scanales.eventflow.service.UsageMetricsService;
 import com.scanales.eventflow.service.UserScheduleService;
 import com.scanales.eventflow.service.UserScheduleService.TalkDetails;
@@ -68,7 +65,6 @@ public class ProfileResource {
 
   @Inject UsageMetricsService metrics;
 
-  @Inject NotificationService notifications;
 
   @GET
   @Authenticated
@@ -237,33 +233,6 @@ public class ProfileResource {
         .build();
   }
 
-  @POST
-  @Path("test-notification")
-  @Authenticated
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
-  public Response testNotification(Map<String, String> body) {
-    String talkId = body != null ? body.get("talkId") : null;
-    if (talkId == null || talkId.isBlank()) {
-      return Response.status(Response.Status.BAD_REQUEST)
-          .entity(Map.of("status", "error", "message", "Selecciona una Charla"))
-          .build();
-    }
-    var info = eventService.findTalkInfo(talkId);
-    if (info == null) {
-      return Response.status(Response.Status.NOT_FOUND).entity(Map.of("status", "missing")).build();
-    }
-    String userId = getEmail();
-    Notification n = new Notification();
-    n.userId = userId;
-    n.talkId = talkId;
-    n.eventId = info.event().getId();
-    n.type = NotificationType.TEST;
-    n.title = "Notificación de prueba";
-    n.message = info.talk().getName();
-    notifications.enqueue(n);
-    return Response.ok(Map.of("status", "ok")).build();
-  }
 
   private boolean acceptsJson(HttpHeaders headers) {
     String accept = headers.getHeaderString(HttpHeaders.ACCEPT);

--- a/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
+++ b/quarkus-app/src/main/resources/templates/ProfileResource/profile.html
@@ -6,19 +6,6 @@
 <p><strong>Email:</strong> {email}</p>
 
 <h2 class="page-title">Tus Charlas Registradas</h2>
-<div class="test-notification">
-  <select id="test-talk-select">
-    <option value="">--Selecciona una charla--</option>
-    {#for g in groups}
-      {#for d in g.days}
-        {#for t in d.talks}
-          <option value="{t.id}">{t.name}</option>
-        {/for}
-      {/for}
-    {/for}
-  </select>
-  <button id="test-notification-btn" class="btn">Prueba de Notificaciones</button>
-</div>
 {#if groups.isEmpty()}
 <p>Aún no hay charlas.</p>
 {#else}
@@ -230,32 +217,6 @@
         });
       });
     });
-
-    const testBtn = document.getElementById('test-notification-btn');
-    if (testBtn) {
-      testBtn.addEventListener('click', async () => {
-        const sel = document.getElementById('test-talk-select');
-        const talkId = sel ? sel.value : '';
-        if (!talkId) {
-          showNotification('info', 'Selecciona una Charla');
-          return;
-        }
-        try {
-          const res = await fetch('/private/profile/test-notification', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
-            body: JSON.stringify({ talkId })
-          });
-          if (res.ok) {
-            showNotification('success', 'Notificación de prueba enviada');
-          } else {
-            showNotification('error', 'No se pudo enviar la notificación');
-          }
-        } catch (e) {
-          showNotification('error', 'No se pudo enviar la notificación');
-        }
-      });
-    }
 
     updateSummary();
   })();

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/ProfileResourceTest.java
@@ -4,8 +4,6 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.scanales.eventflow.notifications.NotificationService;
-import com.scanales.eventflow.notifications.NotificationConfig;
 import com.scanales.eventflow.service.UserScheduleService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
@@ -18,17 +16,9 @@ public class ProfileResourceTest {
 
   @Inject UserScheduleService userSchedule;
 
-  @Inject NotificationService notifications;
-  @Inject NotificationConfig config;
 
   @BeforeEach
   void setup() {
-    config.enabled = true;
-    config.userCap = 100;
-    config.globalCap = 1000;
-    config.maxQueueSize = 10000;
-    config.dedupeWindow = java.time.Duration.ofMinutes(30);
-    notifications.reset();
     userSchedule.reset();
   }
 
@@ -112,20 +102,6 @@ public class ProfileResourceTest {
         .header("Location", endsWith("/private/profile"));
   }
 
-  @Test
-  @TestSecurity(user = "user@example.com")
-  public void testNotificationEndpointCreatesNotification() {
-    given()
-        .header("Accept", "application/json")
-        .header("Content-Type", "application/json")
-        .body("{\"talkId\":\"t1\"}")
-        .when()
-        .post("/private/profile/test-notification")
-        .then()
-        .statusCode(200)
-        .body("status", is("ok"));
-    assertEquals(1, notifications.listForUser("user@example.com", 10, false).size());
-  }
 
   @Test
   @TestSecurity(user = "user@example.com")


### PR DESCRIPTION
## Summary
- remove legacy "Prueba de Notificaciones" controls from profile page
- drop test notification endpoint and related test

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3587188788333a951634d8c066734