### PR TITLE
Separate English documentation from Spanish content

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Also available in [Español](README.es.md).
 
 See the [documentation](docs/README.md) for more guides.
 
-## Arquitectura
+## Architecture
 
-La estrategia de persistencia de EventFlow está documentada en:
- - [Opciones de persistencia](docs/es/architecture/persistence-options.md)
- - [ADR 2025-09-07: Persistencia centralizada](docs/es/architecture/ADR-2025-09-07-persistence-service-centralized.md)
+EventFlow's persistence strategy is documented in:
+
+- [Persistence options](docs/en/architecture/persistence-options.md)
+- [ADR 2025-09-07: Centralized persistence service](docs/en/architecture/ADR-2025-09-07-persistence-service-centralized.md)
 
 
 Latest stable release: **v2.2.1**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,4 +7,5 @@ Select your language:
 
 ## Architecture
 
-- [Persistencia](es/architecture/README.md)
+- [Architecture (English)](en/architecture/README.md)
+- [Arquitectura (Español)](es/architecture/README.md)

--- a/docs/en/admin-metrics-ui.md
+++ b/docs/en/admin-metrics-ui.md
@@ -1,6 +1,6 @@
 # Admin Metrics UI
 
-This page summarizes the layout tokens and breakpoints used in the mobile-first Admin → Métricas screen.
+This page summarizes the layout tokens and breakpoints used in the mobile-first Admin → Metrics screen.
 
 ## Breakpoints
 - ≥1200px: four-column grid

--- a/docs/en/architecture/README.md
+++ b/docs/en/architecture/README.md
@@ -1,8 +1,8 @@
 # Architecture
 
-This section brings together design records and technical notes on the persistence of Eventflow.
+This section gathers design records and technical notes about EventFlow persistence.
 
-- [Persistence options] (persistent -opptions.md)
-- [Persistence service] (Persistence-Service.md)
--[ADR 2025-09-07: Centralized persistence] (ADR-2025-09-07-Persensnce-Service-Centralized.md)
-- [Architecture Rules] (Rules.md)
+- [Persistence options](persistence-options.md)
+- [Persistence service](persistence-service.md)
+- [ADR 2025-09-07: Centralized persistence service](ADR-2025-09-07-persistence-service-centralized.md)
+- [Architecture rules](rules.md)

--- a/docs/en/metrics-ctas.md
+++ b/docs/en/metrics-ctas.md
@@ -1,23 +1,23 @@
-# Ctas metrics
+# CTA metrics
 
 ## Definitions and formulas
-- ** ctas (range) **: Sum of clicks on releases, report ISSUE and KO-FI within the selected range.
-- ** Daily average (by cta and total) ** = `sum_en_rango / nº_días_contemplados_en_el_rango`.
-- ** Simple deviation ** About total daily within the range (population method).
-- ** Picos **:
-  - *Option A (by default) *: Top-3 total range of the range.
-  - *Option B (configurable) *: Total ≥ average + 2 × dev.est.
-- ** Time zone **: The event is used to group per day.
+- **CTAs (range):** Sum of clicks on Releases, Report Issue, and Ko-fi within the selected range.
+- **Daily average (per CTA and total):** `sum_in_range / days_in_range`.
+- **Standard deviation (simple):** Population method over the daily totals within the range.
+- **Peaks:**
+  - *Option A (default):* Top 3 totals within the range.
+  - *Option B (configurable):* Total ≥ average + 2 × standard deviation.
+- **Time zone:** Use the event time zone to group by day.
 
 ## Presentation rules
 - Table ordered by descending date.
-- Badges "peak" with tooltip "peak according to rule configured for this range."
-- Placeholders and messages of "without data to export in this range." When appropriate.
+- "Peak" badges with tooltip "Peak according to the rule configured for this range.".
+- Show "No data to export in this range." placeholders and messages when applicable.
 
 ## Links
