### PR TITLE
feat: unify notification menu and toast controls

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -105,7 +105,11 @@
   }
   const container=document.getElementById('ef-toast-container');
   const manager=container?new ToastQueueManager(container):null;
+  function updateCloseAllVisibility(){if(manager)manager.updateCloseAll();}
+  window.updateCloseAllVisibility=updateCloseAllVisibility;
+  updateCloseAllVisibility();
   const badge=document.getElementById('notif-badge');
+  const UNREAD_KEY='ef_global_unread_count';
   let unread=0;
 
   function renderBadge(){
@@ -119,12 +123,13 @@
     }
   }
 
-  async function updateUnreadFromLocal(){
-    if(!window.EFNotificationsAdapter||!badge)return;
+  function updateUnreadFromLocal(){
+    if(!badge)return;
     try{
-      unread=await window.EFNotificationsAdapter.getUnreadCount();
-      renderBadge();
-    }catch(_){unread=0;renderBadge();}
+      const raw=localStorage.getItem(UNREAD_KEY);
+      unread=raw?parseInt(raw,10):0;
+    }catch(_){unread=0;}
+    renderBadge();
   }
   window.updateUnreadFromLocal=updateUnreadFromLocal;
   if(badge){

--- a/quarkus-app/src/main/resources/templates/_layout.qute.html
+++ b/quarkus-app/src/main/resources/templates/_layout.qute.html
@@ -3,12 +3,23 @@
 <head>
   <meta charset="UTF-8">
   <title>{#insert title}EventFlow{/insert}</title>
+  <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/css/notifications.css">
-</head>
-<body>
-  {#insert body}{/insert}
-  {#include fragments/toasts.qute.html/}
+  <script>window.__EF_NOTIFICATIONS_MODE__='global';</script>
+  <script src="/js/notifications-adapter.js" defer></script>
+  <script src="/js/app.js" defer></script>
   <script src="/js/notifications.js" defer></script>
   <script src="/js/global-notifications-ws.js" defer></script>
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Ir al contenido principal</a>
+  <header class="nav-menu" id="nav-menu" aria-label="Principal">
+    <a href="/" class="nav-logo"><h2 class="title">EventFlow</h2></a>
+    <div class="nav-links" id="primary-navigation" data-primary-navigation>
+      {#include fragments/notifications-bell.html/}
+    </div>
+  </header>
+  {#insert body}{/insert}
+  {#include fragments/toasts.qute.html/}
 </body>
 </html>

--- a/quarkus-app/src/main/resources/templates/fragments/notifications-bell.html
+++ b/quarkus-app/src/main/resources/templates/fragments/notifications-bell.html
@@ -1,12 +1,7 @@
-{@java.lang.Long unreadCount}
-<div class="notifications-bell">
-  <a href="/notifications/center" class="nav-link" aria-label="Notificaciones">
-    <span class="icon-bell" aria-hidden="true"></span>
-    <span class="sr-only">Notificaciones</span>
-    {#if unreadCount != null && unreadCount > 0}
-      <span class="badge">{unreadCount}</span>
-    {#else}
-      <span class="badge hidden">0</span>
-    {/if}
-  </a>
-</div>
+<a href="/notifications/center"
+   class="nav-link notifications-bell {#if currentPath?? && currentPath.startsWith('/notifications')}active{/if}"
+   aria-label="Notificaciones" data-nav-link>
+  <span class="icon-bell" aria-hidden="true"></span>
+  <span class="sr-only">Notificaciones</span>
+  <span id="notif-badge" class="badge hidden">0</span>
+</a>

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -28,11 +28,7 @@
                 <a href="/private/admin" data-nav-link>Admin</a>
             {/if}
         {/if}
-        <a href="/notifications/center" class="nav-link notifications-bell {#if currentPath?? && currentPath.startsWith('/notifications')}active{/if}" aria-label="Notificaciones" data-nav-link>
-            <span class="icon-bell" aria-hidden="true"></span>
-            <span class="sr-only">Notificaciones</span>
-            <span id="notif-badge" class="badge hidden">0</span>
-        </a>
+        {#include fragments/notifications-bell.html/}
         {#if app:isAuthenticated()}
             <div class="user-menu" data-user-menu>
                 <button id="userMenuBtn" class="user-menu-btn" data-user-menu-btn aria-label="Usuario" aria-expanded="false" aria-controls="userDropdown">


### PR DESCRIPTION
## Summary
- ensure notification bell link is consistent across Qute layouts
- read unread notification count from local storage and toggle badge
- expose function to hide "Cerrar todas" button when no toasts remain

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b639e096848333a0403d3d9715f940