### PR TITLE
Ensure logout clears session cookie

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/HtmlSessionExpiryFilter.java
@@ -60,7 +60,9 @@ public class HtmlSessionExpiryFilter implements ContainerRequestFilter {
           Response.status(Response.Status.FOUND)
               .header(HttpHeaders.LOCATION, "/")
               .header("X-Redirected-By", "session-expired")
-              .header(HttpHeaders.SET_COOKIE, "q_session=; Path=/; Max-Age=0; HttpOnly; Secure")
+              .header(
+                  HttpHeaders.SET_COOKIE,
+                  "q_session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None")
               .build());
     }
   }

--- a/quarkus-app/src/main/java/com/scanales/logout/LogoutResource.java
+++ b/quarkus-app/src/main/java/com/scanales/logout/LogoutResource.java
@@ -17,7 +17,9 @@ public class LogoutResource {
     LOG.info("Processing logout request");
     return Response.status(Response.Status.SEE_OTHER)
         .header(HttpHeaders.LOCATION, "/")
-        .header(HttpHeaders.SET_COOKIE, "q_session=; Path=/; Max-Age=0; HttpOnly; Secure")
+        .header(
+            HttpHeaders.SET_COOKIE,
+            "q_session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None")
         .build();
   }
 }

--- a/quarkus-app/src/test/java/com/scanales/logout/LogoutResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/logout/LogoutResourceTest.java
@@ -19,6 +19,8 @@ public class LogoutResourceTest {
         .then()
         .statusCode(303)
         .header("Location", equalTo("/"))
-        .header("Set-Cookie", equalTo("q_session=; Path=/; Max-Age=0; HttpOnly; Secure"));
+        .header(
+            "Set-Cookie",
+            equalTo("q_session=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=None"));
   }
 }


### PR DESCRIPTION
## Summary
- Add `SameSite=None` to `q_session` cookie clearing on logout and session expiry
- Update logout test for new cookie attributes

## Testing
- `mvn test`
- `pytest tests/test_enforce_severity.py`


------
https://chatgpt.com/codex/tasks/task_e_68b595f42f408333ba095a8d177ced03