### PR TITLE
feat: add metrics admin maintenance actions

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -612,8 +612,12 @@ public class UsageMetricsService {
     }
   }
 
-  /** Test helper to reset internal state between tests. */
-  void reset() {
+  /**
+   * Resets all tracked metrics. Intended for administrative use and tests.
+   * Clears in-memory counters and removes any persisted metrics files so that
+   * a fresh dataset can be recorded.
+   */
+  public void reset() {
     counters.clear();
     talkViews.clear();
     eventViews.clear();
@@ -631,6 +635,15 @@ public class UsageMetricsService {
     lastFlushTime = System.currentTimeMillis();
     lastError = null;
     currentState = HealthState.OK;
+    lastFileSizeBytes = 0;
+    schemaVersion = CURRENT_SCHEMA_VERSION;
+    metricsPath = metricsV2Path;
+    try {
+      Files.deleteIfExists(metricsV1Path);
+      Files.deleteIfExists(metricsV2Path);
+    } catch (IOException e) {
+      LOG.warn("Failed to delete metrics file", e);
+    }
   }
 
   private static class RateLimiter {

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/index.html
@@ -97,6 +97,12 @@
         <div class="list-row"><span class="label">schemaVersion</span><span class="metric">{data.schemaVersion}</span></div>
         <div class="list-row"><span class="label">fileSizeBytes</span><span class="metric">{data.fileSizeBytes}</span></div>
       </div>
+      <div class="action-group">
+        <form method="post" action="/private/admin/metrics/reset" onsubmit="return confirm('¿Borrar datos?');">
+          <button type="submit" class="btn">Reset data</button>
+        </form>
+        <a href="/private/admin/metrics/data" class="btn btn-secondary">Download data</a>
+      </div>
     </div>
 
     <div class="card">

--- a/quarkus-app/src/main/resources/templates/AdminMetricsResource/registrants.html
+++ b/quarkus-app/src/main/resources/templates/AdminMetricsResource/registrants.html
@@ -4,7 +4,18 @@
 {#main}
 <section class="admin-metrics">
   <h1 class="page-title">{talk.name} - {event.title}</h1>
-  <table>
+  <form method="get" class="filter">
+    <input type="hidden" name="talk" value="{talk.id}">
+    <input type="search" name="name" placeholder="Nombre" value="{name}">
+    <input type="search" name="email" placeholder="Email" value="{email}">
+    <select name="size">
+      <option value="20"{#if size == 20} selected{/if}>20</option>
+      <option value="50"{#if size == 50} selected{/if}>50</option>
+      <option value="100"{#if size == 100} selected{/if}>100</option>
+    </select>
+    <button type="submit" class="btn btn-secondary">Filtrar</button>
+  </form>
+  <table class="table registrants-table">
     <thead><tr><th>Nombre</th><th>Email</th></tr></thead>
     <tbody>
     {#for u in users}
@@ -12,6 +23,14 @@
     {/for}
     </tbody>
   </table>
+  <div class="pagination">
+    {#if hasPrev}
+      <a href="?talk={talk.id}&name={name}&email={email}&size={size}&page={prev}" class="btn btn-secondary">Anterior</a>
+    {/if}
+    {#if hasNext}
+      <a href="?talk={talk.id}&name={name}&email={email}&size={size}&page={next}" class="btn btn-secondary">Siguiente</a>
+    {/if}
+  </div>
   <a href="/private/admin/metrics/registrations" class="btn btn-secondary">Volver</a>
 </section>
 {/main}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/private_/AdminMetricsExportTest.java
@@ -14,7 +14,6 @@ import com.scanales.eventflow.service.UsageMetricsService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import jakarta.inject.Inject;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,13 +33,7 @@ public class AdminMetricsExportTest {
   void setUp() {
     eventService.reset();
     speakerService.reset();
-    try {
-      Method m = UsageMetricsService.class.getDeclaredMethod("reset");
-      m.setAccessible(true);
-      m.invoke(metrics);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    metrics.reset();
     // Basic event with a single talk and speaker
     Speaker sp = new Speaker();
     sp.setId("sp1");


### PR DESCRIPTION
## Summary
- allow admins to reset or download raw metrics data
- paginate and filter registrants list for talks
- expose UsageMetricsService reset for admin use

## Testing
- `./dev/pr-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b580aa3c8c8333bc38fa5d6d807b7d