### PR TITLE
Fix main deploy when PR image missing

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -1,3 +1,4 @@
+---
 name: Promote by Digest
 
 on:
@@ -5,16 +6,21 @@ on:
     branches: [main]
 
 env:
-  REGISTRY:   ${{ vars.REGISTRY }}
+  REGISTRY: ${{ vars.REGISTRY }}
   IMAGE_NAME: ${{ vars.IMAGE_NAME }}
-  GKE_PROJECT:   ${{ vars.GKE_PROJECT }}
-  GKE_CLUSTER:   ${{ vars.GKE_CLUSTER }}
-  GKE_LOCATION:  ${{ vars.GKE_LOCATION }}
+  GKE_PROJECT: ${{ vars.GKE_PROJECT }}
+  GKE_CLUSTER: ${{ vars.GKE_CLUSTER }}
+  GKE_LOCATION: ${{ vars.GKE_LOCATION }}
   GKE_NAMESPACE: ${{ vars.GKE_NAMESPACE || 'prod' }}
   GH_TOKEN: ${{ github.token }}
 
 jobs:
+  build:
+    uses: ./.github/workflows/build-native.yml
+    secrets: inherit
+
   deploy:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -22,25 +28,28 @@ jobs:
       - name: Login to Quay
         run: echo "${{ secrets.QUAY_PASSWORD }}" | docker login "${REGISTRY}" -u "${{ secrets.QUAY_USERNAME }}" --password-stdin
 
-      - name: Resolve PR tag -> digest (promote-by-digest)
+      - name: Resolve image digest
         id: ref
         run: |
           set -euo pipefail
           sudo apt-get update -y && sudo apt-get install -y jq skopeo
           prs=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls -H "Accept: application/vnd.github+json")
           pr=$(echo "$prs" | jq -r '.[0].number // empty')
-          head=$(echo "$prs" | jq -r '.[0].head.sha // empty')
-          if [ -z "$pr" ] || [ -z "$head" ]; then
-            echo "No pull request found for commit ${{ github.sha }}" >&2
-            exit 1
-          fi
-          prtag="docker://${REGISTRY}/${IMAGE_NAME}:pr-${pr}-${head}"
-          if ! DIGEST=$(skopeo inspect --format '{{.Digest}}' "$prtag" 2>/dev/null); then
+          if [ -n "$pr" ]; then
+            head=$(echo "$prs" | jq -r '.[0].head.sha')
+            prtag="docker://${REGISTRY}/${IMAGE_NAME}:pr-${pr}-${head}"
             headtag="docker://${REGISTRY}/${IMAGE_NAME}:${head}"
-            if ! DIGEST=$(skopeo inspect --format '{{.Digest}}' "$headtag" 2>/dev/null); then
-              echo "No image found for $prtag or $headtag" >&2
-              exit 1
-            fi
+          else
+            head="${{ github.sha }}"
+            headtag="docker://${REGISTRY}/${IMAGE_NAME}:${head}"
+          fi
+          if [ -n "$pr" ] && DIGEST=$(skopeo inspect --format '{{.Digest}}' "$prtag" 2>/dev/null); then
+            :
+          elif DIGEST=$(skopeo inspect --format '{{.Digest}}' "$headtag" 2>/dev/null); then
+            :
+          else
+            echo "No image found for $prtag or $headtag" >&2
+            exit 1
           fi
           echo "ref=${REGISTRY}/${IMAGE_NAME}@${DIGEST}" | tee /tmp/ref.txt
           echo "ref=${REGISTRY}/${IMAGE_NAME}@${DIGEST}" >> $GITHUB_OUTPUT
@@ -62,8 +71,8 @@ jobs:
         uses: google-github-actions/get-gke-credentials@v2
         with:
           cluster_name: ${{ env.GKE_CLUSTER }}
-          location:     ${{ env.GKE_LOCATION }}
-          project_id:   ${{ env.GKE_PROJECT }}
+          location: ${{ env.GKE_LOCATION }}
+          project_id: ${{ env.GKE_PROJECT }}
 
       - name: Apply manifests & rollout (by digest)
         run: |


### PR DESCRIPTION
## Summary
- build image on push to main using existing build-native workflow
- allow main deploy to fall back to commit tag when PR tag is unavailable

## Testing
- `python -m yamllint .github/workflows/main-deploy.yml` *(fails: line-length)*
- `mvn -f quarkus-app/pom.xml test`


------
https://chatgpt.com/codex/tasks/task_e_68b50f2dfd188333a81c9efb42b71468