### PR TITLE
Standardize notification toasts and fix break link

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -20,7 +20,7 @@
   padding: 0.75rem 1rem;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-  max-width: 90%;
+  width: min(360px, 90%);
   pointer-events: auto;
   display: flex;
   flex-direction: column;

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -60,14 +60,16 @@
       toast.appendChild(msg);
       const actions=document.createElement('div');
       actions.className='ef-toast__actions';
-      const link=document.createElement('a');
-      link.href=vm.url||'#';
-      link.textContent='Ver charla';
-      actions.appendChild(link);
+      if(vm.url){
+        const link=document.createElement('a');
+        link.href=vm.url;
+        link.textContent='Ver charla';
+        actions.appendChild(link);
+      }
       const close=document.createElement('button');
       close.type='button';
       close.textContent='×';
-      close.addEventListener('click',()=>this.close(vm.id));
+      close.addEventListener('click',e=>{e.preventDefault();e.stopPropagation();this.close(vm.id);});
       actions.appendChild(close);
       toast.appendChild(actions);
       return toast;
@@ -135,7 +137,7 @@
         id:dto.id||uid(),
         title:dto.title||dto.type,
         message:dto.message||'',
-        url:dto.talkId?('/talks/'+dto.talkId):'#'
+        url:(dto.talkId && dto.category!== 'break')?('/talks/'+dto.talkId):null
       };
       manager.enqueue(vm);
     },


### PR DESCRIPTION
## Summary
- standardize toast size and layout
- fix toast close button
- avoid linking to non-existent pages for break notifications

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b35ec3b2848333a73be42725d2b269