### PR TITLE
feat: grant admin role based on email

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/AdminRoleAugmentor.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/AdminRoleAugmentor.java
@@ -1,6 +1,7 @@
 package com.scanales.eventflow.security;
 
 import com.scanales.eventflow.util.AdminUtils;
+import io.quarkus.security.identity.AuthenticationRequestContext;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
@@ -15,7 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class AdminRoleAugmentor implements SecurityIdentityAugmentor {
 
   @Override
-  public Uni<SecurityIdentity> augment(SecurityIdentity identity) {
+  public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
     if (identity != null && AdminUtils.isAdmin(identity) && !identity.getRoles().contains("admin")) {
       return Uni.createFrom().item(QuarkusSecurityIdentity.builder(identity).addRole("admin").build());
     }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/AdminRoleAugmentor.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/AdminRoleAugmentor.java
@@ -3,7 +3,6 @@ package com.scanales.eventflow.security;
 import com.scanales.eventflow.util.AdminUtils;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.identity.SecurityIdentityAugmentor;
-import io.quarkus.security.identity.request.AuthenticationRequestContext;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
 import io.smallrye.mutiny.Uni;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,7 +15,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 public class AdminRoleAugmentor implements SecurityIdentityAugmentor {
 
   @Override
-  public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+  public Uni<SecurityIdentity> augment(SecurityIdentity identity) {
     if (identity != null && AdminUtils.isAdmin(identity) && !identity.getRoles().contains("admin")) {
       return Uni.createFrom().item(QuarkusSecurityIdentity.builder(identity).addRole("admin").build());
     }

--- a/quarkus-app/src/main/java/com/scanales/eventflow/security/AdminRoleAugmentor.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/security/AdminRoleAugmentor.java
@@ -1,0 +1,30 @@
+package com.scanales.eventflow.security;
+
+import com.scanales.eventflow.util.AdminUtils;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.SecurityIdentityAugmentor;
+import io.quarkus.security.identity.request.AuthenticationRequestContext;
+import io.quarkus.security.runtime.QuarkusSecurityIdentity;
+import io.smallrye.mutiny.Uni;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Adds the {@code admin} role to authenticated identities whose email matches the
+ * {@code ADMIN_LIST} configuration property.
+ */
+@ApplicationScoped
+public class AdminRoleAugmentor implements SecurityIdentityAugmentor {
+
+  @Override
+  public Uni<SecurityIdentity> augment(SecurityIdentity identity, AuthenticationRequestContext context) {
+    if (identity != null && AdminUtils.isAdmin(identity) && !identity.getRoles().contains("admin")) {
+      return Uni.createFrom().item(QuarkusSecurityIdentity.builder(identity).addRole("admin").build());
+    }
+    return Uni.createFrom().item(identity);
+  }
+
+  @Override
+  public int priority() {
+    return 1;
+  }
+}

--- a/quarkus-app/src/test/java/io/eventflow/notifications/global/AdminNotificationPageAccessTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/global/AdminNotificationPageAccessTest.java
@@ -1,0 +1,23 @@
+package io.eventflow.notifications.global;
+
+import static io.restassured.RestAssured.given;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class AdminNotificationPageAccessTest {
+
+  @Test
+  @TestSecurity(user = "sergio.canales.e@gmail.com")
+  public void adminFromListCanAccess() {
+    given().when().get("/admin/notifications").then().statusCode(200);
+  }
+
+  @Test
+  @TestSecurity(user = "alice")
+  public void nonAdminGets403() {
+    given().when().get("/admin/notifications").then().statusCode(403);
+  }
+}


### PR DESCRIPTION
## Summary
- grant `admin` role to authenticated users whose email is in `ADMIN_LIST`
- add tests verifying admin-list-based access to notification page

## Testing
- `./mvnw test -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76ee4dad08333940ad640b07a579b