### PR TITLE
Handle missing currentPath in layout

### DIFF
--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -28,7 +28,7 @@
                 <a href="/private/admin" data-nav-link>Admin</a>
             {/if}
         {/if}
-        <a href="/notifications/center" class="nav-link notifications-bell {#if currentPath.startsWith('/notifications')}active{/if}" aria-label="Notificaciones" data-nav-link>
+        <a href="/notifications/center" class="nav-link notifications-bell {#if currentPath?? && currentPath.startsWith('/notifications')}active{/if}" aria-label="Notificaciones" data-nav-link>
             <span class="icon-bell" aria-hidden="true"></span>
             <span class="sr-only">Notificaciones</span>
             <span id="notif-badge" class="badge hidden">0</span>


### PR DESCRIPTION
## Summary
- avoid Qute `TemplateException` by checking if `currentPath` is present before using it

## Testing
- `mvn test`
- `mvn -Dtest=NotificationsMenuTest test`

------
https://chatgpt.com/codex/tasks/task_e_68b47e0a6c5083338e467f23dd637c16