### PR TITLE
feat: link toast to notification center

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications-center.js
@@ -74,11 +74,13 @@
       const div = document.createElement('div');
       div.className = 'card notif';
       div.dataset.id = n.id;
+      if (n.id) div.id = n.id;
 
       const checked = selected.has(n.id) ? 'checked' : '';
       const readLabel = n.readAt ? 'No leída' : 'Leída';
       const chip = chipFor(n);
       const url = n.targetUrl || (n.talkId ? `/talks/${encodeURIComponent(n.talkId)}` : '/notifications/center');
+      const linkLabel = n.talkId ? 'Ver charla' : 'Revisar';
 
       div.innerHTML = `
         <div class="row items-start gap-3">
@@ -90,7 +92,7 @@
           </div>
           <div class="col shrink">
             <button class="btn-link js-read" data-id="${n.id}">${readLabel}</button>
-            <a class="btn-link js-open" data-id="${n.id}" href="${escapeAttr(url)}" rel="nofollow">Revisar</a>
+            <a class="btn-link js-open" data-id="${n.id}" href="${escapeAttr(url)}" rel="nofollow">${linkLabel}</a>
           </div>
         </div>`;
       listEl.appendChild(div);
@@ -262,5 +264,10 @@
   render();
   if (window.updateUnreadFromLocal) {
     window.updateUnreadFromLocal();
+  }
+  const hash = window.location.hash.slice(1);
+  if (hash) {
+    const el = document.getElementById(hash);
+    if (el) el.scrollIntoView();
   }
 })();

--- a/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
+++ b/quarkus-app/src/main/resources/META-INF/resources/js/notifications.js
@@ -62,6 +62,12 @@
       toast.appendChild(msg);
       const actions=document.createElement('div');
       actions.className='ef-toast__actions';
+      if(vm.centerUrl){
+        const detail=document.createElement('a');
+        detail.href=vm.centerUrl;
+        detail.textContent='Ver detalle';
+        actions.appendChild(detail);
+      }
       if(vm.url){
         const link=document.createElement('a');
         link.href=vm.url;
@@ -143,11 +149,13 @@
     accept(dto){
       if(window.updateUnreadFromLocal)window.updateUnreadFromLocal();
       if(!manager)return;
+      const id=dto.id||uid();
       const vm={
-        id:dto.id||uid(),
+        id:id,
         title:dto.title||dto.type,
         message:dto.message||'',
-        url:(dto.talkId && dto.category!== 'break')?('/talks/'+dto.talkId):null
+        url:(dto.talkId && dto.category!=='break')?('/talks/'+dto.talkId):null,
+        centerUrl:dto.id?('/notifications/center#'+dto.id):'/notifications/center'
       };
       manager.enqueue(vm);
     },


### PR DESCRIPTION
## Summary
- add link from toast notifications to notification center
- show talk link on notifications center items
- support scrolling to specific notification via hash

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8240474888333a8d86e988cc9fdc1