### PR TITLE
fix: always run deps job

### DIFF
--- a/.github/workflows/pr-quality-suite.yml
+++ b/.github/workflows/pr-quality-suite.yml
@@ -69,7 +69,6 @@ jobs:
   deps:
     name: deps
     needs: paths
-    if: needs.paths.outputs.deps_changed == 'true'
     uses: ./.github/workflows/pr-deps-hygiene.yml
     secrets: inherit
 


### PR DESCRIPTION
## Summary
- run deps job unconditionally so it's marked successful

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' .github/workflows/pr-quality-suite.yml`
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fe23b8048333a348aff60290b1ce