### PR TITLE
feat(home): add "Ocurriendo ahora" box

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -3,6 +3,8 @@ package com.scanales.eventflow.public_;
 import com.scanales.eventflow.model.Event;
 import com.scanales.eventflow.service.EventService;
 import com.scanales.eventflow.service.UsageMetricsService;
+import io.eventflow.home.now.NowBoxService;
+import io.eventflow.home.now.NowBoxView;
 import io.quarkus.qute.CheckedTemplate;
 import io.quarkus.qute.TemplateInstance;
 import jakarta.annotation.security.PermitAll;
@@ -27,6 +29,8 @@ public class HomeResource {
 
   @Inject UsageMetricsService metrics;
 
+  @Inject NowBoxService nowBoxService;
+
   @CheckedTemplate
   static class Templates {
     static native TemplateInstance home(
@@ -35,7 +39,8 @@ public class HomeResource {
         LocalDate today,
         String version,
         Map<String, String> stats,
-        Map<String, String> links);
+        Map<String, String> links,
+        NowBoxView nowBox);
   }
 
   @GET
@@ -83,7 +88,8 @@ public class HomeResource {
             "releasesUrl", "https://github.com/scanalesespinoza/eventflow/releases",
             "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
-    return Templates.home(upcoming, past, today, "2.2.0", stats, links);
+    var nowBox = nowBoxService.build();
+    return Templates.home(upcoming, past, today, "2.2.0", stats, links, nowBox);
   }
 
   @GET

--- a/quarkus-app/src/main/java/io/eventflow/home/now/NowBoxService.java
+++ b/quarkus-app/src/main/java/io/eventflow/home/now/NowBoxService.java
@@ -1,0 +1,119 @@
+package io.eventflow.home.now;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.eventflow.time.AppClock;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import java.time.*;
+import java.util.*;
+import java.util.stream.*;
+
+@ApplicationScoped
+public class NowBoxService {
+
+  @ConfigProperty(name = "nowbox.lookback", defaultValue = "PT30M")
+  Duration lookback;
+
+  @ConfigProperty(name = "nowbox.lookahead", defaultValue = "PT60M")
+  Duration lookahead;
+
+  @Inject EventService events;
+  @Inject AppClock clock;
+
+  public NowBoxView build() {
+    Instant nowInstant = clock.now();
+    List<NowBoxView.EventNow> list = new ArrayList<>();
+
+    for (Event ev : events.listEvents()) {
+      ZoneId tz = ev.getZoneId();
+      ZonedDateTime now = ZonedDateTime.ofInstant(nowInstant, tz);
+      ZonedDateTime start = ev.getStartDateTime();
+      ZonedDateTime end = ev.getEndDateTime();
+      if (start == null || end == null) continue;
+      if (now.isBefore(start) || !now.isBefore(end)) continue; // only active events
+
+      List<Talk> agenda = ev.getAgenda();
+      if (agenda == null || agenda.isEmpty()) continue;
+
+      List<Talk> currents = agenda.stream()
+          .filter(t -> isCurrent(t, ev, now, tz))
+          .sorted(Comparator.comparing(t -> startAt(t, ev, tz)))
+          .collect(Collectors.toList());
+
+      List<Talk> past = agenda.stream()
+          .filter(t -> isPast(t, ev, now, tz))
+          .sorted(Comparator.comparing((Talk t) -> endAt(t, ev, tz)).reversed())
+          .collect(Collectors.toList());
+
+      List<Talk> future = agenda.stream()
+          .filter(t -> isFuture(t, ev, now, tz))
+          .sorted(Comparator.comparing(t -> startAt(t, ev, tz)))
+          .collect(Collectors.toList());
+
+      NowBoxView.EventNow en = new NowBoxView.EventNow();
+      en.eventId = ev.getId();
+      en.eventName = ev.getTitle();
+      en.eventTimezone = tz.getId();
+      en.agendaUrl = "/event/" + ev.getId();
+      if (!past.isEmpty()) en.last = toView(ev, past.get(0), tz);
+      if (!currents.isEmpty()) en.current = toView(ev, currents.get(0), tz);
+      if (!future.isEmpty()) en.next = toView(ev, future.get(0), tz);
+
+      if (en.last != null || en.current != null || en.next != null) list.add(en);
+    }
+
+    NowBoxView view = new NowBoxView();
+    view.events = list.stream()
+        .sorted(Comparator
+            .comparing((NowBoxView.EventNow e) -> e.current == null)
+            .thenComparing(e -> e.current != null ? e.current.start :
+                (e.next != null ? e.next.start : (e.last != null ? e.last.end : ZonedDateTime.ofInstant(nowInstant, ZoneId.of("UTC")))))
+        ).collect(Collectors.toList());
+    return view;
+  }
+
+  private boolean isCurrent(Talk t, Event ev, ZonedDateTime now, ZoneId tz) {
+    ZonedDateTime start = startAt(t, ev, tz);
+    ZonedDateTime end = endAt(t, ev, tz);
+    return start != null && end != null && !now.isBefore(start) && now.isBefore(end);
+  }
+
+  private boolean isPast(Talk t, Event ev, ZonedDateTime now, ZoneId tz) {
+    ZonedDateTime end = endAt(t, ev, tz);
+    return end != null && !now.isBefore(end) && Duration.between(end, now).compareTo(lookback) <= 0;
+  }
+
+  private boolean isFuture(Talk t, Event ev, ZonedDateTime now, ZoneId tz) {
+    ZonedDateTime start = startAt(t, ev, tz);
+    return start != null && start.isAfter(now) && Duration.between(now, start).compareTo(lookahead) <= 0;
+  }
+
+  private ZonedDateTime startAt(Talk t, Event ev, ZoneId tz) {
+    if (ev.getDate() == null || t.getStartTime() == null) return null;
+    LocalDate date = ev.getDate().plusDays(Math.max(0, t.getDay() - 1));
+    return ZonedDateTime.of(date, t.getStartTime(), tz);
+  }
+
+  private ZonedDateTime endAt(Talk t, Event ev, ZoneId tz) {
+    ZonedDateTime start = startAt(t, ev, tz);
+    return start != null ? start.plusMinutes(t.getDurationMinutes()) : null;
+  }
+
+  private NowBoxView.ActivityView toView(Event ev, Talk t, ZoneId tz) {
+    NowBoxView.ActivityView v = new NowBoxView.ActivityView();
+    v.id = t.getId();
+    v.title = t.getName();
+    v.type = t.isBreak() ? "break" : "talk";
+    v.start = startAt(t, ev, tz);
+    v.end = endAt(t, ev, tz);
+    v.room = t.getLocation();
+    v.speaker = t.getSpeakerNames();
+    v.detailUrl = t.isBreak()
+        ? "/event/" + ev.getId() + "#break-" + t.getId()
+        : "/event/" + ev.getId() + "/talk/" + t.getId();
+    return v;
+  }
+}

--- a/quarkus-app/src/main/java/io/eventflow/home/now/NowBoxView.java
+++ b/quarkus-app/src/main/java/io/eventflow/home/now/NowBoxView.java
@@ -1,0 +1,30 @@
+package io.eventflow.home.now;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/** View model for the "Ocurriendo ahora" box. */
+public class NowBoxView {
+  public List<EventNow> events;
+
+  public static class EventNow {
+    public String eventId;
+    public String eventName;
+    public String eventTimezone; // optional
+    public ActivityView last;    // may be null
+    public ActivityView current; // may be null
+    public ActivityView next;    // may be null
+    public String agendaUrl;     // e.g. /events/{eventId}
+  }
+
+  public static class ActivityView {
+    public String id;          // talk or break id
+    public String title;
+    public String type;        // "talk" | "break"
+    public ZonedDateTime start;
+    public ZonedDateTime end;
+    public String detailUrl;   // link to detail
+    public String room;        // optional
+    public String speaker;     // optional for talks
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/styles.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/styles.css
@@ -1583,3 +1583,34 @@ footer {
 }
 
 .auth .login-button { display: none !important; }
+
+/* Now box styles */
+.now-box.box{
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0,0,0,.06);
+  padding: 16px;
+  margin-bottom: 16px;
+}
+.now-grid{
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+@media (min-width: 768px){
+  .now-grid{ grid-template-columns: repeat(2, 1fr); }
+}
+.now-event{ border: 1px solid #eee; border-radius: 12px; padding: 12px; }
+.now-event-header{
+  display:flex; align-items:center; justify-content:space-between; gap:8px; margin-bottom:8px;
+}
+.now-rows{ display:flex; flex-direction:column; gap:6px; }
+.now-row{
+  display:flex; align-items:flex-start; gap:8px; background:#fafafa; border-radius:10px; padding:10px 12px;
+}
+.row-link{ text-decoration:none; color:inherit; display:flex; flex-direction:column; }
+.chip{ font-size:.75rem; padding:2px 6px; border-radius:999px; white-space:nowrap; align-self:flex-start; }
+.chip-last{ background:#eee; color:#555; }
+.chip-current{ background:#e6f7ea; color:#1b7f38; }
+.chip-next{ background:#e9f1ff; color:#1b4fbd; }
+.btn-ghost{ border:1px solid #e3e8ef; padding:6px 10px; border-radius:8px; text-decoration:none; color:#334; }

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -86,3 +86,9 @@ notifications.global.enabled=true
 notifications.simulation.enabled=true
 notifications.simulation.allow-real=false
 notifications.simulation.max-items=500
+
+# Now box configuration
+nowbox.enabled=true
+nowbox.lookback=PT30M
+nowbox.lookahead=PT60M
+nowbox.refresh-interval=PT30S

--- a/quarkus-app/src/main/resources/templates/HomeResource/home.html
+++ b/quarkus-app/src/main/resources/templates/HomeResource/home.html
@@ -2,6 +2,7 @@
 {#title}Inicio{/title}
 {#breadcrumbs}<span>Inicio</span>{/breadcrumbs}
 {#main}
+{#include _now-box nowBox=nowBox /}
 <section class="home-section">
     <h1 class="page-title">Eventos disponibles</h1>
     {#if upcoming.isEmpty()}

--- a/quarkus-app/src/main/resources/templates/_now-box.qute.html
+++ b/quarkus-app/src/main/resources/templates/_now-box.qute.html
@@ -1,0 +1,55 @@
+{#if nowBox.events != null && !nowBox.events.isEmpty()}
+<div class="box now-box">
+  <div class="box-header">
+    <h2>Ocurriendo ahora</h2>
+    <p class="muted">Lo más reciente, en curso y lo que viene por evento.</p>
+  </div>
+
+  <div class="now-grid">
+    {#for e in nowBox.events}
+    <section class="now-event">
+      <header class="now-event-header">
+        <h3 class="event-title">
+          <a class="link-title" href="/event/{e.eventId}">
+            {e.eventName} <span aria-hidden="true" class="chev">›</span>
+          </a>
+        </h3>
+        <a class="btn-ghost" href="{e.agendaUrl}">Ver agenda completa</a>
+      </header>
+
+      <div class="now-rows">
+        {#if e.last}
+          <div class="now-row now-last">
+            <span class="chip chip-last">Finalizada</span>
+            <a class="row-link" href="{e.last.detailUrl}">
+              <strong>{e.last.title}</strong>
+              <small>{e.last.start?datetime}–{e.last.end?datetime} {#if e.last.room}• {e.last.room}{/if}</small>
+            </a>
+          </div>
+        {/if}
+
+        {#if e.current}
+          <div class="now-row now-current">
+            <span class="chip chip-current">En curso</span>
+            <a class="row-link" href="{e.current.detailUrl}">
+              <strong>{e.current.title}</strong>
+              <small>{e.current.start?datetime}–{e.current.end?datetime} {#if e.current.room}• {e.current.room}{/if}</small>
+            </a>
+          </div>
+        {/if}
+
+        {#if e.next}
+          <div class="now-row now-next">
+            <span class="chip chip-next">Próxima</span>
+            <a class="row-link" href="{e.next.detailUrl}">
+              <strong>{e.next.title}</strong>
+              <small>{e.next.start?datetime}–{e.next.end?datetime} {#if e.next.room}• {e.next.room}{/if}</small>
+            </a>
+          </div>
+        {/if}
+      </div>
+    </section>
+    {/for}
+  </div>
+</div>
+{/if}

--- a/quarkus-app/src/main/resources/templates/layout/base.html
+++ b/quarkus-app/src/main/resources/templates/layout/base.html
@@ -53,10 +53,10 @@
 <div id="notification" class="notification hidden" role="alert"></div>
 <div id="loading" class="loading hidden"><div class="spinner"></div></div>
 <main id="main-content" class="container">
+    {#insert main}{/}
     {#if version?? || links??}
         {#include partials/project-header version=version stats=stats links=links /}
     {/if}
-    {#insert main}{/}
 </main>
 <footer>
     <div class="container">

--- a/quarkus-app/src/test/java/io/eventflow/home/now/NowBoxServiceTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/home/now/NowBoxServiceTest.java
@@ -1,0 +1,55 @@
+package io.eventflow.home.now;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.scanales.eventflow.model.Event;
+import com.scanales.eventflow.model.Talk;
+import com.scanales.eventflow.service.EventService;
+import io.eventflow.time.SimulatedClock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.time.*;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+class NowBoxServiceTest {
+
+  @Inject EventService events;
+  @Inject NowBoxService service;
+  @Inject SimulatedClock sim;
+
+  @BeforeEach
+  void setup() {
+    events.reset();
+    sim.clear();
+  }
+
+  @Test
+  void selectsLastCurrentNextInEventTimezone() {
+    Event e = new Event("e1", "Ev", "d");
+    e.setDate(LocalDate.of(2023, 1, 1));
+    e.setTimezone("America/Santiago");
+    Talk t1 = new Talk("t1", "t1");
+    t1.setStartTime(LocalTime.of(9, 0));
+    t1.setDurationMinutes(60);
+    Talk t2 = new Talk("t2", "t2");
+    t2.setStartTime(LocalTime.of(10, 0));
+    t2.setDurationMinutes(60);
+    Talk t3 = new Talk("t3", "t3");
+    t3.setStartTime(LocalTime.of(11, 0));
+    t3.setDurationMinutes(60);
+    e.getAgenda().addAll(List.of(t1, t2, t3));
+    events.saveEvent(e);
+
+    sim.set(Instant.parse("2023-01-01T13:30:00Z")); // 10:30 in Santiago
+
+    NowBoxView view = service.build();
+    assertEquals(1, view.events.size());
+    NowBoxView.EventNow en = view.events.get(0);
+    assertEquals("t1", en.last.id);
+    assertEquals("t2", en.current.id);
+    assertEquals("t3", en.next.id);
+  }
+}


### PR DESCRIPTION
## Summary
- show "Ocurriendo ahora" section on home with last/current/next activities per event
- move project-header component to bottom of the page
- style now-box consistent with existing box look and add config properties

## Testing
- `mvn -q test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8fea61d0c833383c4f2c9904791ed