### PR TITLE
feat(admin): add notification simulation UI

### DIFF
--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/AdminNotificationSimulationPageResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/AdminNotificationSimulationPageResource.java
@@ -1,0 +1,26 @@
+package io.eventflow.notifications.global;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/** Admin page to simulate notifications. */
+@Path("/admin/notifications/sim")
+public class AdminNotificationSimulationPageResource {
+
+  @CheckedTemplate(basePath = "admin")
+  static class Templates {
+    static native TemplateInstance notifications_sim();
+  }
+
+  @GET
+  @Produces(MediaType.TEXT_HTML)
+  @RolesAllowed("admin")
+  public TemplateInstance page() {
+    return Templates.notifications_sim();
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotification.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotification.java
@@ -9,7 +9,9 @@ public class GlobalNotification {
   public String talkId; // optional (required for category=break)
   public String title;
   public String message;
+  public String targetUrl; // optional link for client navigation
   public long createdAt; // epoch millis
   public String dedupeKey; // hash(type|eventId|timeSlot)
   public Long expiresAt; // optional
+  public boolean test; // simulation flag
 }

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotificationService.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotificationService.java
@@ -122,9 +122,11 @@ class Json {
     if (n.talkId != null) b.add("talkId", n.talkId);
     if (n.title != null) b.add("title", n.title);
     if (n.message != null) b.add("message", n.message);
+    if (n.targetUrl != null) b.add("targetUrl", n.targetUrl);
     b.add("createdAt", n.createdAt);
     if (n.dedupeKey != null) b.add("dedupeKey", n.dedupeKey);
     if (n.expiresAt != null) b.add("expiresAt", n.expiresAt);
+    if (n.test) b.add("test", true);
     return b.build().toString();
   }
 }

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/NotificationSimulationResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/NotificationSimulationResource.java
@@ -1,0 +1,127 @@
+package io.eventflow.notifications.global;
+
+import io.eventflow.time.AppClock;
+import io.eventflow.time.SimulatedClock;
+import com.scanales.eventflow.service.EventService;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/** REST resource to simulate notification generation. */
+@Path("/admin/api/notifications/sim")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+@RolesAllowed("admin")
+public class NotificationSimulationResource {
+
+  @Inject SimulatedClock simClock;
+  @Inject AppClock appClock;
+  @Inject EventService events;
+  @Inject GlobalNotificationService service;
+
+  private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+
+  @ConfigProperty(name = "notifications.upcoming.window", defaultValue = "PT5M")
+  Duration upcomingWin;
+
+  @ConfigProperty(name = "notifications.endingSoon.window", defaultValue = "PT5M")
+  Duration endingWin;
+
+  @ConfigProperty(name = "notifications.simulation.allow-real", defaultValue = "false")
+  boolean allowReal;
+
+  @ConfigProperty(name = "notifications.simulation.max-items", defaultValue = "500")
+  int maxItems;
+
+  /** Request DTO. */
+  public static class SimRequest {
+    public String eventId;
+    public String mode; // preview | test-broadcast | real-broadcast
+    public Instant pivot;
+    public boolean includeEvent = true;
+    public boolean includeTalks = true;
+    public boolean includeBreaks = true;
+    public List<String> states;
+    public boolean sequence;
+    public long paceMs = 1500;
+  }
+
+  @POST
+  @Path("/dry-run")
+  public Response dryRun(SimRequest req) {
+    Instant pivot = Optional.ofNullable(req.pivot).orElse(appClock.now());
+    req.pivot = pivot;
+    simClock.set(pivot);
+    try {
+      List<GlobalNotification> plan =
+          SimulationEngine.plan(req, events, upcomingWin, endingWin);
+      if (plan.size() > maxItems) {
+        plan = plan.subList(0, maxItems);
+      }
+      return Response.ok(plan).build();
+    } finally {
+      simClock.clear();
+    }
+  }
+
+  @POST
+  @Path("/execute")
+  public Response execute(SimRequest req) {
+    Instant pivot = Optional.ofNullable(req.pivot).orElse(appClock.now());
+    req.pivot = pivot;
+    simClock.set(pivot);
+    try {
+      List<GlobalNotification> plan =
+          SimulationEngine.plan(req, events, upcomingWin, endingWin);
+      if (plan.size() > maxItems) {
+        plan = plan.subList(0, maxItems);
+      }
+      if ("preview".equals(req.mode) || req.mode == null) {
+        return Response.ok(plan).build();
+      }
+      if ("real-broadcast".equals(req.mode) && !allowReal) {
+        return Response.status(Response.Status.FORBIDDEN)
+            .entity(Map.of("error", "real-broadcast disabled"))
+            .build();
+      }
+      boolean testFlag = !"real-broadcast".equals(req.mode);
+      if (req.sequence) {
+        final Instant p = pivot;
+        for (int i = 0; i < plan.size(); i++) {
+          GlobalNotification n = plan.get(i);
+          long delay = Math.max(0, req.paceMs) * i;
+          scheduler.schedule(
+              () -> {
+                simClock.set(p);
+                try {
+                  n.test = testFlag;
+                  n.createdAt = p.toEpochMilli();
+                  service.enqueue(n);
+                } finally {
+                  simClock.clear();
+                }
+              },
+              delay,
+              TimeUnit.MILLISECONDS);
+        }
+        return Response.accepted(Map.of("scheduled", plan.size(), "test", testFlag)).build();
+      }
+      for (GlobalNotification n : plan) {
+        n.test = testFlag;
+        n.createdAt = pivot.toEpochMilli();
+        service.enqueue(n);
+      }
+      return Response.ok(Map.of("enqueued", plan.size(), "test", testFlag)).build();
+    } finally {
+      simClock.clear();
+    }
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/SimulationEngine.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/SimulationEngine.java
@@ -1,0 +1,144 @@
+package io.eventflow.notifications.global;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import java.time.*;
+import java.util.*;
+
+/** Utility to compute which notifications would be emitted at a given instant. */
+public class SimulationEngine {
+
+  public static List<GlobalNotification> plan(
+      NotificationSimulationResource.SimRequest req,
+      EventService events,
+      Duration upcomingWin,
+      Duration endingWin) {
+    List<GlobalNotification> out = new ArrayList<>();
+    Instant pivot = req.pivot;
+    List<String> states =
+        req.states != null
+            ? req.states
+            : List.of("UPCOMING", "STARTED", "ENDING_SOON", "FINISHED");
+    for (Event ev : events.listEvents()) {
+      if (req.eventId != null && !req.eventId.equals(ev.getId())) continue;
+      ZoneId tz = ev.getZoneId();
+      ZonedDateTime now = ZonedDateTime.ofInstant(pivot, tz);
+      if (req.includeEvent) {
+        evalEvent(ev, now, upcomingWin, endingWin, states, pivot, out);
+      }
+      if ((req.includeTalks || req.includeBreaks) && ev.getAgenda() != null) {
+        for (Talk t : ev.getAgenda()) {
+          if (t.getStartTime() == null) continue;
+          boolean isBreak = t.isBreak();
+          if (isBreak && !req.includeBreaks) continue;
+          if (!isBreak && !req.includeTalks) continue;
+          ZonedDateTime start =
+              ZonedDateTime.of(ev.getDate().plusDays(t.getDay() - 1), t.getStartTime(), tz);
+          ZonedDateTime end = start.plusMinutes(t.getDurationMinutes());
+          evalSlot(ev, t, isBreak ? "break" : "talk", start, end, now, upcomingWin, endingWin,
+              states, pivot, out);
+        }
+      }
+    }
+    return out;
+  }
+
+  private static void evalEvent(
+      Event ev,
+      ZonedDateTime now,
+      Duration upcomingWin,
+      Duration endingWin,
+      List<String> states,
+      Instant pivot,
+      List<GlobalNotification> out) {
+    ZonedDateTime start = ev.getStartDateTime();
+    ZonedDateTime end = ev.getEndDateTime();
+    if (start == null || end == null) return;
+    if (states.contains("UPCOMING") && inWindow(now, start.minus(upcomingWin), start)) {
+      out.add(create("event", ev.getId(), null, ev.getTitle(), "UPCOMING", start, pivot));
+    }
+    if (states.contains("STARTED") && !now.isBefore(start) && now.isBefore(end)) {
+      out.add(create("event", ev.getId(), null, ev.getTitle(), "STARTED", start, pivot));
+    }
+    if (states.contains("ENDING_SOON") && inWindow(now, end.minus(endingWin), end)) {
+      out.add(create("event", ev.getId(), null, ev.getTitle(), "ENDING_SOON", end, pivot));
+    }
+    if (states.contains("FINISHED") && !now.isBefore(end)) {
+      out.add(create("event", ev.getId(), null, ev.getTitle(), "FINISHED", end, pivot));
+    }
+  }
+
+  private static void evalSlot(
+      Event ev,
+      Talk t,
+      String category,
+      ZonedDateTime start,
+      ZonedDateTime end,
+      ZonedDateTime now,
+      Duration upcomingWin,
+      Duration endingWin,
+      List<String> states,
+      Instant pivot,
+      List<GlobalNotification> out) {
+    if (states.contains("UPCOMING") && inWindow(now, start.minus(upcomingWin), start)) {
+      out.add(create(category, ev.getId(), t.getId(), t.getName(), "UPCOMING", start, pivot));
+    }
+    if (states.contains("STARTED") && !now.isBefore(start) && now.isBefore(end)) {
+      out.add(create(category, ev.getId(), t.getId(), t.getName(), "STARTED", start, pivot));
+    }
+    if (states.contains("ENDING_SOON") && inWindow(now, end.minus(endingWin), end)) {
+      out.add(create(category, ev.getId(), t.getId(), t.getName(), "ENDING_SOON", end, pivot));
+    }
+    if (states.contains("FINISHED") && !now.isBefore(end)) {
+      out.add(create(category, ev.getId(), t.getId(), t.getName(), "FINISHED", end, pivot));
+    }
+  }
+
+  private static boolean inWindow(ZonedDateTime now, ZonedDateTime from, ZonedDateTime to) {
+    return !now.isBefore(from) && now.isBefore(to);
+  }
+
+  private static GlobalNotification create(
+      String category,
+      String eventId,
+      String talkId,
+      String message,
+      String type,
+      ZonedDateTime edge,
+      Instant pivot) {
+    GlobalNotification n = new GlobalNotification();
+    n.type = type;
+    n.category = category;
+    n.eventId = eventId;
+    n.talkId = talkId;
+    n.message = message;
+    n.title = titleFor(category, type);
+    n.createdAt = pivot.toEpochMilli();
+    n.dedupeKey =
+        String.format(
+            "global:%s:%s:%s:%d",
+            category,
+            talkId != null ? talkId : eventId,
+            type,
+            edge.toEpochSecond());
+    return n;
+  }
+
+  private static String titleFor(String category, String type) {
+    String base =
+        switch (category) {
+          case "event" -> "El evento";
+          case "talk" -> "La charla";
+          case "break" -> "Break";
+          default -> "Aviso";
+        };
+    return switch (type) {
+      case "UPCOMING" -> base + " comienza pronto";
+      case "STARTED" -> base + " en curso";
+      case "ENDING_SOON" -> base + " por finalizar";
+      case "FINISHED" -> base + " finalizado";
+      default -> base;
+    };
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/time/AppClock.java
+++ b/quarkus-app/src/main/java/io/eventflow/time/AppClock.java
@@ -1,0 +1,14 @@
+package io.eventflow.time;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/** Simple abstraction over the system clock allowing simulation. */
+public interface AppClock {
+  /** Returns current instant. */
+  Instant now();
+
+  /** Returns current date time in given zone. */
+  ZonedDateTime now(ZoneId zone);
+}

--- a/quarkus-app/src/main/java/io/eventflow/time/SimulatedClock.java
+++ b/quarkus-app/src/main/java/io/eventflow/time/SimulatedClock.java
@@ -1,0 +1,36 @@
+package io.eventflow.time;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/** Holds an overridable instant for simulation purposes. */
+@ApplicationScoped
+@Named("simClock")
+public class SimulatedClock {
+  private final AtomicReference<Instant> override = new AtomicReference<>();
+
+  public boolean isActive() {
+    return override.get() != null;
+  }
+
+  public void set(Instant instant) {
+    override.set(instant);
+  }
+
+  public void clear() {
+    override.set(null);
+  }
+
+  public Instant now() {
+    return Optional.ofNullable(override.get()).orElseGet(Instant::now);
+  }
+
+  public ZonedDateTime now(ZoneId zone) {
+    return ZonedDateTime.ofInstant(now(), zone);
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/time/SystemAppClock.java
+++ b/quarkus-app/src/main/java/io/eventflow/time/SystemAppClock.java
@@ -1,0 +1,25 @@
+package io.eventflow.time;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.annotation.Nullable;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/** Default implementation delegating to system clock unless a simulation is active. */
+@ApplicationScoped
+public class SystemAppClock implements AppClock {
+  @Inject @Nullable @Named("simClock") SimulatedClock sim;
+
+  @Override
+  public Instant now() {
+    return sim != null && sim.isActive() ? sim.now() : Instant.now();
+  }
+
+  @Override
+  public ZonedDateTime now(ZoneId zone) {
+    return sim != null && sim.isActive() ? sim.now(zone) : ZonedDateTime.now(zone);
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
@@ -1,0 +1,78 @@
+(function () {
+  const form = document.getElementById('simForm');
+  const previewBtn = document.getElementById('previewBtn');
+  const emitBtn = document.getElementById('emitBtn');
+  const seqBtn = document.getElementById('sequenceBtn');
+  const resultsTable = document.getElementById('results');
+  const optinToggle = document.getElementById('optinToggle');
+  optinToggle.checked = localStorage.getItem('ef_notif_test_optin') === 'true';
+  optinToggle.addEventListener('change', (e) => {
+    localStorage.setItem('ef_notif_test_optin', e.target.checked ? 'true' : 'false');
+  });
+
+  function buildReq() {
+    const states = Array.from(form.querySelectorAll('input[name="state"]:checked')).map(
+      (c) => c.value
+    );
+    const pivotVal = document.getElementById('pivot').value;
+    return {
+      eventId: document.getElementById('eventId').value || null,
+      pivot: pivotVal ? new Date(pivotVal).toISOString() : null,
+      includeEvent: document.getElementById('incEvent').checked,
+      includeTalks: document.getElementById('incTalks').checked,
+      includeBreaks: document.getElementById('incBreaks').checked,
+      states: states,
+    };
+  }
+
+  function render(plan) {
+    const tbody = resultsTable.querySelector('tbody');
+    tbody.innerHTML = '';
+    plan.forEach((n) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${n.type || ''}</td><td>${n.category || ''}</td><td>${n.title || ''}</td><td>${n.message || ''}</td>`;
+      tbody.appendChild(tr);
+    });
+    resultsTable.classList.toggle('hidden', plan.length === 0);
+  }
+
+  previewBtn.addEventListener('click', async () => {
+    const req = buildReq();
+    const res = await fetch('/admin/api/notifications/sim/dry-run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    if (res.ok) {
+      render(await res.json());
+    }
+  });
+
+  emitBtn.addEventListener('click', async () => {
+    const req = buildReq();
+    req.mode = 'test-broadcast';
+    const res = await fetch('/admin/api/notifications/sim/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    if (res.ok) {
+      const out = await res.json();
+      alert('Enqueued ' + out.enqueued + ' notificaciones de prueba');
+    }
+  });
+
+  seqBtn.addEventListener('click', async () => {
+    const req = buildReq();
+    req.mode = 'test-broadcast';
+    req.sequence = true;
+    const res = await fetch('/admin/api/notifications/sim/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req),
+    });
+    if (res.ok) {
+      alert('Reproducción secuencial iniciada');
+    }
+  });
+})();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/global-notifications-ws.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/global-notifications-ws.js
@@ -13,6 +13,12 @@
     ws.onmessage = (ev) => {
       const msg = JSON.parse(ev.data);
       if (msg.t === 'notif') {
+        if (msg.test) {
+          const optin =
+            localStorage.getItem('ef_notif_test_optin') === 'true' ||
+            window.location.search.includes('test=1');
+          if (!optin) return;
+        }
         const last = Number(localStorage.getItem(storeKey)) || 0;
         if (msg.createdAt && msg.createdAt > last) {
           localStorage.setItem(storeKey, String(msg.createdAt));

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -83,3 +83,6 @@ notifications.backpressure.cutoff.evaluator-queue-depth=8000
 
 # Global notifications
 notifications.global.enabled=true
+notifications.simulation.enabled=true
+notifications.simulation.allow-real=false
+notifications.simulation.max-items=500

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -11,6 +11,7 @@
         <a href="/private/admin/metrics" class="btn">Métricas</a>
         <a href="/private/admin/capacity" class="btn">Capacidad</a>
         <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
+        <a href="/admin/notifications" class="btn">Notificaciones</a>
         <a href="/private/admin/guide" class="btn">Guía</a>
         <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
     </div>

--- a/quarkus-app/src/main/resources/templates/admin/notifications-sim.qute.html
+++ b/quarkus-app/src/main/resources/templates/admin/notifications-sim.qute.html
@@ -1,0 +1,37 @@
+{#include layout/base}
+{#title}Simular notificaciones{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><a href="/admin/notifications">Notificaciones</a><span class="sep">/</span><span>Simular</span>{/breadcrumbs}
+{#main}
+<section class="container mx-auto px-4 py-6">
+  <h1 class="text-2xl font-semibold mb-4">Simular notificaciones</h1>
+  <form id="simForm" class="grid gap-3 card p-4">
+    <label class="sr-only" for="eventId">ID del evento</label>
+    <input id="eventId" class="input" placeholder="ID de evento">
+    <label class="sr-only" for="pivot">Hora pivote</label>
+    <input id="pivot" type="datetime-local" class="input">
+    <div class="row gap-2">
+      <label><input type="checkbox" id="incEvent" checked> Evento</label>
+      <label><input type="checkbox" id="incTalks" checked> Charlas</label>
+      <label><input type="checkbox" id="incBreaks" checked> Breaks</label>
+    </div>
+    <div class="row gap-2">
+      <label><input type="checkbox" name="state" value="UPCOMING" checked> UPCOMING</label>
+      <label><input type="checkbox" name="state" value="STARTED" checked> STARTED</label>
+      <label><input type="checkbox" name="state" value="ENDING_SOON" checked> ENDING_SOON</label>
+      <label><input type="checkbox" name="state" value="FINISHED" checked> FINISHED</label>
+    </div>
+    <div class="row gap-2">
+      <button id="previewBtn" class="btn-secondary" type="button">Previsualizar</button>
+      <button id="emitBtn" class="btn-primary" type="button">Emitir prueba</button>
+      <button id="sequenceBtn" class="btn" type="button">Reproducción secuencial</button>
+    </div>
+    <label class="flex items-center gap-2"><input type="checkbox" id="optinToggle"> Ver simulaciones en este navegador</label>
+  </form>
+  <table id="results" class="mt-4 table-auto w-full hidden">
+    <thead><tr><th>Tipo</th><th>Categoría</th><th>Título</th><th>Mensaje</th></tr></thead>
+    <tbody></tbody>
+  </table>
+</section>
+<script defer src="/js/admin-notifications-sim.js"></script>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/admin/notifications.qute.html
+++ b/quarkus-app/src/main/resources/templates/admin/notifications.qute.html
@@ -4,6 +4,9 @@
 {#main}
 <section class="container mx-auto px-4 py-6">
   <h1 class="text-2xl font-semibold mb-4">Broadcast de Notificaciones</h1>
+  <div class="mb-4">
+    <a href="/admin/notifications/sim" class="btn-secondary">Simular notificaciones</a>
+  </div>
   <form id="broadcast" class="grid gap-3 card p-4">
     <div class="row gap-2">
       <label class="sr-only" for="type">Tipo de notificación</label>

--- a/quarkus-app/src/test/java/io/eventflow/notifications/global/NotificationSimulationResourceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/global/NotificationSimulationResourceTest.java
@@ -1,0 +1,100 @@
+package io.eventflow.notifications.global;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
+import java.time.*;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class NotificationSimulationResourceTest {
+
+  @Inject EventService events;
+  @Inject GlobalNotificationService service;
+
+  private Event sampleEvent() {
+    Event e = new Event("e1", "Ev", "d");
+    e.setDate(LocalDate.of(2023, 1, 1));
+    e.setTimezone("UTC");
+    Talk t1 = new Talk("t1", "Talk1");
+    t1.setStartTime(LocalTime.of(10, 0));
+    t1.setDurationMinutes(60);
+    e.getAgenda().add(t1);
+    return e;
+  }
+
+  @BeforeEach
+  void setup() {
+    events.reset();
+    service.clearAll();
+  }
+
+  @Test
+  @TestSecurity(user = "admin", roles = {"admin"})
+  public void dryRunIncludesUpcoming() {
+    Event e = sampleEvent();
+    events.saveEvent(e);
+    Instant pivot = e.getStartDateTime().minusMinutes(5).toInstant();
+    Map<String, Object> req = Map.of("eventId", e.getId(), "pivot", pivot.toString());
+    String json =
+        given()
+            .contentType(ContentType.JSON)
+            .body(req)
+            .when()
+            .post("/admin/api/notifications/sim/dry-run")
+            .then()
+            .statusCode(200)
+            .extract()
+            .asString();
+    assertTrue(json.contains("UPCOMING"));
+  }
+
+  @Test
+  @TestSecurity(user = "admin", roles = {"admin"})
+  public void executeTestBroadcastEnqueues() {
+    Event e = sampleEvent();
+    events.saveEvent(e);
+    Instant pivot = e.getStartDateTime().minusMinutes(5).toInstant();
+    Map<String, Object> req =
+        new HashMap<>();
+    req.put("eventId", e.getId());
+    req.put("mode", "test-broadcast");
+    req.put("pivot", pivot.toString());
+    given()
+        .contentType(ContentType.JSON)
+        .body(req)
+        .when()
+        .post("/admin/api/notifications/sim/execute")
+        .then()
+        .statusCode(200)
+        .body("test", equalTo(true));
+    assertTrue(service.latest(10).stream().anyMatch(n -> n.test));
+  }
+
+  @Test
+  @TestSecurity(user = "admin", roles = {"admin"})
+  public void realBroadcastForbidden() {
+    Event e = sampleEvent();
+    events.saveEvent(e);
+    Instant pivot = e.getStartDateTime().minusMinutes(5).toInstant();
+    Map<String, Object> req =
+        Map.of("eventId", e.getId(), "mode", "real-broadcast", "pivot", pivot.toString());
+    given()
+        .contentType(ContentType.JSON)
+        .body(req)
+        .when()
+        .post("/admin/api/notifications/sim/execute")
+        .then()
+        .statusCode(403);
+  }
+}


### PR DESCRIPTION
## Summary
- add admin simulation page to preview and emit test notifications
- support sequential playback in simulation API
- wire navigation links for new simulation tool

## Testing
- `./mvnw -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d0082d948333b529eaf22a79bee8