--URLS parameterizable by `links.releases-url`,` links.issan-ull` and `links.donate-url`.
-- Recommended Security: `target =" _ Blank "` + `rel =" noopener "`.
+- URLs configurable through `links.releases-url`, `links.issues-url`, and `links.donate-url`.
+- Recommended security attributes: `target="_blank"` + `rel="noopener"`.
 
 ## Privacy and performance
-- PII is not exposed; only added data.
-- Snapshot/metric cache is reused to avoid charging times.
+- Expose only aggregated data; never include PII.
+- Reuse the snapshot/metrics cache to avoid longer load times.

--- a/docs/en/metrics-dashboard.md
+++ b/docs/en/metrics-dashboard.md
@@ -1,82 +1,82 @@
 # Metrics Dashboard
 
-## Navigation Map
+## Navigation map
 - **Talks:** each row links to the admin view of the talk at `/private/admin/events/{eventId}/edit` with the specific talk in context.
 - **Events:** rows navigate to `/private/admin/events/{eventId}/edit`.
 - **Speakers:** rows navigate to the speaker administration view at `/private/admin/speakers` focused on the selected speaker.
-- **Scenarios:** rows navigate to `/private/admin/events/{eventId}/edit` with the scenario highlighted.
+- **Stages:** rows navigate to `/private/admin/events/{eventId}/edit` with the stage highlighted.
 - The dashboard preserves the selected time range and event filter when navigating to and returning from these pages.
 
-## Filtros y segmentación
-- Los filtros de **Evento**, **Escenario** y **Speaker** se combinan con el rango de fechas.
-- El evento delimita los escenarios disponibles; si un evento no tiene escenarios se muestra un selector deshabilitado con "Sin escenarios".
-- El filtro de speaker restringe charlas y métricas asociadas a ese orador.
+## Filters and segmentation
+- The **Event**, **Stage**, and **Speaker** filters combine with the selected date range.
+- The event filter limits the available stages; if an event has no stages, show a disabled select labeled "No stages available".
+- The speaker filter restricts talks and metrics associated with that presenter.
 
-## Persistencia de contexto
-- Los filtros y rango se representan mediante query params legibles: `range`, `event`, `stage` y `speaker`.
-- Al navegar a vistas de detalle mediante "Ver" se mantienen estos parámetros para poder volver con el mismo estado.
+## Context persistence
+- Filters and range are represented with readable query params: `range`, `event`, `stage`, and `speaker`.
+- When navigating to detail views via "View", keep these parameters so users return to the same state.
 
-## Copys / UX
-- Etiquetas de filtros: "Evento", "Escenario", "Speaker".
-- Placeholders: "Todos", "Buscar speaker…" y "Sin datos suficientes en este rango/segmento".
-- Botón: "Copiar resumen". Toast al copiar: "Resumen copiado".
+## Copy and UX
+- Filter labels: "Event", "Stage", "Speaker".
+- Placeholders: "All", "Search speaker…", and "Insufficient data for this range/segment".
+- Button: "Copy summary". Toast on copy: "Summary copied".
 
-## Formato del resumen copiado
-- Plantilla: `Rango: <rango>\nEvento: <evento>\nEscenario: <escenario>\nSpeaker: <speaker>\nEventos vistos: <n>\nCharlas vistas: <n>\nCharlas registradas: <n>\nVisitas a escenarios: <n>\nÚltima actualización: <timestamp>`
-- Solo se incluyen totales agregados; nunca PII.
+## Copied summary format
+- Template: `Range: <range>\nEvent: <event>\nStage: <stage>\nSpeaker: <speaker>\nEvents viewed: <n>\nTalks viewed: <n>\nRegistrations: <n>\nStage visits: <n>\nLast updated: <timestamp>`
+- Include only aggregated totals—never PII.
 
 ## Export specification
-- Export only the rows and columns visible in the current table, respecting time range, search terms and order.
+- Export only the rows and columns currently visible in the table, respecting range, search terms, and ordering.
 - Columns per table:
