### PR TITLE
chore(ci): retry syft installation

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -86,7 +86,11 @@ jobs:
 
       - name: Install Syft
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+          for i in 1 2 3; do
+            curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin && break
+            sleep 10
+          done
+          syft version
 
       - name: Attach SBOM
         run: |


### PR DESCRIPTION
## Summary
- retry Syft installation up to three times to handle transient network errors

## Testing
- `yamllint .github/workflows/build-native.yml` (errors: line too long, empty-lines)
- `cd quarkus-app && ./mvnw -q test` (failed: Network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68b3d40c16308333b254d4e64a574348