### PR TITLE
Improve notification accessibility and admin tools

### DIFF
--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/AdminNotificationResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/AdminNotificationResource.java
@@ -40,6 +40,12 @@ public class AdminNotificationResource {
   }
 
   @DELETE
+  public Response clear() {
+    service.clearAll();
+    return Response.noContent().build();
+  }
+
+  @DELETE
   @Path("/{id}")
   public Response delete(@PathParam("id") String id) {
     boolean removed = service.removeById(id);

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotificationService.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotificationService.java
@@ -92,6 +92,13 @@ public class GlobalNotificationService {
     }
     return removed;
   }
+
+  /** Clear all notifications from the buffer and reset deduplication state. */
+  public void clearAll() {
+    buffer.clear();
+    dedupe.clear();
+    repo.save(buffer);
+  }
 }
 
 /** Simple JSON utility. */

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications.js
@@ -1,5 +1,6 @@
 (async function(){
   const listEl = document.getElementById('admin-list');
+  const clearBtn = document.getElementById('clearAll');
   async function load(){
     const res = await fetch('/admin/api/notifications/latest?limit=50', { cache:'no-store' });
     if(!res.ok) return;
@@ -31,6 +32,13 @@
     const res = await fetch(`/admin/api/notifications/${id}`, { method:'DELETE' });
     if(res.status===204) load();
   });
+  if(clearBtn){
+    clearBtn.addEventListener('click', async ()=>{
+      if(!confirm('¿Borrar todo el backlog de notificaciones?')) return;
+      const res = await fetch('/admin/api/notifications',{ method:'DELETE' });
+      if(res.status===204) load();
+    });
+  }
   load();
   const demoBtn = document.getElementById('broadcast-demo');
   if(demoBtn){

--- a/quarkus-app/src/main/resources/templates/admin/notifications.qute.html
+++ b/quarkus-app/src/main/resources/templates/admin/notifications.qute.html
@@ -6,19 +6,24 @@
   <h1 class="text-2xl font-semibold mb-4">Broadcast de Notificaciones</h1>
   <form id="broadcast" class="grid gap-3 card p-4">
     <div class="row gap-2">
-      <select name="type" class="input"><option>AGENDA_UPDATED</option><option>ANNOUNCEMENT</option></select>
-      <input class="input" name="eventId" placeholder="eventId (opcional)">
+      <label class="sr-only" for="type">Tipo de notificación</label>
+      <select id="type" name="type" class="input"><option>AGENDA_UPDATED</option><option>ANNOUNCEMENT</option></select>
+      <label class="sr-only" for="eventId">ID de evento (opcional)</label>
+      <input id="eventId" class="input" name="eventId" placeholder="eventId (opcional)">
     </div>
-    <input class="input" name="title" placeholder="Título" required>
-    <textarea class="input" name="message" placeholder="Mensaje" required></textarea>
+    <label class="sr-only" for="title">Título</label>
+    <input id="title" class="input" name="title" placeholder="Título" required>
+    <label class="sr-only" for="message">Mensaje</label>
+    <textarea id="message" class="input" name="message" placeholder="Mensaje" required></textarea>
     <div class="row gap-2">
       <button class="btn-primary" type="submit">Enviar a todos</button>
       <span class="text-sm text-muted-foreground">Se emite a todos los conectados; persistirá en el backlog global.</span>
     </div>
   </form>
 
-  <div class="mt-4">
+  <div class="mt-4 row gap-2">
     <button id="broadcast-demo" class="btn-secondary" type="button">Broadcast demo</button>
+    <button id="clearAll" class="btn-danger" type="button">Borrar backlog</button>
   </div>
 
   <h2 class="text-xl font-semibold mt-8 mb-3">Últimas notificaciones</h2>

--- a/quarkus-app/src/main/resources/templates/notifications/center.html
+++ b/quarkus-app/src/main/resources/templates/notifications/center.html
@@ -23,7 +23,7 @@
       <button class="btn btn-danger" id="deleteAll">Borrar todo</button>
     </div>
   </div>
-  <div id="notif-list" class="grid gap-3"></div>
+  <div id="notif-list" class="grid gap-3" aria-live="polite" aria-atomic="false"></div>
   <div id="empty" class="text-sm text-muted-foreground hidden">Sin notificaciones por ahora.</div>
   <dialog id="confirmDeleteAll">
     <p>Está seguro desea eliminar todas las notificaciones recibidas?</p>

--- a/quarkus-app/src/test/java/io/eventflow/notifications/global/AdminNotificationResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/global/AdminNotificationResourceTest.java
@@ -27,9 +27,7 @@ public class AdminNotificationResourceTest {
 
   @BeforeEach
   public void clear() {
-    for (GlobalNotification g : service.latest(1000)) {
-      service.removeById(g.id);
-    }
+    service.clearAll();
   }
 
   private WsClient connect() throws Exception {
@@ -98,6 +96,24 @@ public class AdminNotificationResourceTest {
         .anyMatch(id::equals);
     assertTrue(found);
     service.removeById(id);
+  }
+
+  @Test
+  @TestSecurity(user = "admin", roles = {"admin"})
+  public void clearEndpointRemovesAll() {
+    Map<String, Object> body = Map.of(
+        "type", "TMP",
+        "title", "t",
+        "message", "m");
+    given().contentType(ContentType.JSON)
+        .body(body)
+        .when()
+        .post("/admin/api/notifications/broadcast")
+        .then()
+        .statusCode(200);
+    assertFalse(service.latest(10).isEmpty());
+    given().when().delete("/admin/api/notifications").then().statusCode(204);
+    assertTrue(service.latest(10).isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add aria-live region for notification list
- label admin notification form inputs and provide backlog clear action
- support clearing notification backlog via REST endpoint and service

## Testing
- `mvn -q test` *(fails: Expected status code <200> but was <500>)*

------
https://chatgpt.com/codex/tasks/task_e_68b470a8428c8333836e8c1b588fd422