-  - **Talks:** `Charla`, `Evento`, `Registros`
-  - **Events:** `Evento`, `Visitas`
-  - **Speakers:** `Orador/a`, `Visitas a perfil`
-  - **Scenarios:** `Escenario`, `Evento`, `Visitas`
-- File name format: `metrics-<tabla>-<rango>-<YYYYMMDD-HHMM>.csv` using the event's timezone.
-- CSV never includes personal identifiable information.
+  - **Talks:** `Talk`, `Event`, `Registrations`
+  - **Events:** `Event`, `Visits`
+  - **Speakers:** `Speaker`, `Profile visits`
+  - **Stages:** `Stage`, `Event`, `Visits`
+- File name format: `metrics-<table>-<range>-<YYYYMMDD-HHMM>.csv` using the event time zone.
+- CSV exports never include personal identifiable information.
 
-## Copy & UX
-- Buttons: `Ver`, `Exportar CSV`
-- Placeholder: `Buscar…`
-- Disabled export message: `Sin datos para exportar en este rango.`
-- Toast: `CSV descargado`
+## Table actions copy
+- Buttons: `View`, `Export CSV`
+- Placeholder: `Search…`
+- Disabled export message: `No data to export in this range.`
+- Toast: `CSV downloaded`
 
-## Tendencias
-- Cada tarjeta y fila de tabla puede mostrar un badge de tendencia con la variación vs. el período anterior.
-- La lógica de cálculo y reglas se describen en `metrics-trends.md`.
+## Trends
+- Each card and table row can display a trend badge with the variation versus the previous period.
+- Calculation logic and rules are described in `metrics-trends.md`.
 
-## QA / Checklist
-- Verify that applying range, search and order is reflected in the exported CSV.
-- Clicking `Ver` opens the correct admin page and preserves context when returning.
-- When a table has no data, export button is disabled and shows the no-data message.
-- Keyboard navigation reaches all `Ver` and `Exportar CSV` buttons and aria labels describe the destination.
-- Confirm CSV contains no personal identifiers such as emails or personal IDs.
+## QA / checklist
+- Verify that applying range, search, and ordering options is reflected in the exported CSV.
+- Clicking `View` opens the correct admin page and preserves context when returning.
+- When a table has no data, the export button is disabled and shows the no-data message.
+- Keyboard navigation reaches all `View` and `Export CSV` buttons, and aria labels describe the destination.
+- Confirm CSV files contain no personal identifiers such as emails or personal IDs.
 
-## Salud de datos y auto-refresh
+## Data health and auto-refresh
 
-### Reglas de “Salud de datos”
-- Hoy: desactualizado si la edad del snapshot supera 2 min.
-- Últimos 7 días: desactualizado si > 15 min.
-- Últimos 30 días: desactualizado si > 30 min.
-- Todo el evento: desactualizado si > 60 min.
-- “Sin datos”: todas las tarjetas en 0 y todas las tablas vacías tras aplicar filtros/rango.
+### Data health rules
+- Today: stale if the snapshot age exceeds 2 minutes.
+- Last 7 days: stale if > 15 minutes.
+- Last 30 days: stale if > 30 minutes.
+- Entire event: stale if > 60 minutes.
+- "No data": all cards at 0 and all tables empty after applying filters/range.
 
-### Semántica de “Última actualización”
-- Se toma del timestamp del snapshot de datos, nunca del reloj del cliente.
-- Se muestra en formato relativo: “hace 2 min”, “hace 45 s”; para <1 s usar “justo ahora”.
+### Meaning of "Last updated"
+- Derived from the timestamp of the data snapshot, never the client clock.
+- Displayed as relative time: "2 min ago", "45 s ago"; use "just now" for <1 s.
 
 ### Auto-refresh
-- Intervalo por defecto: 5 s (configurable).
-- Coalesce de solicitudes: si hay un refresh en curso, no inicia otro.
-- Re-render condicional por hash de datos.
-- Notifica fallos de actualización solo una vez hasta un refresco exitoso.
-- Controles: `Pausar/Continuar` (`data-testid="metrics-refresh-toggle"`, `aria-pressed`) y `Refrescar ahora` (`data-testid="metrics-refresh-now"`, throttle 2 s).
+- Default interval: 5 s (configurable).
+- Coalesce requests: if a refresh is in progress, do not start another.
+- Re-render conditionally based on a data hash.
+- Notify refresh failures only once until the next successful refresh.
+- Controls: `Pause/Resume` (`data-testid="metrics-refresh-toggle"`, `aria-pressed`) and `Refresh now` (`data-testid="metrics-refresh-now"`, throttle 2 s).
 
