### PR TITLE
Limit notifications center to current day

### DIFF
--- a/docs/en/features/notifications.md
+++ b/docs/en/features/notifications.md
@@ -6,7 +6,7 @@ Un rato antes de mi primera charla, aparece un aviso sutil abajo de la pantalla:
 
 Durante el día, la app me avisa cuando una charla “está en curso”, cuando “está por finalizar” y al final “ha finalizado”. Todo sin bloquearme. Si pierdo señal un momento, al volver, las notificaciones se ponen al día solas.
 
-Cuando quiero ver todo con calma, toco la campana (ahora con numerito). Entro al Centro de Notificaciones, donde puedo filtrar Todas / No leídas / Últimas 24 h, marcar como leídas o eliminar varias a la vez. Todo está ordenado en tarjetas compactas, los textos no se cortan raro, y los botones son cómodos de pulsar.
+Cuando quiero ver todo con calma, toco la campana (ahora con numerito). Entro al Centro de Notificaciones, que muestra las actividades del día en curso y me permite filtrar Todas o No leídas, marcar como leídas o eliminar varias a la vez. Todo está ordenado en tarjetas compactas, los textos no se cortan raro, y los botones son cómodos de pulsar.
 
 Me siento acompañada, no perseguida:
 

--- a/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/notifications/NotificationService.java
@@ -112,20 +112,16 @@ public class NotificationService {
    * Paginates notifications for a user applying simple filters.
    *
    * @param userId the owner
-   * @param filter one of "all", "unread" or "last24h"
+   * @param filter one of "all" o "unread"
    * @param cursor timestamp cursor; notifications newer than this are skipped
    * @param limit max items to return
    */
   public NotificationPage listPage(String userId, String filter, Long cursor, int limit) {
     java.util.Deque<Notification> list = store.getUserList(userId);
-    long now = System.currentTimeMillis();
     java.util.stream.Stream<Notification> stream =
         list.stream().sorted((a, b) -> Long.compare(b.createdAt, a.createdAt));
     if ("unread".equalsIgnoreCase(filter)) {
       stream = stream.filter(n -> n.readAt == null);
-    } else if ("last24h".equalsIgnoreCase(filter)) {
-      long cutoff = now - 24 * 60 * 60 * 1000L;
-      stream = stream.filter(n -> n.createdAt >= cutoff);
     }
     if (cursor != null) {
       stream = stream.filter(n -> n.createdAt < cursor);

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -32,12 +32,19 @@
 
   // Render de la lista aplicando filtro y preservando selección
   function render() {
-    const now = Date.now();
     const all = getAll();
     let items = all.filter(n => !n.dismissedAt);
 
-    if (currentFilter === 'unread')  items = items.filter(n => !n.readAt);
-    if (currentFilter === 'last24h') items = items.filter(n => (now - (n.createdAt || 0)) <= 24 * 3600 * 1000);
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date(startOfDay);
+    endOfDay.setDate(endOfDay.getDate() + 1);
+    items = items.filter(n => {
+      const ts = n.createdAt || 0;
+      return ts >= startOfDay.getTime() && ts < endOfDay.getTime();
+    });
+
+    if (currentFilter === 'unread') items = items.filter(n => !n.readAt);
 
     items.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
 

--- a/quarkus-app/src/main/resources/templates/notifications/center.html
+++ b/quarkus-app/src/main/resources/templates/notifications/center.html
@@ -9,12 +9,14 @@
       Aquí verás avisos globales sobre cambios en la agenda de eventos disponibles.
       Marca como leídas o elimina las que no necesites.
     </p>
+    <p class="text-muted">
+      El servicio de notificaciones alertará sobre las actividades del día en curso.
+    </p>
   </header>
   <div class="actions">
     <div class="filters">
       <button class="btn" data-filter="all">Todas</button>
       <button class="btn" data-filter="unread">No leídas</button>
-      <button class="btn" data-filter="last24h">Últimas 24 h</button>
     </div>
     <div class="actions-right">
       <button class="btn" id="selectAll">Seleccionar todos</button>

--- a/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationPageResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/rest/NotificationPageResourceTest.java
@@ -11,6 +11,11 @@ import org.junit.jupiter.api.Test;
 public class NotificationPageResourceTest {
   @Test
   public void centerRendersForVisitor() {
-    given().when().get("/notifications/center").then().statusCode(200).body(containsString("Notificaciones"));
+    given()
+      .when().get("/notifications/center")
+      .then()
+      .statusCode(200)
+      .body(containsString("Notificaciones"))
+      .body(containsString("actividades del día en curso"));
   }
 }


### PR DESCRIPTION
## Summary
- show only notifications from the current day and remove the "Últimas 24 h" filter
- inform users that the center displays alerts for ongoing day activities
- drop unused `last24h` filter from notification service

## Testing
- `mvn test -f quarkus-app/pom.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b493aa59708333a6d990278086c7fc