### PR TITLE
fix: update registration metrics when removing talks

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/private_/ProfileResource.java
@@ -219,7 +219,10 @@ public class ProfileResource {
   @Authenticated
   public Response removeTalkRedirect(@PathParam("id") String id) {
     String email = getEmail();
-    userSchedule.removeTalkForUser(email, id);
+    boolean removed = userSchedule.removeTalkForUser(email, id);
+    if (removed) {
+      metrics.recordTalkUnregister(id, email);
+    }
     return Response.status(Response.Status.SEE_OTHER)
         .header("Location", "/private/profile")
         .build();
@@ -232,6 +235,9 @@ public class ProfileResource {
   public Response removeTalk(@PathParam("id") String id, @Context HttpHeaders headers) {
     String email = getEmail();
     boolean removed = userSchedule.removeTalkForUser(email, id);
+    if (removed) {
+      metrics.recordTalkUnregister(id, email);
+    }
     String status = removed ? "removed" : "missing";
     if (acceptsJson(headers)) {
       return Response.ok(java.util.Map.of("status", status, "talkId", id))

--- a/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceQualityTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/service/UsageMetricsServiceQualityTest.java
@@ -2,6 +2,7 @@ package com.scanales.eventflow.service;
 
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,5 +29,18 @@ public class UsageMetricsServiceQualityTest {
     Map<String, Long> discards = metrics.getDiscarded();
     Assertions.assertEquals(1L, discards.getOrDefault("dedupe", 0L));
     Assertions.assertEquals(1L, discards.getOrDefault("bot", 0L));
+  }
+
+  @Test
+  public void talkRegisterAndUnregisterUpdatesMetrics() {
+    metrics.recordTalkRegister("t9", List.of(), "Mozilla/5.0", "User", "u@example.com");
+    Map<String, Long> snap = metrics.snapshot();
+    Assertions.assertEquals(1L, snap.getOrDefault("talk_register:t9", 0L));
+    Assertions.assertEquals(1, metrics.getRegistrants("t9").size());
+
+    metrics.recordTalkUnregister("t9", "u@example.com");
+    snap = metrics.snapshot();
+    Assertions.assertNull(snap.get("talk_register:t9"));
+    Assertions.assertTrue(metrics.getRegistrants("t9").isEmpty());
   }
 }


### PR DESCRIPTION
## Summary
- ensure removing a talk from profile decrements registration metrics
- track unique registrants by email and drop counter when last registrant leaves
- cover register/unregister flow with test

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b60e8931bc8333aaa0bf7548781222