-### Copys/UX
-- Estados: “OK”, “Desactualizado”, “Sin datos”.
-- Mensajes: “No pudimos actualizar; reintentaremos”, “Sin datos suficientes en este rango/segmento”.
-- Accesibilidad: `aria-live` en estado y “Última actualización”; botones con `aria-pressed` y tooltips.
+### Copy and UX (status)
+- States: "OK", "Stale", "No data".
+- Messages: "Could not refresh; will retry", "No data for this range/segment".
+- Accessibility: `aria-live` on status and "Last updated"; buttons expose `aria-pressed` and tooltips.
 
-### Privacidad y performance
-- Cero PII en mensajes o datos mostrados.
-- Evitar parpadeos: sólo recargar al cambiar el hash de datos.
+### Privacy and performance
+- No PII in messages or displayed data.
+- Avoid flicker by reloading only when the data hash changes.

--- a/docs/en/prompt-dashboard-metrics-mvp.md
+++ b/docs/en/prompt-dashboard-metrics-mvp.md
@@ -1,107 +1,108 @@
-# Prompt for codex - Iteration 1 · Dashboard of metrics (MVP)
+# Prompt for Codex – Iteration 1 · Metrics dashboard (MVP)
 
-## Objective (Business Vision)
-As administrator/or I want a simple and fast metric dashboard that shows me, at a glance, the key activity of the site to make decisions without navigating multiple screens. You must load quickly, be clear and not expose PII.
+## Objective (business vision)
+As an administrator I want a fast, lightweight metrics dashboard that shows the key activity of the site at a glance so I can make decisions without visiting multiple screens. It must load quickly, be clear, and avoid exposing PII.
 
-## Scope - Implementation (application code)
+## Scope – implementation (application code)
 
-1) Display/Admin route → “metric”
-   - Create/update the unique view of Dashboard.
-   - Show “Last update: X min” based on the timestamp of data shown (not the system).
-   - Skeleton Loaders short while the data is resolved.
+1. Display/admin route → `metrics`
+   - Create or update the single dashboard view.
+   - Show “Last updated: X min” based on the timestamp of the displayed data (not the system clock).
+   - Brief skeleton loaders while data is fetched.
 
-2) Global range selector (applies to the entire Dashboard)
-   - Options: Today / last 7 days / last 30 days / the entire event.
-   - Use the same time zone of the event.
-   - When changing the range, refresh cards and tables without navigation and without blocking the UI.
+2. Global range selector (applies to the entire dashboard)
+   - Options: Today / Last 7 days / Last 30 days / Entire event.
+   - Use the event time zone.
+   - Changing the range refreshes cards and tables without navigation and without blocking the UI.
 
-3) Summary cards (upper row)
-   - "Records to my talks (range)" - Total within the range.
-   - "Visits to events (range)" - Total within the range.
-   - "Visits at Start (Rank)" - Total within the range.
-   - "User profile visits (range)" - Total within the range.
-   - "Ctas (rank)" - Three visible counters: releases | Report ISSUE | Ko-fi ☕.
-   - Under each card, short secondary text explaining what is counted (without technicalities).
-   - Empty states: show “0” and the explanatory text (not hide the card).
+3. Summary cards (top row)
+   - “Registrations for my talks (range)” – Total within the selected range.
+   - “Event visits (range)” – Total within the selected range.
+   - “Homepage visits (range)” – Total within the selected range.
+   - “User profile visits (range)” – Total within the selected range.
+   - “CTAs (range)” – Three counters: Releases | Report issue | Ko-fi ☕.
+   - Under each card, short explanatory text describing the metric (non-technical).
+   - Empty state: show `0` plus the explanatory text (do not hide the card).
 
