### PR TITLE
Highlight event title link to details

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1018,12 +1018,18 @@ p.note {
 
 .event-name a {
     color: var(--color-primary);
-    text-decoration: none;
+    text-decoration: underline;
 }
 
 .event-name a:visited {
     color: var(--color-primary);
-    text-decoration: none;
+    text-decoration: underline;
+}
+
+.event-name a::after {
+    content: " \2192";
+    margin-left: 0.25rem;
+    font-size: 0.9rem;
 }
 
 .event-date {

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -21,7 +21,7 @@
                         {/if}
                     </div>
                     <div class="event-main">
-                        <h2 class="event-name"><a href="/event/{e.id}">{e.title}</a></h2>
+                        <h2 class="event-name"><a href="/event/{e.id}" title="Ver detalles del evento">{e.title}</a></h2>
                         {#if e.isOngoing()}
                         <span class="badge info">En curso</span>
                         {/if}
@@ -70,7 +70,7 @@
                             {/if}
                         </div>
                         <div class="event-main">
-                            <h2 class="event-name"><a href="/event/{e.id}">{e.title}</a></h2>
+                            <h2 class="event-name"><a href="/event/{e.id}" title="Ver detalles del evento">{e.title}</a></h2>
                             {#if e.descriptionSummary}
                             <p class="event-description">{e.descriptionSummary}</p>
                             {/if}


### PR DESCRIPTION
## Summary
- underline event titles and append arrow icon to clarify they link to detailed pages
- add title attribute on event titles for accessibility

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d96bddb48333a41dd1e674574186