### PR TITLE
fix(notifications): expire dedupe keys after window

### DIFF
--- a/quarkus-app/src/test/java/io/eventflow/notifications/global/AdminNotificationResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/global/AdminNotificationResourceTest.java
@@ -176,7 +176,21 @@ public class AdminNotificationResourceTest {
     n.message = "m";
     n.dedupeKey = "dk";
     assertTrue(service.enqueue(n));
+    // second enqueue within window should be deduped
     assertFalse(service.enqueue(n));
+
+    GlobalNotification n2 = new GlobalNotification();
+    n2.id = "dedupe2";
+    n2.type = "TEST";
+    n2.title = "t";
+    n2.message = "m";
+    n2.dedupeKey = "dk";
+    n2.createdAt =
+        n.createdAt + GlobalNotificationConfig.dedupeWindow.toMillis() + 1;
+    // after the dedupe window it should be accepted again
+    assertTrue(service.enqueue(n2));
+
     service.removeById("dedupe1");
+    service.removeById("dedupe2");
   }
 }


### PR DESCRIPTION
## Summary
- ensure global notifications dedupe respects configured window
- add test covering acceptance after dedupe window

## Testing
- `mvn -B test`

------
https://chatgpt.com/codex/tasks/task_e_68b58dab3be883339d43f2d7c3cb3035