-4) Essential tables (Top 10, without pagination)
-   - “Talks with more records (range)” - Columns: talk · event · records.
-   - “Most visited events (range)” - Columns: Event · Visits.
-   - “Speakers more visited (range)” - Columns: speaker · Profile visits.
-   - “Most visited scenarios (rank)” - Columns: scenario · event · Visits.
-   - Descending order for the main metric; Maximum 10 rows.
-   - Placeholder when there is no data: "Without sufficient data in this range."
+4. Essential tables (Top 10, no pagination)
+   - “Talks with more registrations (range)” – Columns: Talk · Event · Registrations.
+   - “Most visited events (range)” – Columns: Event · Visits.
+   - “Most visited speakers (range)” – Columns: Speaker · Profile visits.
+   - “Most visited stages (range)” – Columns: Stage · Event · Visits.
+   - Sort descending by the main metric; maximum 10 rows.
+   - Placeholder when empty: “Insufficient data for this range.”
 
-5) Data adapters (reading only; without PII)
-   - Connect with existing metric sources and apply the selected range.
-   - Mapear IDS to legible names (talk, event, speaker, stage) using existing services/dominoes.
-   - Ensure correct aggregations by range for each card/table.
-   - Performance: Avoid n+1; Make a single reading by refresh (reuse Snapshot/cache if it exists).
-   - Do not enter new personal identifiers or sensitive data.
+5. Data adapters (read-only, no PII)
+   - Connect to existing metrics sources and apply the selected range.
+   - Map IDs to readable names (talk, event, speaker, stage) using existing services/domains.
+   - Ensure correct aggregations per range for each card/table.
+   - Performance: avoid N+1 queries; make a single read per refresh (reuse snapshot/cache if available).
+   - Do not introduce new personal identifiers or sensitive data.
 
-6) Presentation states and errors
-   - Show Placeholders and clear messages in the absence of data.
-   - Friendly management of reading errors (non -technical message; not blocking all the view).
+6. Presentation states and errors
+   - Show placeholders and clear messages when data is unavailable.
+   - Handle read errors gracefully (non-technical message; do not block the entire view).
 
-7) Accessibility and Responsive (Minimum)
-   - Accessible labels/ARIA on cards and tables.
-   - Logical tabing order.
-   - Correct behavior in medium screens (laptop).
-   -Add Data-Testids for Qa (Ex.: `Data-Testid =" Metrics-Card-Registrations "`).
+7. Accessibility and responsive baseline
+   - Provide accessible labels/ARIA on cards and tables.
+   - Maintain a logical tab order.
+   - Ensure correct behaviour on medium screens (laptops).
+   - Add data-testids for QA (for example, `data-testid="metrics-card-registrations"`).
 
-8) Performance (Product Budget)
-   - Initial load perceived <300 ms with typical data.
-   - Fluid range transitions without jank.
+8. Performance (product budget)
+   - Initial perceived load <300 ms with typical data.
+   - Smooth range transitions with no jank.
 
-## Scope - Documentation (docs to register)
+## Scope – documentation (records to create)
 
 D1) Functional definitions (metric dictionary)
-- "Records to my talks": Total records confirmed to talks within the range.
-- “Visits to events”: Sum of views of detail/listing pages of each event within the range.
-- “Visits at Start”: Views of the home page within the range.
-- "User profile visits": views of the profile section (aggregate, no PII).
-- "Speakers most visited": views of the speaker profile within the range.
-- "Most visited scenarios": views of the stage (and its event) within the range.
-- "Ctas": click on "Releases", "Report Issue", "Ko-Fi".
+- “Registrations for my talks”: Total confirmed registrations for talks within the range.
+- “Event visits”: Sum of detail/listing views for each event within the range.
+- “Homepage visits”: Views of the home page within the range.
+- “User profile visits”: Views of the profile section (aggregated, no PII).
+- “Most visited speakers”: Views of the speaker profile within the range.
+- “Most visited stages”: Views of the stage (and its event) within the range.
+- “CTAs”: Clicks on “Releases”, “Report issue”, “Ko-fi”.
 
