### PR TITLE
Improve notifications accessibility and admin tools

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -185,7 +185,11 @@
   outline-offset: 2px;
 }
 
-.notifications-bell .icon {
+.notifications-bell .icon-bell::before {
+  content: "\1F514"; /* bell emoji */
+}
+
+.notifications-bell .icon-bell {
   font-size: 1.25rem;
 }
 

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
@@ -32,4 +32,18 @@
     if(res.status===204) load();
   });
   load();
+  const demoBtn = document.getElementById('broadcast-demo');
+  if(demoBtn){
+    demoBtn.addEventListener('click', async ()=>{
+      const now = Date.now();
+      const payloads=[
+        {type:'ANNOUNCEMENT',category:'announcement',title:'Demo 1',message:'Notificación de prueba 1',expiresAt:now+5*60*1000},
+        {type:'ANNOUNCEMENT',category:'announcement',title:'Demo 2',message:'Notificación de prueba 2',expiresAt:now+5*60*1000}
+      ];
+      for(const body of payloads){
+        await fetch('/admin/api/notifications/broadcast',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+      }
+      load();
+    });
+  }
 })();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/app.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/app.js
@@ -149,6 +149,19 @@ function setupAgendaToggle() {
     }
 }
 
+function setupViewFullAgenda() {
+    const btn = document.getElementById('view-full-agenda');
+    if (btn) {
+        btn.addEventListener('click', (e) => {
+            const panel = document.querySelector('#agenda');
+            if (panel) {
+                panel.classList.remove('collapsed');
+                panel.scrollIntoView({ behavior: 'smooth' });
+            }
+        });
+    }
+}
+
 function bannerParallax() {
     const banner = $('banner');
     if (banner) {
@@ -254,6 +267,7 @@ function onDomContentLoaded() {
     setupMenu();
     setupUserMenu();
     setupAgendaToggle();
+    setupViewFullAgenda();
     adjustLayout();
     bannerParallax();
     handleForms();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -96,26 +96,26 @@
     }
     updateCloseAll(){
       const total=this.visible.length+this.queue.length;
-      this.closeAllBtn.hidden=total<=1;
+      const hide = total===0;
+      this.closeAllBtn.hidden = hide;
+      this.closeAllBtn.classList.toggle('hidden', hide);
     }
     metric(name){
       if(window.__metrics&&window.__metrics.count){window.__metrics.count('ui.notifications.'+name);} }
   }
   const container=document.getElementById('ef-toast-container');
   const manager=container?new ToastQueueManager(container):null;
-  const badge=document.querySelector('[data-notifications-badge]');
-  const sr=document.querySelector('[data-notifications-sr]');
+  const badge=document.getElementById('notif-badge');
   let unread=0;
 
   function renderBadge(){
     if(!badge)return;
     if(unread>0){
       badge.textContent=String(unread);
-      badge.hidden=false;
-      if(sr) sr.textContent=unread===1?`1 notificación nueva`:`${unread} notificaciones nuevas`;
+      badge.classList.remove('hidden');
     }else{
-      badge.hidden=true;
-      if(sr) sr.textContent='';
+      badge.textContent='0';
+      badge.classList.add('hidden');
     }
   }
 

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -51,7 +51,7 @@ Evento
     {/if}
     <p><strong>Duración:</strong> {event.days} día{#if event.days > 1}s{/if}</p>
     {#if !event.agenda.isEmpty()}
-    <p><a href="#agenda" class="btn btn-secondary">Ver agenda completa</a></p>
+    <p><a href="#agenda" id="view-full-agenda" class="btn btn-secondary">Ver agenda completa</a></p>
     {/if}
   </div>
   {#if !event.scenarios.isEmpty()}

--- a/quarkus-app/src/main/resources/templates/admin/notifications.qute.html
+++ b/quarkus-app/src/main/resources/templates/admin/notifications.qute.html
@@ -17,6 +17,10 @@
     </div>
   </form>
 
+  <div class="mt-4">
+    <button id="broadcast-demo" class="btn-secondary" type="button">Broadcast demo</button>
+  </div>
+
   <h2 class="text-xl font-semibold mt-8 mb-3">Últimas notificaciones</h2>
   <div id="admin-list" class="grid gap-2"></div>
 </section>

--- a/quarkus-app/src/main/resources/templates/fragments/notifications-bell.html
+++ b/quarkus-app/src/main/resources/templates/fragments/notifications-bell.html
@@ -1,13 +1,12 @@
 {@java.lang.Long unreadCount}
 <div class="notifications-bell">
-  <a
-      href="/notifications/center"
-      aria-label="Notificaciones"
-      aria-controls="notifications-center">
-    <span class="icon" aria-hidden="true">🔔</span>
+  <a href="/notifications/center" class="nav-link" aria-label="Notificaciones">
+    <span class="icon-bell" aria-hidden="true"></span>
+    <span class="sr-only">Notificaciones</span>
     {#if unreadCount != null && unreadCount > 0}
-      <span class="badge" aria-hidden="true">{unreadCount}</span>
-      <span class="sr-only" aria-live="polite">{unreadCount} notificaciones nuevas</span>
+      <span class="badge">{unreadCount}</span>
+    {#else}
+      <span class="badge hidden">0</span>
     {/if}
   </a>
 </div>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -28,10 +28,10 @@
                 <a href="/private/admin" data-nav-link>Admin</a>
             {/if}
         {/if}
-        <a href="/notifications/center" class="nav-link notifications-bell" aria-label="Notificaciones" aria-controls="notifications-center" data-nav-link>
-            <span class="icon" aria-hidden="true">🔔</span>
-            <span class="badge" data-notifications-badge aria-hidden="true" hidden></span>
-            <span class="sr-only" data-notifications-sr aria-live="polite"></span>
+        <a href="/notifications/center" class="nav-link notifications-bell {#if currentPath.startsWith('/notifications')}active{/if}" aria-label="Notificaciones" data-nav-link>
+            <span class="icon-bell" aria-hidden="true"></span>
+            <span class="sr-only">Notificaciones</span>
+            <span id="notif-badge" class="badge hidden">0</span>
         </a>
         {#if app:isAuthenticated()}
             <div class="user-menu" data-user-menu>


### PR DESCRIPTION
## Summary
- Render notification bell link with text for accessibility and persist badge
- Hide 'Cerrar todas' toast control when no pending toasts
- Add full agenda anchor and smooth scroll
- Add demo broadcast button to admin notifications

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b46962ba5c8333af801cc0fa213d99