### PR TITLE
Add marketing secondary pages

### DIFF
--- a/quarkus-app/src/main/java/com/scanales/eventflow/public_/MarketingPagesResource.java
+++ b/quarkus-app/src/main/java/com/scanales/eventflow/public_/MarketingPagesResource.java
@@ -1,0 +1,50 @@
+package com.scanales.eventflow.public_;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateInstance;
+import jakarta.annotation.security.PermitAll;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/")
+@PermitAll
+@Produces(MediaType.TEXT_HTML)
+public class MarketingPagesResource {
+
+  @CheckedTemplate(basePath = "pages")
+  static class Templates {
+    public static native TemplateInstance eventos();
+
+    public static native TemplateInstance comunidad();
+
+    public static native TemplateInstance docs();
+
+    public static native TemplateInstance contacto();
+  }
+
+  @GET
+  @Path("eventos")
+  public TemplateInstance eventos() {
+    return Templates.eventos();
+  }
+
+  @GET
+  @Path("comunidad")
+  public TemplateInstance comunidad() {
+    return Templates.comunidad();
+  }
+
+  @GET
+  @Path("docs")
+  public TemplateInstance docs() {
+    return Templates.docs();
+  }
+
+  @GET
+  @Path("contacto")
+  public TemplateInstance contacto() {
+    return Templates.contacto();
+  }
+}