-D2) Dashboard use guide (short readme in `docs/`)
-- What shows each card/table.
-- How ranges and "last update" work.
-- Common states ("without sufficient data ...").
+D2) Dashboard usage guide (short README in `docs/`)
+- Describe what each card/table shows.
+- Explain how ranges and “Last updated” work.
+- Enumerate common states (“Insufficient data …”).
 
-D3) Copys/UX (text glossary)- Titles/card labels and tables.
-- State messages (Loaders, without data, non -technical error).
+D3) Copy/UX glossary
+- Titles, card labels, and table headings.
+- State messages (loaders, no data, non-technical error).
 
 D4) Performance and privacy criteria
 - Load budget (<300 ms).
-- Confirmation of "Sin Pii".
-- Good aggregation/reading practices.
+- Confirmation of “No PII”.
+- Good aggregation/read practices.
 
-## Acceptance criteria (DOD)
+## Acceptance criteria (DoD)
 
 - Code -
-- CA1: Cards show correct totals according to the selected range.
-- CA2: Tables Top 10 ordered by its metric; Maximum 10 rows; Placeholder When applying.
-- CA3: Change rank cool cards and tables consistently and fluidly.
-- CA4: “Last update” is calculated based on the data shown and is readable (“MIN MIN”).
-- CA5: Initial load <300 ms with typical data; transitions without blockages.
-- Ca6: Without Pii in UI; Minimum accessibility (ARIA, Tab-Aorder, contrast).
+- CA1: Cards show correct totals for the selected range.
+- CA2: Top-10 tables sorted by their metric; max 10 rows; placeholder when empty.
+- CA3: Changing the range refreshes cards and tables consistently and smoothly.
+- CA4: “Last updated” is based on the displayed data and is readable (“X min”).
+- CA5: Initial load <300 ms with typical data; transitions without blocking.
+- CA6: No PII in the UI; minimum accessibility (ARIA, tab order, contrast).
 
 - Docs -
-- CA7: There is an updated metric dictionary.
-- CA8: There is a brief guide for the use of the dashboard in `docs/`.
-- CA9: Copys/UX documented to maintain consistency.
+- CA7: Metric dictionary updated.
+- CA8: Brief dashboard usage guide available in `docs/`.
+- CA9: Copy/UX reference documented for consistency.
 
-## Functional tests (user/operation)
-- Change between today / 7 days / 30 days / the entire event → figures change consistently.
-- Rank without activity in any category → See “without sufficient data” only in that table.
-- Verify that sums and total are consistent by range.
-- Validate basic accessibility (Tab-Aorder, Labels) and Responsive in Laptop.
-- Verify that "updated x min" changes after a new refresh.
+## Functional tests (user/operations)
+- Switching between Today / 7 days / 30 days / Entire event updates figures consistently.
+- Range without activity in a category shows “Insufficient data” only in that table.
+- Validate sums and totals per range.
+- Validate baseline accessibility (tab order, labels) and laptop responsiveness.
+- Confirm “Updated X min ago” changes after a refresh.
 
-## Out of reach (iteration 1)
-- "See" actions to detail, search and export screens (iteration 2).
-- Trends (%δ), comparative and peaks (iteration 3).
-- Additional Scenario/Scenario/Steaker (Iteration 4).
-- Insights of extended ctas (historical with means/deviations) (iteration 5).
-- Health status of the data module (iteration 6).
+## Out of scope (iteration 1)
+- “View” actions to detail, search, and export screens (iteration 2).
+- Trends (%Δ), comparisons, and peaks (iteration 3).
+- Additional scenario/stage/speaker insights (iteration 4).
+- Extended CTA insights (historical means/deviations) (iteration 5).
+- Data health module (iteration 6).


### PR DESCRIPTION
## Summary
- update the root README to reference the English architecture docs and keep content fully in English
- ensure the documentation index links to language-specific architecture sections
- translate the English metrics documentation so it no longer contains Spanish text

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917dc1fe5c083338764a3435317e711)