### PR TITLE
Fix unread notification badge mismatch

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -127,7 +127,10 @@
     }catch(_){unread=0;renderBadge();}
   }
   window.updateUnreadFromLocal=updateUnreadFromLocal;
-  if(badge){window.addEventListener('DOMContentLoaded',updateUnreadFromLocal);}
+  if(badge){
+    window.addEventListener('DOMContentLoaded',updateUnreadFromLocal);
+    document.addEventListener('ef:notifs:changed',updateUnreadFromLocal);
+  }
 
   window.EventFlowNotifications={
     accept(dto){


### PR DESCRIPTION
## Summary
- keep local unread notification count in sync with stored notifications
- refresh bell badge when notification state changes

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5957fe24c833385fe1f8d92dac5e0