### PR TITLE
Add resilience and observability improvements

### DIFF
--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -6,15 +6,15 @@ metadata:
   namespace: eventflow
 spec:
   progressDeadlineSeconds: 600
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: eventflow
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 0
     type: RollingUpdate
   template:
     metadata:
@@ -38,10 +38,10 @@ spec:
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /q/health/ready
+              path: /health/ready
               port: 8080
             initialDelaySeconds: 1
-            periodSeconds: 5
+            periodSeconds: 10
             failureThreshold: 3
           env:
             - name: JAVA_TOOL_OPTIONS

--- a/deployment/pdb.yaml
+++ b/deployment/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: eventflow
+  namespace: eventflow
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: eventflow

--- a/quarkus-app/src/main/java/com/scanales/eventflow/metrics/ServerErrorMetricsMapper.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/metrics/ServerErrorMetricsMapper.java
@@ -1,0 +1,18 @@
+package com.scanales.eventflow.metrics;
+
+import com.scanales.eventflow.service.UsageMetricsService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+public class ServerErrorMetricsMapper {
+
+  @Inject UsageMetricsService metrics;
+
+  @ServerExceptionMapper
+  public Response map(Throwable t, UriInfo uri) {
+    metrics.recordServerError("/" + uri.getPath());
+    return Response.serverError().build();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HealthResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HealthResource.java
@@ -1,0 +1,20 @@
+package com.scanales.eventflow.public_;
+
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/health")
+public class HealthResource {
+
+  @GET
+  @Path("/ready")
+  @PermitAll
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response ready() {
+    return Response.ok("ready").build();
+  }
+}

--- a/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/service/UsageMetricsService.java
@@ -422,6 +422,16 @@ public class UsageMetricsService {
     dirty.set(true);
   }
 
+  /** Record an HTTP 5xx response for the given route. */
+  public void recordServerError(String route) {
+    increment("5xx:" + route);
+  }
+
+  /** Record the outcome of a WebSocket handshake. */
+  public void recordWsHandshake(boolean ok) {
+    increment(ok ? "ws.handshake.ok" : "ws.handshake.fail");
+  }
+
   private void increment(String key) {
     int size = bufferSize.incrementAndGet();
     if (size > bufferMaxSize) {

--- a/quarkus-app/src/main/java/io/eventflow/home/now/NowBoxView.java
+++ b/quarkus-app/src/main/java/io/eventflow/home/now/NowBoxView.java
@@ -1,11 +1,12 @@
 package io.eventflow.home.now;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 
 /** View model for the "Ocurriendo ahora" box. */
 public class NowBoxView {
-  public List<EventNow> events;
+  public List<EventNow> events = Collections.emptyList();
 
   public static class EventNow {
     public String eventId;

--- a/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotificationsWs.java
+++ b/quarkus-app/src/main/java/io/eventflow/notifications/global/GlobalNotificationsWs.java
@@ -17,10 +17,12 @@ import java.io.StringReader;
 public class GlobalNotificationsWs {
 
   @Inject GlobalNotificationService service;
+  @Inject com.scanales.eventflow.service.UsageMetricsService metrics;
 
   @OnOpen
   public void onOpen(Session session) {
     service.register(session);
+    metrics.recordWsHandshake(true);
   }
 
   @OnClose

--- a/quarkus-app/src/main/resources/templates/_now-box.qute.html
+++ b/quarkus-app/src/main/resources/templates/_now-box.qute.html
@@ -1,4 +1,4 @@
-{#if nowBox.events != null && !nowBox.events.isEmpty()}
+{#if nowBox?.events?? && !nowBox.events.isEmpty()}
 <div class="box now-box">
   <div class="box-header">
     <h2>Ocurriendo ahora</h2>
@@ -18,32 +18,32 @@
       </header>
 
       <div class="now-rows">
-        {#if e.last}
+        {#if e.last??}
           <div class="now-row now-last">
             <span class="chip chip-last">Finalizada</span>
             <a class="row-link" href="{e.last.detailUrl}">
               <strong>{e.last.title}</strong>
-              <small>{e.last.start?datetime}–{e.last.end?datetime} {#if e.last.room}• {e.last.room}{/if}</small>
+              <small>{e.last.start?datetime}–{e.last.end?datetime} {#if e.last.room??}• {e.last.room}{/if}</small>
             </a>
           </div>
         {/if}
 
-        {#if e.current}
+        {#if e.current??}
           <div class="now-row now-current">
             <span class="chip chip-current">En curso</span>
             <a class="row-link" href="{e.current.detailUrl}">
               <strong>{e.current.title}</strong>
-              <small>{e.current.start?datetime}–{e.current.end?datetime} {#if e.current.room}• {e.current.room}{/if}</small>
+              <small>{e.current.start?datetime}–{e.current.end?datetime} {#if e.current.room??}• {e.current.room}{/if}</small>
             </a>
           </div>
         {/if}
 
-        {#if e.next}
+        {#if e.next??}
           <div class="now-row now-next">
             <span class="chip chip-next">Próxima</span>
             <a class="row-link" href="{e.next.detailUrl}">
               <strong>{e.next.title}</strong>
-              <small>{e.next.start?datetime}–{e.next.end?datetime} {#if e.next.room}• {e.next.room}{/if}</small>
+              <small>{e.next.start?datetime}–{e.next.end?datetime} {#if e.next.room??}• {e.next.room}{/if}</small>
             </a>
           </div>
         {/if}

--- a/quarkus-app/src/test/java/com/scanales/eventflow/public_/HealthResourceTest.java
+++ b/quarkus-app/src/test/java/com/scanales/eventflow/public_/HealthResourceTest.java
@@ -1,0 +1,16 @@
+package com.scanales.eventflow.public_;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class HealthResourceTest {
+
+  @Test
+  public void readyEndpoint() {
+    given().when().get("/health/ready").then().statusCode(200).body(equalTo("ready"));
+  }
+}

--- a/quarkus-app/src/test/java/io/eventflow/home/now/NowBoxTemplateTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/home/now/NowBoxTemplateTest.java
@@ -1,0 +1,20 @@
+package io.eventflow.home.now;
+
+import io.quarkus.qute.Location;
+import io.quarkus.qute.Template;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class NowBoxTemplateTest {
+
+  @Inject
+  @Location("_now-box.qute.html")
+  Template tmpl;
+
+  @Test
+  public void rendersEmptyModel() {
+    tmpl.data("nowBox", new NowBoxView()).render();
+  }
+}

--- a/quarkus-app/src/test/java/io/eventflow/notifications/global/GlobalNotificationsWsTest.java
+++ b/quarkus-app/src/test/java/io/eventflow/notifications/global/GlobalNotificationsWsTest.java
@@ -83,6 +83,7 @@ public class GlobalNotificationsWsTest {
     assertEquals("notif", j2.getString("t"));
   }
 
+
   @Test
   public void backlogSkipsOldNotifications() throws Exception {
     long startOfDay =


### PR DESCRIPTION
## Summary
- guard NowBox template against missing data
- add lightweight /health/ready endpoint and deploy probes
- track 5xx and WebSocket handshakes in metrics; tighten deployment rollout and availability

## Testing
- `mvn -q -Dtest=HealthResourceTest,NowBoxServiceTest,NowBoxTemplateTest,GlobalNotificationsWsTest test`

------
https://chatgpt.com/codex/tasks/task_e_68bccaf1df7083338e5083e876059f39