### PR TITLE
Refine notification center UI and toast behavior

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/notifications.css
@@ -86,34 +86,21 @@
   overflow-wrap: anywhere;
 }
 
-.notifications-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+#notif-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-sm);
 }
 
-.notification-item {
-  display: flex;
-  flex-direction: column;
-  padding: 0.5rem;
-  min-height: 48px;
-  border-bottom: 1px solid #ddd;
-}
-
-.notification-title {
+.notifications-center .notif .title {
   font-weight: bold;
-  overflow-wrap: anywhere;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
-.notification-message {
-  overflow-wrap: anywhere;
+.notifications-center .notif .meta {
+  margin-top: var(--space-sm);
+  font-size: 0.875rem;
+  color: var(--color-text);
+  opacity: 0.7;
 }
 
 .notifications-center .actions {

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -100,7 +100,7 @@
   }
 
   function chipFor(n) {
-    const cat = (n.category || '').toLowerCase();
+    const cat = (n.category || 'announcement').toLowerCase();
     const label = cat === 'event' ? 'Evento' : cat === 'talk' ? 'Charla' : cat === 'break' ? 'Break' : 'Aviso';
     return `<span class="chip chip-${cat}">${label}</span>`;
   }

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -19,9 +19,9 @@
       const now=Date.now();
       this.timestamps=this.timestamps.filter(t=>now-t<this.rateLimitWindow);
       if(this.timestamps.length>=this.rateLimitMax){this.metric('rate_limited');return;}
-      if(this.visible.some(t=>t.id===vm.id)){this.metric('suppressed');return;}
+      if(this.visible.some(t=>t.id===vm.id)||this.queue.some(t=>t.id===vm.id)){this.metric('suppressed');return;}
       this.timestamps.push(now);
-      if(this.visible.length<this.maxVisible){this.show(vm);}else{this.queue.push(vm);} 
+      if(this.visible.length<this.maxVisible){this.show(vm);}else{this.queue.push(vm);}
       this.updateCloseAll();
     }
     show(vm){

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1440,6 +1440,30 @@ footer {
     background: var(--color-primary);
     color: var(--color-light);
 }
+
+.chip-event {
+    background: var(--color-primary);
+    color: var(--color-light);
+    border-color: var(--color-primary);
+}
+
+.chip-talk {
+    background: #2e7d32;
+    color: var(--color-light);
+    border-color: #2e7d32;
+}
+
+.chip-break {
+    background: #616161;
+    color: var(--color-light);
+    border-color: #616161;
+}
+
+.chip-announcement {
+    background: #ff9800;
+    color: #000;
+    border-color: #ff9800;
+}
 .chips {
     display: flex;
     flex-wrap: wrap;

--- a/quarkus-app/src/main/resources/templates/fragments/toasts.qute.html
+++ b/quarkus-app/src/main/resources/templates/fragments/toasts.qute.html
@@ -1,3 +1,3 @@
-<div id="ef-toast-container" role="status" aria-live="polite" data-max-visible="3" data-auto-dismiss-ms="6000" data-position="bottom">
+<div id="ef-toast-container" role="status" aria-live="polite" data-max-visible="4" data-auto-dismiss-ms="7000" data-position="bottom">
   <button id="ef-toast-close-all" class="ef-toast-close-all" type="button" aria-label="Cerrar todas" hidden>Cerrar todas</button>
 </div>

--- a/tests/notifications_smoke.md
+++ b/tests/notifications_smoke.md
@@ -1,0 +1,7 @@
+# Notifications smoke test
+
+1. Open two browser sessions: one authenticated and one anonymous (incognito).
+2. From **Admin → Broadcast demo**, send a demo notification.
+3. Ensure the toast appears on both clients and "Ver detalle" opens the `targetUrl`.
+4. Delete the notification from Admin.
+5. Open a new tab or client session and verify the deleted notification is not delivered.


### PR DESCRIPTION
## Summary
- unify notification center cards with global styles and tweak metadata layout
- add high-contrast chips per notification category
- improve toast queue deduplication and defaults; document a smoke test

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6635c83748333b362d38550b7219e