### PR TITLE
Add simulation template for admin notifications

### DIFF
--- a/quarkus-app/src/main/resources/templates/admin/notifications_sim.qute.html
+++ b/quarkus-app/src/main/resources/templates/admin/notifications_sim.qute.html
@@ -1,0 +1,43 @@
+{#include layout/base}
+{#title}Simulación de Notificaciones{/title}
+{#breadcrumbs}<a href="/private/admin">Admin</a><span class="sep">/</span><span>Simulación de Notificaciones</span>{/breadcrumbs}
+{#main}
+<section class="container mx-auto px-4 py-6">
+  <h1 class="text-2xl font-semibold mb-4">Simulación de Notificaciones</h1>
+  <form id="broadcast" class="grid gap-3 card p-4">
+    <div class="row gap-2">
+      <label class="sr-only" for="type">Tipo de notificación</label>
+      <select id="type" name="type" class="input"><option>AGENDA_UPDATED</option><option>ANNOUNCEMENT</option></select>
+      <label class="sr-only" for="eventId">ID de evento (opcional)</label>
+      <input id="eventId" class="input" name="eventId" placeholder="eventId (opcional)">
+    </div>
+    <label class="sr-only" for="title">Título</label>
+    <input id="title" class="input" name="title" placeholder="Título" required>
+    <label class="sr-only" for="message">Mensaje</label>
+    <textarea id="message" class="input" name="message" placeholder="Mensaje" required></textarea>
+    <label class="sr-only" for="expiresMinutes">Expira en minutos</label>
+    <input
+      id="expiresMinutes"
+      class="input"
+      name="expiresMinutes"
+      type="number"
+      min="1"
+      placeholder="Expira en minutos (opcional)"
+    >
+    <div class="row gap-2">
+      <button class="btn-primary" type="submit">Enviar a todos</button>
+      <span class="text-sm text-muted-foreground">Se emite a todos los conectados; persistirá en el backlog global.</span>
+    </div>
+  </form>
+
+  <div class="mt-4 row gap-2">
+    <button id="broadcast-demo" class="btn-secondary" type="button">Broadcast demo</button>
+    <button id="clearAll" class="btn-danger" type="button">Borrar backlog</button>
+  </div>
+
+  <h2 class="text-xl font-semibold mt-8 mb-3">Últimas notificaciones</h2>
+  <div id="admin-list" class="grid gap-2"></div>
+</section>
+<script defer src="/js/admin-notifications.js"></script>
+{/main}
+{/include}


### PR DESCRIPTION
## Summary
- add Qute template `notifications_sim.qute.html` for admin notification simulation page

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_68b6dee4e6ec83338be30fa547a42d66