### PR TITLE
Fix GH CLI usage in auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -78,7 +78,7 @@ jobs:
 
           # Verifica checks (el branch protection también lo hará, esto es informativo)
           echo "Checks summary:"
-          gh pr checks $PR_NUMBER || true
+          gh pr checks $PR_NUMBER --repo "${{ github.repository }}" || true
 
           # Intentar merge (fallará si branch protection aún no permite)
-          gh pr merge $PR_NUMBER --squash --delete-branch --merge --repo "${{ github.repository }}"
+          gh pr merge $PR_NUMBER --squash --delete-branch --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary
- ensure gh pr checks runs in correct repo
- avoid conflicting merge flag in auto-merge workflow

## Testing
- `./dev/pr-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b4dc81ef5083338819a416a316e033