### PR TITLE
Fix scenario column truncation in agenda table

### DIFF
--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -696,6 +696,17 @@ a.nav-logo:hover {
     color: var(--color-light);
 }
 
+/* Allow agenda table to size columns based on content */
+.table.agenda-table {
+    table-layout: auto;
+}
+
+/* Prevent truncation of scenario names in agenda table */
+.agenda-location {
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+
 /* --- Admin speaker list --- */
 .speaker-list,
 .talk-list {

--- a/quarkus-app/src/main/resources/templates/EventResource/detail.html
+++ b/quarkus-app/src/main/resources/templates/EventResource/detail.html
@@ -81,9 +81,9 @@ Evento
         <table class="table agenda-table">
           <colgroup>
             <col style="width: 12%;">
-            <col style="width: 68%;">
+            <col style="width: 60%;">
             <col style="width: 10%;">
-            <col style="width: 10%;">
+            <col style="width: 18%;">
           </colgroup>
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- prevent scenario names from being truncated in the agenda table
- increase scenario column width for better readability

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9fd71208333bebda910753aa469