### PR TITLE
docs: add Homedir core glossary and principles

### DIFF
--- a/docs/00-glossary.md
+++ b/docs/00-glossary.md
@@ -1,0 +1,13 @@
+# Glosario
+
+## ADeveloper (AI-Augmented Developer)
+Desarrollador apoyado por IA que lidera la construcción con prompts, revisión ligera y pipelines automáticos.
+
+## ADevelopment (AI-Augmented Development)
+Práctica de desarrollo asistido por IA con guardrails, contratos y tests automatizados.
+
+## HDP (Homedir Persist)
+Motor embebido de documentos JSON (cache en memoria + WAL + snapshots en volúmenes; compactor; cuotas/aislamiento por módulo). Más detalles en [persistencia](04-persistence-hdp.md).
+
+## UniCore (Cloud-Native Modular Core)
+Patrón arquitectónico central de Homedir: monolito modular moderno en un único binario Quarkus con modularidad estricta, blast radius controlado, ligereza (sin DBs/brokers/gateways pesados por defecto; usa HDP), UI SSR con Qute, cloud-native (GitOps/OpenShift) y enfoque AI-augmented ([ADevelopment](#adevelopment-ai-augmented-development)/[ADeveloper](#adeveloper-ai-augmented-developer)). Ver [arquitectura](02-architecture.md).

--- a/docs/00-principles.md
+++ b/docs/00-principles.md
@@ -1,0 +1,12 @@
+# Principios
+
+Manifiesto ligero:
+
+- Monolito modular ligero ([UniCore](00-glossary.md#unicore-cloud-native-modular-core)): un binario con módulos de límites claros.
+- Persistencia simple ([HDP](00-glossary.md#hdp-homedir-persist)): JSON + WAL + volumen; bases externas solo por compliance/escala.
+- Sin mensajería pesada: módulos comunican in-process; Outbox/brokers solo si duele.
+- Frontend sin frameworks SPA: [Qute SSR](07-frontend-server-side.md) + fragmentos HTML + SSE; JS mínimo.
+- Blast radius: aislar recursos por módulo (threads, conexiones, cachés).
+- Seguridad en servidor: JWT Ed25519, RBAC en users, CSRF en formularios.
+- Observabilidad: logs JSON, métricas por módulo, readiness/health granulares.
+- Evolución controlada: extraer “células” solo si ≥3 señales (ritmo, SLOs, carga, compliance).

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -1,24 +1,21 @@
-# Arquitectura del Monolito Modular
+# Arquitectura
 
-## Principios
-- modularidad estricta
-- blast radius contenido
-- ligereza
+[UniCore (Cloud-Native Modular Core)](00-glossary.md#unicore-cloud-native-modular-core) con Quarkus 3 y Java 21.
 
-## Plataforma
-Monolito modular construido con Quarkus y guiado por DDD y arquitectura Hexagonal.
+## Estructura
+- `apps/homedir-api`
+- `modules/{users,events,spaces,pulse}/{core,app,adapters,migrations}`
+- `shared/`, `contracts/`, `infra/`, `tests/`
+- `templates/` (Qute), `static/{css,js}`
 
-## Repositorios
-Estructura separada para backend, web e infraestructura.
+## Persistencia
+[HDP](00-glossary.md#hdp-homedir-persist) como almacenamiento por defecto; schemas lógicos por namespace (módulo). Ver [persistencia](04-persistence-hdp.md).
 
-## Organización de carpetas
-`modules/{users,events,spaces,pulse}` con subcarpetas `core/`, `app/`, `adapters/` y `migrations/`.
+## UI
+UI SSR: vistas y fragmentos por módulo (`/_fragment/*`). Detalles en [frontend server-side](07-frontend-server-side.md).
 
-## Base de datos
-Estrategia `schema-per-module`.
-
-## Observabilidad mínima
-Solo lo necesario para métricas, logs y tracing básicos.
+## Guardrails
+ArchUnit, FT (timeouts/bulkheads/circuit) y pools/cuotas por módulo. Más en [guardrails](03-guardrails.md).
 
 ## Evolución
-Posible migración a "células" si el crecimiento lo exige.
+Extraer “células” solo si aparecen ≥3 señales (ritmo, SLOs, carga, compliance).

--- a/docs/03-guardrails.md
+++ b/docs/03-guardrails.md
@@ -1,17 +1,19 @@
 # Guardrails
 
 ## Dependencias
-Límites de dependencias reforzados con ArchUnit.
+- core no importa otros core.
+- app no depende de adapters.
+- core es framework-free.
+- [ArchUnit](https://www.archunit.org/) obligatorio.
 
-## Recursos
-- pools de base de datos dedicados por módulo
-- bulkheads, timeouts y rate limiting por módulo
+## Recursos por módulo
+- datasources, pools, caches y threads dedicados.
+- límites estrictos configurables.
 
-## Operabilidad
-- kill switches y feature flags
-- health y readiness por módulo
-- observabilidad etiquetada con `module`
+## Resiliencia
+- Fault Tolerance (timeouts, retries, circuit breaker).
+- rate-limit y kill-switches por módulo.
 
-## Edge
-- prefijos de rutas por módulo
-- readiness para mantenimiento selectivo
+## Operación
+- health y readiness por módulo.
+- métricas y trazas etiquetadas con `module`.

--- a/docs/04-persistence-hdp.md
+++ b/docs/04-persistence-hdp.md
@@ -1,22 +1,23 @@
-# Homedir Persist (HDP)
+# Persistencia con HDP
 
-## Resumen
-Servicio embebido de persistencia JSON.
+Ver [HDP en el glosario](00-glossary.md#hdp-homedir-persist).
 
-## Arquitectura
-- memoria con WAL y persistencia en volumen
-- namespaces equivalen a módulos y colecciones a agregados
-- aislamiento por namespace mediante archivos, pools y cuotas
+## Diseño
+WAL append-only + MemTable + snapshots + segments + compaction.
 
 ## Durabilidad
-- políticas `safe`, `balanced` y `fast`
-- recuperación crash-safe y compactor en background
+Modos `safe`, `balanced`, `fast`.
 
 ## API
-SDK Java con opción REST.
+SDK embebido con opción REST.
 
-## Roadmap
-MVP → índices compuestos → replicación.
+## Aislamiento
+Archivos, pools e I/O por namespace; cuotas de memoria y espacio.
 
-## Migración
-Criterios claros para pasar a una base de datos externa.
+## Backup/Restore
+Snapshot + replay del WAL.
+
+## Cuándo no usar
+- joins complejos
+- reporting pesado
+- transacciones multi-agregado fuertes

--- a/docs/07-frontend-server-side.md
+++ b/docs/07-frontend-server-side.md
@@ -1,0 +1,17 @@
+# Frontend Server-Side
+
+Sin Next.js, Node.js, React, Vue o Angular.
+
+## Qute SSR
+Layout base, vistas y fragmentos HTML. Funciona sin JS; validación en servidor y CSRF en formularios.
+
+## Fragmentos
+Endpoints `/_fragment/*` por módulo.
+
+## Asíncrono mínimo
+`fetch()` de fragmentos y Server-Sent Events para Pulse.
+
+## Accesibilidad
+Debe funcionar sin JS; rutas protegidas por roles.
+
+Ver la [arquitectura](02-architecture.md) para la ubicación de templates.


### PR DESCRIPTION
## Summary
- add glossary for ADeveloper, ADevelopment, HDP and UniCore (Cloud-Native Modular Core)
- document Homedir principles and update architecture, guardrails and persistence docs
- describe Qute-based server-side frontend approach

## Testing
- `dev/pr-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c00dff91ac8333ad6772f5942aca4d