--- a/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
+++ b/quarkus-app/src/main/resources/META-INF/resources/css/homedir.css
@@ -1,0 +1,339 @@
+:root {
+  --hd-color-primary: #5b4bff;
+  --hd-color-secondary: #06b6d4;
+  --hd-color-accent: #f97316;
+  --hd-color-surface: #ffffff;
+  --hd-color-muted: #6b7280;
+  --hd-color-border: #e5e7eb;
+  --hd-color-background: #f8fafc;
+  --hd-color-ink: #0f172a;
+  --hd-radius: 16px;
+  --hd-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  --hd-spacing-section: clamp(2.5rem, 2vw + 1.5rem, 4rem);
+}
+
+.hd-body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: var(--hd-color-background);
+  color: var(--hd-color-ink);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.hd-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.hd-skip-link {
+  position: absolute;
+  left: 1rem;
+  top: -48px;
+  background: var(--hd-color-primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: top 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  box-shadow: var(--hd-shadow);
+  z-index: 999;
+}
+
+.hd-skip-link:focus {
+  top: 1rem;
+}
+
+.hd-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--hd-color-border);
+}
+
+.hd-nav-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+}
+
+.hd-logo {
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--hd-color-primary);
+  text-decoration: none;
+  font-size: 1.2rem;
+}
+
+.hd-nav-menu {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.hd-nav-link {
+  color: var(--hd-color-ink);
+  font-weight: 600;
+  text-decoration: none;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.hd-nav-link:hover,
+.hd-nav-link:focus-visible {
+  background: rgba(91, 75, 255, 0.12);
+  color: var(--hd-color-primary);
+  outline: none;
+}
+
+.hd-nav-cta {
+  white-space: nowrap;
+}
+
+.hd-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+  padding: 0.65rem 1.2rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.hd-btn-primary {
+  background: linear-gradient(135deg, var(--hd-color-primary), var(--hd-color-secondary));
+  color: #fff;
+  box-shadow: var(--hd-shadow);
+}
+
+.hd-btn-primary:hover,
+.hd-btn-primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 45px rgba(91, 75, 255, 0.25);
+  outline: none;
+}
+
+.hd-section {
+  padding: var(--hd-spacing-section) 1.5rem;
+}
+
+.hd-section-page-header {
+  background: linear-gradient(135deg, rgba(91, 75, 255, 0.06), rgba(6, 182, 212, 0.08));
+  border-bottom: 1px solid var(--hd-color-border);
+}
+
+.hd-section-page-content {
+  background: var(--hd-color-background);
+}
+
+.hd-page {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.hd-page-title {
+  font-size: clamp(2rem, 1.4rem + 1vw, 2.8rem);
+  margin: 0 0 0.75rem;
+  letter-spacing: -0.02em;
+}
+
+.hd-page-intro {
+  margin: 0;
+  max-width: 720px;
+  color: var(--hd-color-muted);
+  font-size: 1.05rem;
+}
+
+.hd-section-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.hd-page-grid {
+  margin-top: 1rem;
+}
+
+.hd-card {
+  background: var(--hd-color-surface);
+  border: 1px solid var(--hd-color-border);
+  border-radius: var(--hd-radius);
+  padding: 1.25rem;
+  box-shadow: var(--hd-shadow);
+}
+
+.hd-card-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+.hd-card-text {
+  margin: 0;
+  color: var(--hd-color-muted);
+  line-height: 1.6;
+}
+
+.hd-link-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.hd-link-item {
+  margin: 0;
+}
+
+.hd-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--hd-radius);
+  background: var(--hd-color-surface);
+  border: 1px solid var(--hd-color-border);
+  font-weight: 700;
+  color: var(--hd-color-primary);
+  text-decoration: none;
+  box-shadow: var(--hd-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hd-link:hover,
+.hd-link:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 45px rgba(91, 75, 255, 0.18);
+  outline: none;
+}
+
+.hd-form {
+  background: var(--hd-color-surface);
+  border: 1px solid var(--hd-color-border);
+  border-radius: var(--hd-radius);
+  padding: 1.5rem;
+  box-shadow: var(--hd-shadow);
+}
+
+.hd-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1rem;
+}
+
+.hd-form-label {
+  font-weight: 700;
+  color: var(--hd-color-ink);
+}
+
+.hd-form-input {
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid var(--hd-color-border);
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background: #fff;
+}
+
+.hd-form-input:focus {
+  border-color: var(--hd-color-primary);
+  box-shadow: 0 0 0 3px rgba(91, 75, 255, 0.2);
+  outline: none;
+}
+
+.hd-form-actions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 0.5rem;
+}
+
+.hd-form-hint {
+  margin-top: 0.75rem;
+  color: var(--hd-color-muted);
+  font-size: 0.95rem;
+}
+
+.hd-footer {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 1.5rem;
+  margin-top: auto;
+}
+
+.hd-footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.hd-footer-text {
+  margin: 0;
+}
+
+.hd-footer-links {
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.hd-footer-link {
+  color: #cbd5e1;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hd-footer-link:hover,
+.hd-footer-link:focus-visible {
+  color: #fff;
+  text-decoration: underline;
+  outline: none;
+}
+
+@media (max-width: 768px) {
+  .hd-nav-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hd-nav-menu {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .hd-nav-cta {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .hd-section-grid,
+  .hd-link-list {
+    grid-template-columns: 1fr;
+  }
+
+  .hd-section {
+    padding-inline: 1.25rem;
+  }
+}

--- a/quarkus-app/src/main/resources/templates/fragments/footer.html
+++ b/quarkus-app/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,13 @@
+<footer class="hd-footer">
+  <div class="hd-footer-inner">
+    <p class="hd-footer-text">
+      Homedir · Proyecto de la comunidad Open Source Santiago
+    </p>
+    <p class="hd-footer-links">
+      <a href="/eventos" class="hd-footer-link">Eventos</a>
+      <a href="/comunidad" class="hd-footer-link">Comunidad</a>
+      <a href="/docs" class="hd-footer-link">Docs</a>
+      <a href="/contacto" class="hd-footer-link">Contacto</a>
+    </p>
+  </div>
+</footer>

--- a/quarkus-app/src/main/resources/templates/fragments/nav.html
+++ b/quarkus-app/src/main/resources/templates/fragments/nav.html
@@ -1,0 +1,13 @@
+<nav class="hd-nav" aria-label="Principal">
+  <div class="hd-nav-inner">
+    <a href="/" class="hd-logo">Homedir</a>
+    <div class="hd-nav-menu">
+      <a href="/" class="hd-nav-link">Inicio</a>
+      <a href="/eventos" class="hd-nav-link">Eventos</a>
+      <a href="/comunidad" class="hd-nav-link">Comunidad</a>
+      <a href="/docs" class="hd-nav-link">Docs</a>
+      <a href="/contacto" class="hd-nav-link">Contacto</a>
+    </div>
+    <a href="/ingresar" class="hd-btn hd-btn-primary hd-nav-cta">Ingresar</a>
+  </div>
+</nav>

--- a/quarkus-app/src/main/resources/templates/layout/main.html
+++ b/quarkus-app/src/main/resources/templates/layout/main.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{#insert title}Homedir{/insert}</title>
+  <link rel="stylesheet" href="/css/homedir.css" />
+</head>
+<body class="hd-body">
+  <a class="hd-skip-link" href="#main-content">Saltar al contenido principal</a>
+  {#include fragments/nav.html /}
+  <main id="main-content" class="hd-main">
+    {#insert body}{/insert}
+  </main>
+  {#include fragments/footer.html /}
+</body>
+</html>

--- a/quarkus-app/src/main/resources/templates/pages/comunidad.html
+++ b/quarkus-app/src/main/resources/templates/pages/comunidad.html
@@ -1,0 +1,50 @@
+{#include layout/main}
+
+{#title}Comunidad · Homedir{/title}
+
+{#body}
+  <section class="hd-section hd-section-page-header">
+    <div class="hd-page">
+      <h1 class="hd-page-title">Comunidad</h1>
+      <p class="hd-page-intro">
+        <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+        <!-- TODO: texto exacto desde la maqueta -->
+        Homedir es un proyecto impulsado por la comunidad Open Source Santiago.
+      </p>
+    </div>
+  </section>
+
+  <section class="hd-section hd-section-page-content">
+    <div class="hd-page">
+      <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+      <div class="hd-section-grid hd-page-grid">
+        <article class="hd-card">
+          <h2 class="hd-card-title">Open Source Santiago</h2>
+          <p class="hd-card-text">
+            <!-- TODO -->
+            Comunidad que impulsa el ecosistema open-source, cloud-native y de desarrolladores en Chile.
+          </p>
+        </article>
+
+        <article class="hd-card">
+          <h2 class="hd-card-title">Contribuir a Homedir</h2>
+          <p class="hd-card-text">
+            <!-- TODO: agregar link a repositorio en GitHub -->
+            Revisa el repositorio en GitHub, abre issues o PRs y ayuda a hacer crecer la plataforma.
+          </p>
+        </article>
+
+        <article class="hd-card">
+          <h2 class="hd-card-title">Eventos y meetups</h2>
+          <p class="hd-card-text">
+            <!-- TODO -->
+            Conecta con otros organizadores y participa en meetups y conferencias técnicas.
+          </p>
+        </article>
+      </div>
+
+      <!-- TODO: seccion para links (Discord, sitio OSSantiago, etc.) -->
+    </div>
+  </section>
+{/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/pages/contacto.html
+++ b/quarkus-app/src/main/resources/templates/pages/contacto.html
@@ -1,0 +1,47 @@
+{#include layout/main}
+
+{#title}Contacto · Homedir{/title}
+
+{#body}
+  <section class="hd-section hd-section-page-header">
+    <div class="hd-page">
+      <h1 class="hd-page-title">Contacto</h1>
+      <p class="hd-page-intro">
+        <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+        <!-- TODO -->
+        Si quieres usar Homedir en tu comunidad o evento, conversemos.
+      </p>
+    </div>
+  </section>
+
+  <section class="hd-section hd-section-page-content">
+    <div class="hd-page">
+      <form class="hd-form hd-contact-form">
+        <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+        <!-- TODO: conectar este formulario a un mecanismo real (correo / backend) en otra iteración -->
+        <div class="hd-form-field">
+          <label for="name" class="hd-form-label">Nombre</label>
+          <input id="name" type="text" class="hd-form-input" placeholder="Tu nombre" />
+        </div>
+        <div class="hd-form-field">
+          <label for="email" class="hd-form-label">Correo electrónico</label>
+          <input id="email" type="email" class="hd-form-input" placeholder="tu@correo.com" />
+        </div>
+        <div class="hd-form-field">
+          <label for="message" class="hd-form-label">Mensaje</label>
+          <textarea id="message" class="hd-form-input" rows="4" placeholder="Cuéntanos sobre tu evento o comunidad"></textarea>
+        </div>
+        <div class="hd-form-actions">
+          <button type="submit" class="hd-btn hd-btn-primary" disabled>
+            Enviar mensaje
+          </button>
+        </div>
+        <p class="hd-form-hint">
+          <!-- aclaración -->
+          Este formulario es solo de demostración por ahora. En una próxima iteración se conectará con un canal real de contacto.
+        </p>
+      </form>
+    </div>
+  </section>
+{/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/pages/docs.html
+++ b/quarkus-app/src/main/resources/templates/pages/docs.html
@@ -1,0 +1,37 @@
+{#include layout/main}
+
+{#title}Documentación · Homedir{/title}
+
+{#body}
+  <section class="hd-section hd-section-page-header">
+    <div class="hd-page">
+      <h1 class="hd-page-title">Documentación y recursos</h1>
+      <p class="hd-page-intro">
+        <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+        <!-- TODO -->
+        Aprende cómo instalar, configurar y extender Homedir para tus eventos.
+      </p>
+    </div>
+  </section>
+
+  <section class="hd-section hd-section-page-content">
+    <div class="hd-page">
+      <ul class="hd-link-list">
+        <li class="hd-link-item">
+          <!-- TODO: enlaza a README principal en GitHub -->
+          <a href="https://github.com/os-santiago/homedir" target="_blank" rel="noopener" class="hd-link">
+            Repositorio en GitHub
+          </a>
+        </li>
+        <li class="hd-link-item">
+          <!-- TODO: enlaza a documentación técnica si existe -->
+          <a href="https://github.com/os-santiago/homedir/tree/main/docs" target="_blank" rel="noopener" class="hd-link">
+            Documentación técnica
+          </a>
+        </li>
+        <!-- TODO: agrega más enlaces oficiales según exista contenido -->
+      </ul>
+    </div>
+  </section>
+{/body}
+{/include}

--- a/quarkus-app/src/main/resources/templates/pages/eventos.html
+++ b/quarkus-app/src/main/resources/templates/pages/eventos.html
@@ -1,0 +1,47 @@
+{#include layout/main}
+
+{#title}Eventos · Homedir{/title}
+
+{#body}
+  <section class="hd-section hd-section-page-header">
+    <div class="hd-page">
+      <h1 class="hd-page-title">Eventos con Homedir</h1>
+      <p class="hd-page-intro">
+        <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+        <!-- TODO: reemplazar con texto exacto de la maqueta -->
+        Diseña y organiza eventos con múltiples escenarios, actividades y experiencias para tu comunidad.
+      </p>
+    </div>
+  </section>
+
+  <section class="hd-section hd-section-page-content">
+    <div class="hd-page">
+      <!-- TODO: alinear contenido y estilo con maqueta Canva -->
+      <!-- TODO: aquí se puede explicar cómo Homedir modela eventos, espacios, escenarios, etc. -->
+      <div class="hd-section-grid hd-page-grid">
+        <article class="hd-card">
+          <h2 class="hd-card-title">Estructura de eventos</h2>
+          <p class="hd-card-text">
+            <!-- TODO -->
+            Homedir te permite organizar eventos con espacios, escenarios, tracks y actividades de forma jerárquica.
+          </p>
+        </article>
+        <article class="hd-card">
+          <h2 class="hd-card-title">Experiencia de asistentes</h2>
+          <p class="hd-card-text">
+            <!-- TODO -->
+            Tus asistentes pueden navegar la agenda, descubrir actividades y planificar su día.
+          </p>
+        </article>
+        <article class="hd-card">
+          <h2 class="hd-card-title">Pensado para organizadores</h2>
+          <p class="hd-card-text">
+            <!-- TODO -->
+            Centraliza la configuración del evento y evita perderte entre hojas de cálculo.
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+{/body}
+{/include}


### PR DESCRIPTION
## Summary
- add marketing layout, navigation and footer fragments for public pages
- create marketing templates for Eventos, Comunidad, Docs and Contacto with placeholder content
- wire new routes and styling for secondary marketing sections

## Testing
- mvn -f quarkus-app/pom.xml test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692da831813c833398278fde0a89aef2)