### PR TITLE
feat: add notification simulation admin page

### DIFF
--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/AdminNotificationSimulationResource.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/AdminNotificationSimulationResource.java
@@ -1,0 +1,26 @@
+package io.eventflow.notifications.global;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/** Admin page for simulating notification runs. */
+@Path("/admin/notifications/sim")
+public class AdminNotificationSimulationResource {
+
+    @CheckedTemplate
+    static class Templates {
+        static native TemplateInstance index();
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    @RolesAllowed("admin")
+    public TemplateInstance page() {
+        return Templates.index();
+    }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/admin-notifications-sim.js
@@ -1,0 +1,46 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const eventId = document.getElementById('eventId');
+  const pivot = document.getElementById('pivot');
+  const states = document.getElementById('states');
+  const resultsTable = document.getElementById('results');
+  const resultsBody = resultsTable.querySelector('tbody');
+  const optin = document.getElementById('optin');
+
+  // initialise opt-in state
+  optin.checked = localStorage.getItem('ef_notif_test_optin') === '1';
+  optin.addEventListener('change', () => {
+    if (optin.checked) {
+      localStorage.setItem('ef_notif_test_optin', '1');
+    } else {
+      localStorage.removeItem('ef_notif_test_optin');
+    }
+  });
+
+  function collectParams() {
+    return {
+      eventId: eventId.value || undefined,
+      pivot: pivot.value,
+      states: Array.from(states.selectedOptions).map(o => o.value),
+    };
+  }
+
+  async function call(url) {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(collectParams()),
+    });
+    const data = await resp.json();
+    resultsBody.innerHTML = '';
+    data.forEach(row => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td class="border px-2 py-1">${row.recipient || ''}</td><td class="border px-2 py-1">${row.message || ''}</td>`;
+      resultsBody.appendChild(tr);
+    });
+    resultsTable.classList.remove('hidden');
+  }
+
+  document.getElementById('preview').addEventListener('click', () => call('/admin/api/notifications/sim/dry-run'));
+  document.getElementById('execute').addEventListener('click', () => call('/admin/api/notifications/sim/execute'));
+  document.getElementById('replay').addEventListener('click', () => call('/admin/api/notifications/sim/execute?mode=sequential'));
+});

--- a/quarkus-app/src/main/resources/templates/AdminNotificationSimulationResource/index.html
+++ b/quarkus-app/src/main/resources/templates/AdminNotificationSimulationResource/index.html
@@ -1,0 +1,39 @@
+{#include layout/base}
+{#title}Simulación de notificaciones{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Simulación de notificaciones</span>{/breadcrumbs}
+{#main}
+<section class="container mx-auto px-4 py-6">
+  <h1 class="text-2xl font-semibold mb-4">Simulación de notificaciones</h1>
+  <form id="sim-form" class="grid gap-3 card p-4">
+    <div class="row gap-2">
+      <label class="sr-only" for="eventId">Evento</label>
+      <input id="eventId" class="input" name="eventId" placeholder="ID de evento (opcional)">
+      <label class="sr-only" for="pivot">Hora pivote</label>
+      <input id="pivot" class="input" type="datetime-local" name="pivot">
+    </div>
+    <label class="sr-only" for="states">Estados</label>
+    <select id="states" class="input" multiple>
+      <option value="UPCOMING">UPCOMING</option>
+      <option value="LIVE">LIVE</option>
+      <option value="ENDED">ENDED</option>
+    </select>
+    <div class="row gap-2 items-center flex-wrap">
+      <button id="preview" type="button" class="btn-primary">Previsualizar</button>
+      <button id="execute" type="button" class="btn-secondary">Emitir prueba</button>
+      <button id="replay" type="button" class="btn-secondary">Reproducción secuencial</button>
+      <label class="row gap-1 items-center ml-auto">
+        <input type="checkbox" id="optin" class="input w-4 h-4">
+        <span class="text-sm">Ver simulaciones en este navegador</span>
+      </label>
+    </div>
+  </form>
+  <table id="results" class="min-w-full mt-4 hidden">
+    <thead>
+      <tr><th class="px-2 py-1 text-left">Destino</th><th class="px-2 py-1 text-left">Mensaje</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</section>
+<script defer src="/js/admin-notifications-sim.js"></script>
+{/main}
+{/include}

--- a/quarkus-app/src/main/resources/templates/AdminResource/admin.html
+++ b/quarkus-app/src/main/resources/templates/AdminResource/admin.html
@@ -12,6 +12,8 @@
         <a href="/private/admin/capacity" class="btn">Capacidad</a>
         <a href="/private/admin/backup" class="btn">Respaldo de datos</a>
         <a href="/private/admin/guide" class="btn">Guía</a>
+        <a href="/admin/notifications" class="btn">Broadcast de notificaciones</a>
+        <a href="/admin/notifications/sim" class="btn">Simulación de notificaciones</a>
         <a href="/private/profile" class="btn btn-secondary">Volver a perfil</a>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- add AdminNotificationSimulationResource exposing `/admin/notifications/sim`
- add Qute template and JS for running notification simulations
- link admin panel to broadcast and simulation pages

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d41152c883338e5d0774c1364348