### PR TITLE
docs: document centralized persistence architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Also available in [Español](README.es.md).
 
 See the [documentation](docs/README.md) for more guides.
 
+## Arquitectura
+
+La estrategia de persistencia de EventFlow está documentada en:
+- [Opciones de persistencia](docs/architecture/persistence-options.md)
+- [ADR 2025-09-07: Persistencia centralizada](docs/architecture/ADR-2025-09-07-persistence-service-centralized.md)
+
+
 Latest stable release: **v2.2.0**.
 
 ## Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,3 +4,7 @@ Select your language:
 
 - [English](en/README.md)
 - [Español](es/README.md)
+
+## Architecture
+
+- [Persistence architecture](architecture/README.md)

--- a/docs/architecture/ADR-2025-09-07-persistence-service-centralized.md
+++ b/docs/architecture/ADR-2025-09-07-persistence-service-centralized.md
@@ -1,0 +1,16 @@
+# ADR 2025-09-07: Persistencia centralizada
+
+## Contexto
+EventFlow necesita escalar a múltiples réplicas y persistir estado compartido. Se evaluaron tres opciones: sidecar, servicio centralizado y object storage.
+
+## Decisión
+Adoptar un **servicio centralizado de persistencia** (Solución B) en esta fase.
+
+## Consecuencias
+- **Positivas:** consistencia fuerte y operación más simple.
+- **Positivas:** escala independiente de EventFlow.
+- **Negativas:** latencia de red extra.
+- **Futuro:** migración planificada a Object Storage (S3/MinIO).
+
+## Estado
+Aceptado

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,7 @@
+# Architecture
+
+This section gathers design records and technical notes for EventFlow's persistence.
+
+- [Opciones de persistencia](persistence-options.md)
+- [Servicio de persistencia](persistence-service.md)
+- [ADR 2025-09-07: Persistencia centralizada](ADR-2025-09-07-persistence-service-centralized.md)

--- a/docs/architecture/persistence-options.md
+++ b/docs/architecture/persistence-options.md
@@ -1,0 +1,43 @@
+# Opciones de persistencia – EventFlow
+
+## Opción A – Sidecar por pod
+### Pros
+- Simplicidad al desplegarse junto con cada réplica.
+- Latencia mínima al operar localmente.
+### Contras
+- Duplica recursos y estado en cada pod.
+- Sincronización compleja entre réplicas.
+### Cuándo aplicaría
+- Despliegues de baja escala o entornos de desarrollo.
+
+## Opción B – Servicio centralizado
+### Pros
+- Consistencia fuerte y control de concurrencia.
+- Escala de forma independiente de EventFlow.
+### Contras
+- Añade una latencia de red.
+- Requiere alta disponibilidad.
+### Cuándo aplicaría
+- Cuando se necesitan múltiples réplicas con estado compartido inmediato.
+
+## Opción C – Object Storage
+### Pros
+- Escalabilidad prácticamente ilimitada.
+- Coste operativo reducido.
+### Contras
+- Consistencia eventual.
+- Latencia superior para operaciones de lectura/escritura.
+### Target state
+- Destino a largo plazo para cargas masivas y durabilidad.
+
+## Comparación
+| Criterio | Opción A – Sidecar | Opción B – Servicio centralizado | Opción C – Object Storage |
+| --- | --- | --- | --- |
+| Complejidad | Baja | Media | Media |
+| Latencia | Mínima | Moderada | Alta |
+| Consistencia | Local, no compartida | Fuerte | Eventual |
+| Escalabilidad | Ligada a pods | Independiente | Ilimitada |
+| Operación | Gestión por pod | Servicio único | Servicio administrado |
+
+## Decisión
+Se adopta la **Opción B – servicio centralizado** como solución inmediata porque ofrece consistencia fuerte y permite escalar sin duplicar el estado como en la Opción A.

--- a/docs/architecture/persistence-service.md
+++ b/docs/architecture/persistence-service.md
@@ -1,0 +1,21 @@
+# Servicio de persistencia centralizado
+
+La solución implementada expone un servicio HTTP dedicado a almacenar y recuperar el estado de EventFlow.
+
+## Endpoints
+- `GET /state/{key}`: obtiene el estado asociado a `key`.
+- `PUT /state/{key}`: crea o reemplaza el estado.
+- `DELETE /state/{key}`: elimina el estado.
+- `POST /locks/{key}` y `DELETE /locks/{key}`: administración de locks.
+
+## ETag y control de concurrencia
+Cada respuesta `GET` incluye un `ETag` que representa la versión del recurso. Las actualizaciones deben enviar `If-Match` con el `ETag` recibido. Si no coincide, el servicio retorna `412 Precondition Failed` para evitar sobrescrituras.
+
+## Locks
+Se ofrecen locks optimistas y pesimistas. Los clientes pueden solicitar un lock explícito sobre una clave para operaciones de larga duración. Los locks expiran automáticamente para prevenir bloqueos permanentes.
+
+## Write-Ahead Log (WAL)
+Todas las mutaciones se registran en un WAL. En caso de fallo, el servicio puede reproducir las entradas para restaurar el estado. El WAL también sirve como fuente para replicación.
+
+## Eventos
+Cuando cambia el estado, el servicio publica un evento `state.updated`. Esto permite que otros componentes de EventFlow reaccionen a la modificación y mantengan caches o vistas materializadas.


### PR DESCRIPTION
## Summary
- add architecture docs for persistence options
- record ADR for centralized persistence service
- document service design and link docs in readmes

## Testing
- `mvn -f quarkus-app/pom.xml test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf345183c8333806f487ee3603362