### PR TITLE
chore: release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.2.1] - 2025-09-12
+### Changed
+- Actualización de versión y documentación para release 2.2.1.
+
+### Security/Supply Chain
+- Imagen publicada con alias `:2.2.1`, firmada y con SBOM adjunto.
+
 ## [2.2.0] - 2025-08-17
 ### Added
 - Quality gate en PR: análisis estático (diff-aware), reglas de arquitectura (monorepo), cobertura en el diff, higiene de dependencias.

--- a/README.es.md
+++ b/README.es.md
@@ -10,7 +10,7 @@
 
 Plataforma inteligente de gestión de eventos: espacios, actividades, ponentes, asistentes y planificación personalizada.
 
-Versión estable más reciente: **v2.2.0**.
+Versión estable más reciente: **v2.2.1**.
 
 ## Funciones
 - Gestiona eventos, ponentes, escenarios y charlas

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ La estrategia de persistencia de EventFlow está documentada en:
  - [ADR 2025-09-07: Persistencia centralizada](docs/es/architecture/ADR-2025-09-07-persistence-service-centralized.md)
 
 
-Latest stable release: **v2.2.0**.
+Latest stable release: **v2.2.1**.
 
 ## Features
 - Manage events, speakers, scenarios, and talks

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,13 +1,13 @@
-# EventFlow 2.2.0
+# EventFlow 2.2.1
 
 **Resumen**
-- Mejoras de métricas y UI (Admin), fixes menores.
-- Calidad: gates automáticos en PR y pipelines optimizados.
-- Supply chain: imagen `:2.2.0` firmada + SBOM; deploy por digest.
+- Correcciones menores y mejoras de documentación.
+- Calidad: pipelines ajustados y verificación actualizada.
+- Supply chain: imagen `:2.2.1` firmada + SBOM; deploy por digest.
 
 **Detalles**
 - Ver CHANGELOG para lista completa.
 
 **Container**
-- `quay.io/sergio_canales_e/eventflow:2.2.0` (alias)
+- `quay.io/sergio_canales_e/eventflow:2.2.1` (alias)
 - Despliegue por digest recomendado (CD actual lo aplica).

--- a/SECURITY.es.md
+++ b/SECURITY.es.md
@@ -33,7 +33,7 @@ Usa uno de estos canales privados:
    `EVENTFLOW SECURITY: <título corto>`
 
 Incluye cuando aplique:
-- Versiones afectadas (ej. `2.2.0`)
+- Versiones afectadas (ej. `2.2.1`)
 - Entorno (local/Docker/Kubernetes/OpenShift)
 - Resumen del impacto (¿qué puede hacer un atacante?)
 - Pasos de reproducción o prueba de concepto

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Use one of these private channels:
    `EVENTFLOW SECURITY: <short title>`
 
 Please include (as applicable):
-- Affected versions (e.g., `2.2.0`)
+- Affected versions (e.g., `2.2.1`)
 - Environment (local/Docker/Kubernetes/OpenShift)
 - Impact summary (what can an attacker do?)
 - Reproduction steps or proof-of-concept

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
         - name: eventflow
           # Alias tag; production uses immutable digests
-          image: quay.io/sergio_canales_e/eventflow:2.2.0
+          image: quay.io/sergio_canales_e/eventflow:2.2.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/docs/en/ci-cd.md
+++ b/docs/en/ci-cd.md
@@ -31,9 +31,9 @@ After merging to `main`:
 
 ```bash
 git fetch origin && git checkout main && git pull
-git tag -a v2.2.0 -m "EventFlow 2.2.0"
-git push origin v2.2.0
+git tag -a v2.2.1 -m "EventFlow 2.2.1"
+git push origin v2.2.1
 
 # Optional GitHub Release
-gh release create v2.2.0 -F RELEASE_NOTES.md -t "EventFlow 2.2.0"
+gh release create v2.2.1 -F RELEASE_NOTES.md -t "EventFlow 2.2.1"
 ```

