### PR TITLE
fix: delete only selected notifications

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -123,11 +123,18 @@
 
     // Eliminar seleccionadas
     if (e.target.closest('#deleteSelected')) {
-      if (selected.size === 0) return;
+      // Recalcular selección real desde el DOM para evitar desync
+      const checked = document.querySelectorAll('.js-select:checked');
+      if (checked.length === 0) return;
+      selected.clear();
+      for (const cb of checked) {
+        const id = cb.getAttribute('data-id');
+        if (id) selected.add(id);
+      }
       const all = getAll();
       const now = Date.now();
       for (const n of all) {
-        if (selected.has(n.id) && !n.dismissedAt) n.dismissedAt = now;
+        if (selected.has(String(n.id)) && !n.dismissedAt) n.dismissedAt = now;
       }
       saveAll(all);
       selected.clear();


### PR DESCRIPTION
## Summary
- ensure only checked notifications are removed in the center view

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68b3b9fcb71483338a4a8df385351e6b