--- a/docs/es/ci-cd.md
+++ b/docs/es/ci-cd.md
@@ -31,9 +31,9 @@ Después de fusionarse con 'Main`:
 
 `` `Bash
 Git Fetch Origin && Git Checkout Main && Git Pull
-git etiqueta -a v2.2.0 -m "eventflow 2.2.0"
-Git Push Origin v2.2.0
+git etiqueta -a v2.2.1 -m "eventflow 2.2.1"
+Git Push Origin v2.2.1
 
 # Lanzamiento opcional de GitHub
-GH Release Create v2.2.0 -f libe_notes.md -t "Eventflow 2.2.0"
+GH Release Create v2.2.1 -f libe_notes.md -t "Eventflow 2.2.1"
 `` `` ``

--- a/quarkus-app/README.md
+++ b/quarkus-app/README.md
@@ -71,7 +71,7 @@ native executable:
 
 After getting a cup of coffee, you'll be able to run this executable directly:
 
-> ./target/eventflow-2.2.0-runner
+> ./target/eventflow-2.2.1-runner
 
 
 ## Google Login Demo

--- a/quarkus-app/pom.xml
+++ b/quarkus-app/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.scanales</groupId>
     <artifactId>eventflow</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
 
     <properties>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/quarkus-app/src/main/docker/Dockerfile.jvm
+++ b/quarkus-app/src/main/docker/Dockerfile.jvm
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:2.2.0 .
+# docker build -f src/main/docker/Dockerfile.jvm -t eventflow:2.2.1 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.0
+# docker run -i --rm -p 8080:8080 eventflow:2.2.1
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.0
+# docker run -i --rm -p 8080:8080 eventflow:2.2.1
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.legacy-jar
+++ b/quarkus-app/src/main/docker/Dockerfile.legacy-jar
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:2.2.0 .
+# docker build -f src/main/docker/Dockerfile.legacy-jar -t eventflow:2.2.1 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.0
+# docker run -i --rm -p 8080:8080 eventflow:2.2.1
 #
 # If you want to include the debug port into your docker image
 # you will have to expose the debug port (default 5005 being the default) like this :  EXPOSE 8080 5005.
@@ -20,7 +20,7 @@
 #
 # Then run the container using :
 #
-# docker run -i --rm -p 8080:8080 eventflow:2.2.0
+# docker run -i --rm -p 8080:8080 eventflow:2.2.1
 #
 # This image uses the `run-java.sh` script to run the application.
 # This scripts computes the command line to execute your Java application, and

--- a/quarkus-app/src/main/docker/Dockerfile.native
+++ b/quarkus-app/src/main/docker/Dockerfile.native
@@ -7,11 +7,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:2.2.0 .
+# docker build -f src/main/docker/Dockerfile.native -t eventflow-native:2.2.1 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:2.2.0
+# docker run -i --rm -p 8080:8080 eventflow-native:2.2.1
 #
 # The base image has been switched to a distroless variant to reduce the attack surface
 ###

--- a/quarkus-app/src/main/docker/Dockerfile.native-micro
+++ b/quarkus-app/src/main/docker/Dockerfile.native-micro
@@ -10,11 +10,11 @@
 #
 # Then, build the image with:
 #
-# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:2.2.0 .
+# docker build -f src/main/docker/Dockerfile.native-micro -t eventflow-native:2.2.1 .
 #
 # Then run the container using:
 #
-# docker run -i --rm -p 8080:8080 eventflow-native:2.2.0
+# docker run -i --rm -p 8080:8080 eventflow-native:2.2.1
 #
 # The `quay.io/quarkus/ubi9-quarkus-micro-image:2.0` base image is based on UBI 9.
 # To use UBI 8, switch to `quay.io/quarkus/quarkus-micro-image:2.0`.

--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/HomeResource.java
@@ -89,7 +89,7 @@ public class HomeResource {
             "issuesUrl", "https://github.com/scanalesespinoza/eventflow/issues",
             "donateUrl", "https://ko-fi.com/sergiocanales");
     var nowBox = nowBoxService.build();
-    return Templates.home(upcoming, past, today, "2.2.0", stats, links, nowBox);
+    return Templates.home(upcoming, past, today, "2.2.1", stats, links, nowBox);
   }
 
   @GET

--- a/quarkus-app/src/main/resources/application.properties
+++ b/quarkus-app/src/main/resources/application.properties
@@ -19,7 +19,7 @@ quarkus.oidc.token.principal-claim=id_token
 %prod.mp.jwt.verify.audiences=${GOOGLE_CLIENT_ID}
 %prod.smallrye.jwt.verify.algorithm=RS256
 # Application version
-quarkus.application.version=2.2.0
+quarkus.application.version=2.2.1
 # Store Vert.x cache on a writable volume
 quarkus.vertx.cache-directory=${eventflow.data.dir:./data}/vertx-cache
 # Store HTTP file uploads on a writable volume


### PR DESCRIPTION
## Summary
- bump version to 2.2.1 across docs, config and source
- update release notes and changelog for v2.2.1
- point deployment manifests to the new image tag

## Testing
- `mvn -f quarkus-app/pom.xml enforcer:enforce`
- `./dev/deps-check.sh`
- `mvn -f quarkus-app/pom.xml test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3804e8dd483338d610b9538ccb8c0